### PR TITLE
Samples fix

### DIFF
--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -190,8 +190,8 @@ int main(int argc, char *argv[])
     Aws::Iot::MqttClient mqttClient(bootstrap);
     std::shared_ptr<Mqtt::MqttConnection> connection(nullptr);
 
-    std::promise<bool> connectionFinishedPromise;
-    std::promise<bool> shutdownCompletedPromise;
+    std::promise<void> connectionFinishedPromise;
+    std::promise<void> shutdownCompletedPromise;
 
     discoveryClient->Discover(thingName, [&](DiscoverResponse *response, int error, int httpResponseCode) {
         if (!error && response->GGGroups)
@@ -254,7 +254,7 @@ int main(int argc, char *argv[])
                             if (!errorCode)
                             {
                                 fprintf(stdout, "Successfully subscribed to %s\n", topic.c_str());
-                                connectionFinishedPromise.set_value(true);
+                                connectionFinishedPromise.set_value();
                             }
                             else
                             {
@@ -271,7 +271,7 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        connectionFinishedPromise.set_value(true);
+                        connectionFinishedPromise.set_value();
                     }
                 }
                 else
@@ -297,7 +297,7 @@ int main(int argc, char *argv[])
 
             connection->OnDisconnect = [&](Mqtt::MqttConnection & /*connection*/) {
                 fprintf(stdout, "Connection disconnected. Shutting Down.....\n");
-                shutdownCompletedPromise.set_value(true);
+                shutdownCompletedPromise.set_value();
             };
 
             if (!connection->Connect(thingName.c_str(), false))

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -190,10 +190,8 @@ int main(int argc, char *argv[])
     Aws::Iot::MqttClient mqttClient(bootstrap);
     std::shared_ptr<Mqtt::MqttConnection> connection(nullptr);
 
-    std::mutex semaphoreLock;
-    std::condition_variable semaphore;
-    std::atomic<bool> connectionFinished(false);
-    std::atomic<bool> shutdownCompleted(false);
+    std::promise<bool> connectionFinishedPromise;
+    std::promise<bool> shutdownCompletedPromise;
 
     discoveryClient->Discover(thingName, [&](DiscoverResponse *response, int error, int httpResponseCode) {
         if (!error && response->GGGroups)
@@ -256,8 +254,7 @@ int main(int argc, char *argv[])
                             if (!errorCode)
                             {
                                 fprintf(stdout, "Successfully subscribed to %s\n", topic.c_str());
-                                connectionFinished = true;
-                                semaphore.notify_one();
+                                connectionFinishedPromise.set_value(true);
                             }
                             else
                             {
@@ -274,8 +271,7 @@ int main(int argc, char *argv[])
                     }
                     else
                     {
-                        connectionFinished = true;
-                        semaphore.notify_one();
+                        connectionFinishedPromise.set_value(true);
                     }
                 }
                 else
@@ -301,8 +297,7 @@ int main(int argc, char *argv[])
 
             connection->OnDisconnect = [&](Mqtt::MqttConnection & /*connection*/) {
                 fprintf(stdout, "Connection disconnected. Shutting Down.....\n");
-                shutdownCompleted = true;
-                semaphore.notify_one();
+                shutdownCompletedPromise.set_value(true);
             };
 
             if (!connection->Connect(thingName.c_str(), false))
@@ -323,8 +318,7 @@ int main(int argc, char *argv[])
     });
 
     {
-        std::unique_lock<std::mutex> lock(semaphoreLock);
-        semaphore.wait(lock, [&]() { return connectionFinished.load(); });
+        connectionFinishedPromise.get_future().wait();
     }
 
     while (true)
@@ -373,8 +367,7 @@ int main(int argc, char *argv[])
 
     connection->Disconnect();
     {
-        std::unique_lock<std::mutex> lock(semaphoreLock);
-        semaphore.wait(lock, [&]() { return shutdownCompleted.load(); });
+        shutdownCompletedPromise.get_future().wait();
     }
 
     return 0;

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
 
     std::mutex mutex;
     std::unique_lock<std::mutex> uniqueLock(mutex);
