### PR TITLE
Fix error in samples when "--ca_file" not provided

### DIFF
--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -124,10 +124,13 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    auto clientConfig = Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
-                            .WithEndpoint(endpoint)
-                            .WithCertificateAuthority(caFile.c_str())
-                            .Build();
+    auto clientConfigBuilder = Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str());
+    clientConfigBuilder.WithEndpoint(endpoint);
+    if (!caFile.empty())
+    {
+        clientConfigBuilder.WithCertificateAuthority(caFile.c_str());
+    }
+    auto clientConfig = clientConfigBuilder.Build();
 
     if (!clientConfig)
     {

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -164,10 +164,13 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    auto clientConfig = Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
-                            .WithEndpoint(endpoint)
-                            .WithCertificateAuthority(caFile.c_str())
-                            .Build();
+    auto clientConfigBuilder = Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str());
+    clientConfigBuilder.WithEndpoint(endpoint);
+    if (!caFile.empty())
+    {
+        clientConfigBuilder.WithCertificateAuthority(caFile.c_str());
+    }
+    auto clientConfig = clientConfigBuilder.Build();
 
     if (!clientConfig)
     {


### PR DESCRIPTION
builder pattern doesn't look as cool anymore, but what are you gonna do

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