-    conditionVariable.wait(uniqueLock, [&]() { return connectionSucceeded || connectionClosed; });
+    conditionVariable.wait(uniqueLock, [&]() { return connectionCompleted.load(); });
 
     if (connectionSucceeded)
     {

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
 
     /*
      * Since no exceptions are used, always check the bool operator
-     * when an error could have occured.
+     * when an error could have occurred.
      */
     if (!mqttClient)
     {

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -239,7 +239,6 @@ int main(int argc, char *argv[])
         subAckedPromise.get_future().wait();
 
         subAckedPromise = std::promise<void>();
-        std::atomic<bool> jobExecutionRejectedCompleted(false);
         auto failureHandler = [&](RejectedError *rejectedError, int ioErr) {
             if (ioErr)
             {

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -285,13 +285,13 @@ int main(int argc, char *argv[])
         describeJobExecutionRequest.IncludeJobDocument = true;
         Aws::Crt::UUID uuid;
         describeJobExecutionRequest.ClientToken = uuid.ToString();
-        std::atomic<bool> publishDescribeJobExeCompelted(false);
+        std::atomic<bool> publishDescribeJobExeCompleted(false);
 
         auto publishHandler = [&](int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
-                publishDescribeJobExeCompelted = true;
+                publishDescribeJobExeCompleted = true;
                 conditionVariable.notify_one();
                 return;
             }
@@ -299,7 +299,7 @@ int main(int argc, char *argv[])
 
         client.PublishDescribeJobExecution(
             std::move(describeJobExecutionRequest), AWS_MQTT_QOS_AT_LEAST_ONCE, publishHandler);
-        conditionVariable.wait(uniqueLock, [&]() { return publishDescribeJobExeCompelted.load(); });
+        conditionVariable.wait(uniqueLock, [&]() { return publishDescribeJobExeCompleted.load(); });
     }
 
     if (!connectionClosed)

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
 
     /*
      * Since no exceptions are used, always check the bool operator
-     * when an error could have occured.
+     * when an error could have occurred.
      */
     if (!mqttClient)
     {
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
 
             if (rejectedError)
             {
-                fprintf(stderr, "Service Error %d occured\n", (int)rejectedError->Code.value());
+                fprintf(stderr, "Service Error %d occurred\n", (int)rejectedError->Code.value());
                 return;
             }
         };

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -164,10 +164,8 @@ int main(int argc, char *argv[])
      * In a real world application you probably don't want to enforce synchronous behavior
      * but this is a sample console application, so we'll just do that with a condition variable.
      */
-    std::condition_variable conditionVariable;
-    std::atomic<bool> connectionSucceeded(false);
-    std::atomic<bool> connectionClosed(false);
-    std::atomic<bool> connectionCompleted(false);
+    std::promise<bool> connectionCompletedPromise;
+    std::promise<void> connectionClosedPromise;
 
     /*
      * This will execute when an mqtt connect has completed or failed.
@@ -176,16 +174,13 @@ int main(int argc, char *argv[])
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            connectionSucceeded = false;
+            connectionCompletedPromise.set_value(false);
         }
         else
         {
             fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionSucceeded = true;
+            connectionCompletedPromise.set_value(true);
         }
-
-        connectionCompleted = true;
-        conditionVariable.notify_one();
     };
 
     /*
@@ -194,9 +189,8 @@ int main(int argc, char *argv[])
     auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
         {
             fprintf(stdout, "Disconnect completed\n");
-            connectionClosed = true;
+            connectionClosedPromise.set_value();
         }
-        conditionVariable.notify_one();
     };
 
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
@@ -212,11 +206,7 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    std::mutex mutex;
-    std::unique_lock<std::mutex> uniqueLock(mutex);
-    conditionVariable.wait(uniqueLock, [&]() { return connectionSucceeded || connectionClosed; });
-
-    if (connectionSucceeded)
+    if (connectionCompletedPromise.get_future().get())
     {
         IotJobsClient client(connection);
 
@@ -224,23 +214,17 @@ int main(int argc, char *argv[])
         describeJobExecutionSubscriptionRequest.ThingName = thingName;
         describeJobExecutionSubscriptionRequest.JobId = jobId;
 
-        // This isn't absolutely neccessary but since we're doing a publish almost immediately afterwards,
+        // This isn't absolutely necessary but since we're doing a publish almost immediately afterwards,
         // to be cautious make sure the subscribe has finished before doing the publish.
-        std::atomic<bool> subAcked(false);
-        auto subAckHandler = [&](int ioErr) {
-            if (!ioErr)
-            {
-                subAcked = true;
-                conditionVariable.notify_one();
-            }
+        std::promise<void> subAckedPromise;
+        auto subAckHandler = [&](int) {
+            /* if error code returns it will be recorded by the other callback */
+            subAckedPromise.set_value();
         };
-        std::atomic<bool> jobExecutionAcceptedCompleted(false);
         auto subscriptionHandler = [&](DescribeJobExecutionResponse *response, int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
-                jobExecutionAcceptedCompleted = true;
-                conditionVariable.notify_one();
                 return;
             }
 
@@ -248,36 +232,31 @@ int main(int argc, char *argv[])
             fprintf(stdout, "Job Id: %s\n", response->Execution->JobId->c_str());
             fprintf(stdout, "ClientToken: %s\n", response->ClientToken->c_str());
             fprintf(stdout, "Execution Status: %s\n", JobStatusMarshaller::ToString(*response->Execution->Status));
-            jobExecutionAcceptedCompleted = true;
-            conditionVariable.notify_one();
         };
 
         client.SubscribeToDescribeJobExecutionAccepted(
             describeJobExecutionSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, subscriptionHandler, subAckHandler);
-        conditionVariable.wait(uniqueLock, [&]() { return subAcked || jobExecutionAcceptedCompleted; });
-        subAcked = false;
+        subAckedPromise.get_future().wait();
+
+        subAckedPromise = std::promise<void>();
         std::atomic<bool> jobExecutionRejectedCompleted(false);
         auto failureHandler = [&](RejectedError *rejectedError, int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
-                jobExecutionRejectedCompleted = true;
-                conditionVariable.notify_one();
                 return;
             }
 
             if (rejectedError)
             {
                 fprintf(stderr, "Service Error %d occured\n", (int)rejectedError->Code.value());
-                jobExecutionRejectedCompleted = true;
-                conditionVariable.notify_one();
                 return;
             }
         };
 
         client.SubscribeToDescribeJobExecutionRejected(
             describeJobExecutionSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, failureHandler, subAckHandler);
-        conditionVariable.wait(uniqueLock, [&]() { return subAcked || jobExecutionRejectedCompleted; });
+        subAckedPromise.get_future().wait();
 
         DescribeJobExecutionRequest describeJobExecutionRequest;
         describeJobExecutionRequest.ThingName = thingName;
@@ -285,28 +264,25 @@ int main(int argc, char *argv[])
         describeJobExecutionRequest.IncludeJobDocument = true;
         Aws::Crt::UUID uuid;
         describeJobExecutionRequest.ClientToken = uuid.ToString();
-        std::atomic<bool> publishDescribeJobExeCompleted(false);
+        std::promise<void> publishDescribeJobExeCompletedPromise;
 
         auto publishHandler = [&](int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
-                publishDescribeJobExeCompleted = true;
-                conditionVariable.notify_one();
-                return;
             }
+            publishDescribeJobExeCompletedPromise.set_value();
         };
 
         client.PublishDescribeJobExecution(
             std::move(describeJobExecutionRequest), AWS_MQTT_QOS_AT_LEAST_ONCE, publishHandler);
-        conditionVariable.wait(uniqueLock, [&]() { return publishDescribeJobExeCompleted.load(); });
+        publishDescribeJobExeCompletedPromise.get_future().wait();
     }
 
-    if (!connectionClosed)
+    /* Disconnect */
+    if (connection->Disconnect())
     {
-        /* Disconnect */
-        connection->Disconnect();
-        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed.load(); });
+        connectionClosedPromise.get_future().wait();
     }
     return 0;
 }

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -232,12 +232,12 @@ int main(int argc, char *argv[])
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            connectionCompletedPromise.set_value(true);
+            connectionCompletedPromise.set_value(false);
         }
         else
         {
             fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionCompletedPromise.set_value(false);
+            connectionCompletedPromise.set_value(true);
         }
     };
 
@@ -301,18 +301,19 @@ int main(int argc, char *argv[])
                 if (errorCode)
                 {
                     fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+                    exit(-1);
                 }
                 else
                 {
                     if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
                     {
                         fprintf(stderr, "Subscribe rejected by the broker.");
+                        exit(-1);
                     }
                     else
                     {
                         fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                     }
-                    exit(-1);
                 }
                 subscribeFinishedPromise.set_value();
             };

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -234,9 +234,9 @@ int main(int argc, char *argv[])
      */
     std::mutex mutex;
     std::condition_variable conditionVariable;
-    bool connectionSucceeded = false;
-    bool connectionClosed = false;
-    bool connectionCompleted = false;
+    std::atomic<bool> connectionSucceeded(false);
+    std::atomic<bool> connectionClosed(false);
+    std::atomic<bool> connectionCompleted(false);
 
     /*
      * This will execute when an mqtt connect has completed or failed.
@@ -245,7 +245,6 @@ int main(int argc, char *argv[])
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            std::lock_guard<std::mutex> lockGuard(mutex);
             connectionSucceeded = false;
         }
         else
@@ -254,7 +253,6 @@ int main(int argc, char *argv[])
             connectionSucceeded = true;
         }
         {
-            std::lock_guard<std::mutex> lockGuard(mutex);
             connectionCompleted = true;
         }
         conditionVariable.notify_one();
@@ -272,7 +270,6 @@ int main(int argc, char *argv[])
     auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
-            std::lock_guard<std::mutex> lockGuard(mutex);
             connectionClosed = true;
         }
         conditionVariable.notify_one();
@@ -302,7 +299,7 @@ int main(int argc, char *argv[])
     }
 
     std::unique_lock<std::mutex> uniqueLock(mutex);
-    conditionVariable.wait(uniqueLock, [&]() { return connectionCompleted; });
+    conditionVariable.wait(uniqueLock, [&]() { return connectionCompleted.load(); });
 
     if (connectionSucceeded)
     {
@@ -319,7 +316,7 @@ int main(int argc, char *argv[])
         /*
          * Subscribe for incoming publish messages on topic.
          */
-        bool subscribeFinished = false;
+        std::atomic<bool> subscribeFinished(false);
         auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS, int errorCode) {
             if (errorCode)
             {
@@ -341,7 +338,7 @@ int main(int argc, char *argv[])
         };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
-        conditionVariable.wait(uniqueLock, [&]() { return subscribeFinished; });
+        conditionVariable.wait(uniqueLock, [&]() { return subscribeFinished.load(); });
 
         while (true)
         {
@@ -379,18 +376,18 @@ int main(int argc, char *argv[])
         /*
          * Unsubscribe from the topic.
          */
-        bool unsubscribeFinished = false;
+        std::atomic<bool> unsubscribeFinished(false);
         connection->Unsubscribe(topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) {
             unsubscribeFinished = true;
             conditionVariable.notify_one();
         });
-        conditionVariable.wait(uniqueLock, [&]() { return unsubscribeFinished; });
+        conditionVariable.wait(uniqueLock, [&]() { return unsubscribeFinished.load(); });
     }
 
     /* Disconnect */
     if (connection->Disconnect())
     {
-        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed; });
+        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed.load(); });
     }
     return 0;
 }

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -362,9 +362,8 @@ int main(int argc, char *argv[])
          * Unsubscribe from the topic.
          */
         std::promise<bool> unsubscribeFinishedPromise;
-        connection->Unsubscribe(topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) {
-            unsubscribeFinishedPromise.set_value(true);
-        });
+        connection->Unsubscribe(
+            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { unsubscribeFinishedPromise.set_value(true); });
         unsubscribeFinishedPromise.get_future().wait();
     }
 

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -317,20 +317,20 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::atomic<bool> subscribeFinished(false);
-        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS, int errorCode) {
+        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
             if (errorCode)
             {
                 fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
             }
             else
             {
-                if (packetId)
-                {
-                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
-                }
-                else
+                if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
                 {
                     fprintf(stderr, "Subscribe rejected by the broker.");
+                }
+                else 
+                {
+                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                 }
             }
             subscribeFinished = true;

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -249,7 +249,6 @@ int main(int argc, char *argv[])
         }
     };
 
-
     auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
         fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
     };

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -236,10 +236,19 @@ int main(int argc, char *argv[])
         }
         else
         {
-            fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionCompletedPromise.set_value(true);
+            if (returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+            {
+                fprintf(stdout, "Connection failed with mqtt return code %d\n", (int)returnCode);
+                connectionCompletedPromise.set_value(false);
+            }
+            else
+            {
+                fprintf(stdout, "Connection completed successfully.");
+                connectionCompletedPromise.set_value(true);
+            }
         }
     };
+
 
     auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
         fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -416,9 +416,8 @@ int main(int argc, char *argv[])
          * Unsubscribe from the topic.
          */
         std::promise<bool> unsubscribeFinishedPromise;
-        connection->Unsubscribe(topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) {
-            unsubscribeFinishedPromise.set_value(true);
-        });
+        connection->Unsubscribe(
+            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { unsubscribeFinishedPromise.set_value(true); });
         unsubscribeFinishedPromise.get_future().wait();
     }
 

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -276,9 +276,8 @@ int main(int argc, char *argv[])
      * In a real world application you probably don't want to enforce synchronous behavior
      * but this is a sample console application, so we'll just do that with a condition variable.
      */
-    std::atomic<bool> connectionSucceeded(false);
     std::promise<bool> connectionCompletedPromise;
-    std::promise<bool> connectionClosedPromise;
+    std::promise<void> connectionClosedPromise;
 
     /*
      * This will execute when an mqtt connect has completed or failed.
@@ -287,15 +286,12 @@ int main(int argc, char *argv[])
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            connectionSucceeded = false;
+            connectionCompletedPromise.set_value(true);
         }
         else
         {
             fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionSucceeded = true;
-        }
-        {
-            connectionCompletedPromise.set_value(true);
+            connectionCompletedPromise.set_value(false);
         }
     };
 
@@ -311,7 +307,7 @@ int main(int argc, char *argv[])
     auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
-            connectionClosedPromise.set_value(true);
+            connectionClosedPromise.set_value();
         }
     };
 
@@ -338,9 +334,7 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    connectionCompletedPromise.get_future().wait();
-
-    if (connectionSucceeded)
+    if (connectionCompletedPromise.get_future().get())
     {
         /*
          * This is invoked upon the receipt of a Publish on a subscribed topic.
@@ -355,7 +349,7 @@ int main(int argc, char *argv[])
         /*
          * Subscribe for incoming publish messages on topic.
          */
-        std::promise<bool> subscribeFinishedPromise;
+        std::promise<void> subscribeFinishedPromise;
         auto onSubAck =
             [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
                 if (errorCode)
@@ -372,8 +366,9 @@ int main(int argc, char *argv[])
                     {
                         fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                     }
+                    exit(-1);
                 }
-                subscribeFinishedPromise.set_value(true);
+                subscribeFinishedPromise.set_value();
             };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
@@ -415,9 +410,9 @@ int main(int argc, char *argv[])
         /*
          * Unsubscribe from the topic.
          */
-        std::promise<bool> unsubscribeFinishedPromise;
+        std::promise<void> unsubscribeFinishedPromise;
         connection->Unsubscribe(
-            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { unsubscribeFinishedPromise.set_value(true); });
+            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { unsubscribeFinishedPromise.set_value(); });
         unsubscribeFinishedPromise.get_future().wait();
     }
 

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -290,8 +290,16 @@ int main(int argc, char *argv[])
         }
         else
         {
-            fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionCompletedPromise.set_value(true);
+            if (returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+            {
+                fprintf(stdout, "Connection failed with mqtt return code %d\n", (int)returnCode);
+                connectionCompletedPromise.set_value(false);
+            }
+            else
+            {
+                fprintf(stdout, "Connection completed successfully.");
+                connectionCompletedPromise.set_value(true);
+            }
         }
     };
 

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -371,20 +371,20 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::atomic<bool> subscribeFinished(false);
-        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS, int errorCode) {
+        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
             if (errorCode)
             {
                 fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
             }
             else
             {
-                if (packetId)
-                {
-                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
-                }
-                else
+                if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
                 {
                     fprintf(stderr, "Subscribe rejected by the broker.");
+                }
+                else 
+                {
+                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                 }
             }
             subscribeFinished = true;

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -286,12 +286,12 @@ int main(int argc, char *argv[])
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            connectionCompletedPromise.set_value(true);
+            connectionCompletedPromise.set_value(false);
         }
         else
         {
             fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionCompletedPromise.set_value(false);
+            connectionCompletedPromise.set_value(true);
         }
     };
 
@@ -355,18 +355,19 @@ int main(int argc, char *argv[])
                 if (errorCode)
                 {
                     fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+                    exit(-1);
                 }
                 else
                 {
                     if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
                     {
                         fprintf(stderr, "Subscribe rejected by the broker.");
+                        exit(-1);
                     }
                     else
                     {
                         fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                     }
-                    exit(-1);
                 }
                 subscribeFinishedPromise.set_value();
             };

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -371,25 +371,26 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::atomic<bool> subscribeFinished(false);
-        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
-            if (errorCode)
-            {
-                fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
-            }
-            else
-            {
-                if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
+        auto onSubAck =
+            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
+                if (errorCode)
                 {
-                    fprintf(stderr, "Subscribe rejected by the broker.");
+                    fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
                 }
-                else 
+                else
                 {
-                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                    if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
+                    {
+                        fprintf(stderr, "Subscribe rejected by the broker.");
+                    }
+                    else
+                    {
+                        fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                    }
                 }
-            }
-            subscribeFinished = true;
-            conditionVariable.notify_one();
-        };
+                subscribeFinished = true;
+                conditionVariable.notify_one();
+            };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
         conditionVariable.wait(uniqueLock, [&]() { return subscribeFinished.load(); });

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -373,20 +373,29 @@ int main(int argc, char *argv[])
         /*
          * Subscribe for incoming publish messages on topic.
          */
+        bool subscribeFinished = false;
         auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS, int errorCode) {
-            if (packetId)
+            if (errorCode)
             {
-                fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
             }
             else
             {
-                fprintf(stdout, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+                if (packetId)
+                {
+                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                }
+                else
+                {
+                    fprintf(stderr, "Subscribe rejected by the broker.");
+                }
             }
+            subscribeFinished = true;
             conditionVariable.notify_one();
         };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
-        conditionVariable.wait(uniqueLock);
+        conditionVariable.wait(uniqueLock, [&]() { return subscribeFinished; });
 
         while (true)
         {
@@ -424,9 +433,13 @@ int main(int argc, char *argv[])
         /*
          * Unsubscribe from the topic.
          */
-        connection->Unsubscribe(
-            topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) { conditionVariable.notify_one(); });
-        conditionVariable.wait(uniqueLock);
+        bool unsubscribeFinished = false;
+        connection->Unsubscribe(topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) {
+            unsubscribeFinished = true;
+            conditionVariable.notify_one();
+        });
+
+        conditionVariable.wait(uniqueLock, [&]() { return unsubscribeFinished; });
     }
 
     /* Disconnect */

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -276,11 +276,9 @@ int main(int argc, char *argv[])
      * In a real world application you probably don't want to enforce synchronous behavior
      * but this is a sample console application, so we'll just do that with a condition variable.
      */
-    std::mutex mutex;
-    std::condition_variable conditionVariable;
     std::atomic<bool> connectionSucceeded(false);
-    std::atomic<bool> connectionClosed(false);
-    std::atomic<bool> connectionCompleted(false);
+    std::promise<bool> connectionCompletedPromise;
+    std::promise<bool> connectionClosedPromise;
 
     /*
      * This will execute when an mqtt connect has completed or failed.
@@ -297,9 +295,8 @@ int main(int argc, char *argv[])
             connectionSucceeded = true;
         }
         {
-            connectionCompleted = true;
+            connectionCompletedPromise.set_value(true);
         }
-        conditionVariable.notify_one();
     };
 
     auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
@@ -314,9 +311,8 @@ int main(int argc, char *argv[])
     auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
-            connectionClosed = true;
+            connectionClosedPromise.set_value(true);
         }
-        conditionVariable.notify_one();
     };
 
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
@@ -342,8 +338,7 @@ int main(int argc, char *argv[])
         exit(-1);
     }
 
-    std::unique_lock<std::mutex> uniqueLock(mutex);
-    conditionVariable.wait(uniqueLock, [&]() { return connectionCompleted.load(); });
+    connectionCompletedPromise.get_future().wait();
 
     if (connectionSucceeded)
     {
@@ -360,7 +355,7 @@ int main(int argc, char *argv[])
         /*
          * Subscribe for incoming publish messages on topic.
          */
-        std::atomic<bool> subscribeFinished(false);
+        std::promise<bool> subscribeFinishedPromise;
         auto onSubAck =
             [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
                 if (errorCode)
@@ -378,12 +373,11 @@ int main(int argc, char *argv[])
                         fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                     }
                 }
-                subscribeFinished = true;
-                conditionVariable.notify_one();
+                subscribeFinishedPromise.set_value(true);
             };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onPublish, onSubAck);
-        conditionVariable.wait(uniqueLock, [&]() { return subscribeFinished.load(); });
+        subscribeFinishedPromise.get_future().wait();
 
         while (true)
         {
@@ -421,18 +415,17 @@ int main(int argc, char *argv[])
         /*
          * Unsubscribe from the topic.
          */
-        std::atomic<bool> unsubscribeFinished(false);
+        std::promise<bool> unsubscribeFinishedPromise;
         connection->Unsubscribe(topic.c_str(), [&](Mqtt::MqttConnection &, uint16_t, int) {
-            unsubscribeFinished = true;
-            conditionVariable.notify_one();
+            unsubscribeFinishedPromise.set_value(true);
         });
-        conditionVariable.wait(uniqueLock, [&]() { return unsubscribeFinished.load(); });
+        unsubscribeFinishedPromise.get_future().wait();
     }
 
     /* Disconnect */
     if (connection->Disconnect())
     {
-        conditionVariable.wait(uniqueLock, [&]() { return connectionClosed.load(); });
+        connectionClosedPromise.get_future().wait();
     }
     return 0;
 }


### PR DESCRIPTION
*Issue #, if available:*

Possible dead lock without the predicate, and the onSubAck will show the subscription success even if the errorCode raised.
Related to https://github.com/awslabs/aws-c-mqtt/issues/136
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/88

*Description of changes:*

- add predicate for each conditionVariable.wait()
- changed the booleans in basic_sub_pub & raw_sub_pub to atomic
- Fixed the onSubAck callback to check the error code and QoS returned.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
