### PR TITLE
All V2 SDK samples can share policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,18 +62,18 @@ Source: `samples/identity/fleet_provisioning`
 cd ~/aws-iot-device-sdk-cpp-v2-build/samples/identity/fleet_provisioning
 
 Run the sample like this to provision using CreateKeysAndCertificate:
- 
+
 ```
-./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA> 
---cert <path to the certificate> --key <path to the private key> 
+./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA>
+--cert <path to the certificate> --key <path to the private key>
 --template_name <template name> --template_parameters <template parameters json>
 ```
 
 Run the sample like this to provision using Csr:
- 
+
 ```
-./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA> 
---cert <path to the certificate> --key <path to the private key> 
+./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA>
+--cert <path to the certificate> --key <path to the private key>
 --template_name <template name> --template_parameters <template parameters json> --csr <path to the CSR in PEM format>
 ```
 
@@ -82,7 +82,9 @@ Your Thing's
 must provide privileges for this sample to connect, subscribe, publish,
 and receive.
 
-```json
+<details>
+<summary>(see sample policy)</summary>
+<pre>
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -94,7 +96,7 @@ and receive.
       "Resource": [
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json"
       ]
     },
     {
@@ -108,18 +110,19 @@ and receive.
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create/json/rejected",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/accepted",
         "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/certificates/create-from-csr/json/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename<b>/provision/json/rejected"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/accepted",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/provisioning-templates/<b>templatename</b>/provision/json/rejected"
       ]
     },
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
-```
+</pre>
+</details>
 
 ## Basic MQTT Pub-Sub
 
@@ -241,7 +244,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
@@ -310,7 +313,7 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,6 +12,7 @@ Since the sample is subscribed to the same topic, it will also receive the messa
 Type `quit` and press enter to end the sample.
 
 Source: `samples/mqtt/basic_pub_sub`
+
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,
@@ -60,7 +61,7 @@ and receive.
 
 To run the basic MQTT Pub-Sub use the following command:
 
-```
+``` sh
 ./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
 --topic <topic name>
@@ -80,7 +81,7 @@ This sample uses the AWS IoT
 [Fleet provisioning](https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html)
 to provision devices using either a CSR or KeysAndcertificate and subsequently calls RegisterThing.
 
-On startup, the script subscribes to topics based on the request type of either CSR or Keys topics, 
+On startup, the script subscribes to topics based on the request type of either CSR or Keys topics,
 publishes the request to corresponding topic and calls RegisterThing.
 
 Source: `samples/identity/fleet_provisioning`
@@ -170,6 +171,7 @@ on the device and an update is sent to the server with the new "reported"
 value.
 
 Source: `samples/shadow/shadow_sync`
+
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,
@@ -241,6 +243,7 @@ This sample requires you to create jobs for your device to execute. See
 On startup, the sample describes a job that is pending execution.
 
 Source: `samples/jobs/describe_job_execution`
+
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,

--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,6 @@ Since the sample is subscribed to the same topic, it will also receive the messa
 Type `quit` and press enter to end the sample.
 
 Source: `samples/mqtt/basic_pub_sub`
-
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,
@@ -22,32 +21,48 @@ and receive.
 <summary>(see sample policy)</summary>
 <pre>
 {
-    "Effect": "Allow",
-    "Action": [
-        "iot:Receive",
-        "iot:Publish"
-    ],
-    "Resource": [
-        "arn:aws:iot:<your-region>:<your-id>:topic/a/b"
-    ],
-},
-{
-    "Effect": "Allow",
-    "Action": [
+  "Version": "2012-10-17",
+  "Statement": [
+
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Publish",
+        "iot:Receive"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "iot:Subscribe"
-    ],
-    "Resource": [
-        "arn:aws:iot:<your-region>:<your-id>:topicfilter/a/b"
-    ]
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:Connect"
+      ],
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    }
+
+  ]
 }
 </pre>
 </details>
 
 To run the basic MQTT Pub-Sub use the following command:
 
-```sh
-./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA> 
---cert <path to the certificate> --key <path to the private key> 
+```
+./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
+--cert <path to the certificate> --key <path to the private key>
 --topic <topic name>
 ```
 
@@ -59,33 +74,31 @@ This is a starting point for using custom
 
 source: `samples/mqtt/raw_pub_sub`
 
-
 ## Fleet provisioning
 
 This sample uses the AWS IoT
 [Fleet provisioning](https://docs.aws.amazon.com/iot/latest/developerguide/provision-wo-cert.html)
 to provision devices using either a CSR or KeysAndcertificate and subsequently calls RegisterThing.
 
-On startup, the script subscribes to topics based on the request type of either CSR or Keys topics,
+On startup, the script subscribes to topics based on the request type of either CSR or Keys topics, 
 publishes the request to corresponding topic and calls RegisterThing.
 
 Source: `samples/identity/fleet_provisioning`
-
 cd ~/aws-iot-device-sdk-cpp-v2-build/samples/identity/fleet_provisioning
 
 Run the sample like this to provision using CreateKeysAndCertificate:
- 
-```sh
-./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA> 
---cert <path to the certificate> --key <path to the private key> 
+
+``` sh
+./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA>
+--cert <path to the certificate> --key <path to the private key>
 --template_name <template name> --template_parameters <template parameters json>
 ```
 
 Run the sample like this to provision using Csr:
- 
-```sh
-./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA> 
---cert <path to the certificate> --key <path to the private key> 
+
+``` sh
+./fleet-provisioning --endpoint <endpoint> --ca_file <path to root CA>
+--cert <path to the certificate> --key <path to the private key>
 --template_name <template name> --template_parameters <template parameters json> --csr <path to the CSR in PEM format>
 ```
 
@@ -129,13 +142,12 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
   ]
 }
 </pre>
 </details>
-
 
 ## Shadow
 
@@ -158,7 +170,6 @@ on the device and an update is sent to the server with the new "reported"
 value.
 
 Source: `samples/shadow/shadow_sync`
-
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,
@@ -170,6 +181,7 @@ and receive.
 {
   "Version": "2012-10-17",
   "Statement": [
+
     {
       "Effect": "Allow",
       "Action": [
@@ -209,8 +221,9 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
+
   ]
 }
 </pre>
@@ -228,7 +241,6 @@ This sample requires you to create jobs for your device to execute. See
 On startup, the sample describes a job that is pending execution.
 
 Source: `samples/jobs/describe_job_execution`
-
 Your Thing's
 [Policy](https://docs.aws.amazon.com/iot/latest/developerguide/iot-policies.html)
 must provide privileges for this sample to connect, subscribe, publish,
@@ -239,6 +251,7 @@ and receive.
 {
   "Version": "2012-10-17",
   "Statement": [
+
     {
       "Effect": "Allow",
       "Action": [
@@ -278,8 +291,9 @@ and receive.
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/samples-client-id"
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
+
   ]
 }
 </pre>

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -33,7 +33,7 @@ static void s_printHelp()
     fprintf(stdout, "ca_file: ca file to use in verifying TLS connections.\n");
     fprintf(stdout, "\tIt's the path to a CA file in PEM format\n");
     fprintf(stdout, "thing_name: the name of your IOT thing\n");
-    fprintf(stdout, "topic: targeted topic. Default is sdk/test/cpp-v2\n");
+    fprintf(stdout, "topic: targeted topic. Default is test/topic\n");
     fprintf(stdout, "mode: default both\n");
     fprintf(stdout, "message: message to publish. default 'Hello World'\n");
     fprintf(stdout, "proxy-host: proxy host to use for discovery call. Default is to not use a proxy.\n");
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
     String keyPath;
     String caFile;
     String thingName;
-    String topic("sdk/test/cpp-v2");
+    String topic("test/topic");
     String mode("both");
     String message("Hello World");
 

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -99,7 +99,7 @@ int main(int argc, char *argv[])
     String certificatePath;
     String keyPath;
     String caFile;
-    String clientId(Aws::Crt::UUID().ToString());
+    String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String templateName;
     String templateParameters;
     String csrFile;
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
      * Actually perform the connect dance.
      */
     fprintf(stdout, "Connecting...\n");
-    if (!connection->Connect("client_id12335456", true, 0))
+    if (!connection->Connect(clientId.c_str(), true, 0))
     {
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
         exit(-1);

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -69,6 +69,7 @@ int main(int argc, char *argv[])
     String certificatePath;
     String keyPath;
     String caFile;
+    String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String thingName;
     String jobId;
 
@@ -206,7 +207,7 @@ int main(int argc, char *argv[])
      * Actually perform the connect dance.
      */
     fprintf(stdout, "Connecting...\n");
-    if (!connection->Connect("client_id12335456", true, 0))
+    if (!connection->Connect(clientId.c_str(), true, 0))
     {
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
         exit(-1);

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -21,7 +21,7 @@ static void s_printHelp()
     fprintf(
         stdout,
         "basic-pub-sub --endpoint <endpoint> --cert <path to cert>"
-        " --key <path to key> --topic --ca_file <optional: path to custom ca>"
+        " --key <path to key> --topic <topic> --ca_file <optional: path to custom ca>"
         " --use_websocket --signing_region <region> --proxy_host <host> --proxy_port <port>\n\n");
     fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
     fprintf(
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     String keyPath;
     String caFile;
     String topic;
-    String clientId(Aws::Crt::UUID().ToString());
+    String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String signingRegion;
     String proxyHost;
     uint16_t proxyPort(8080);

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -32,7 +32,7 @@ static void s_printHelp()
         stdout,
         "cert: path to your client certificate in PEM format. If this is not set you must specify use_websocket\n");
     fprintf(stdout, "key: path to your key in PEM format. If this is not set you must specify use_websocket\n");
-    fprintf(stdout, "topic: topic to publish, subscribe to.\n");
+    fprintf(stdout, "topic: topic to publish, subscribe to. (optional)\n");
     fprintf(stdout, "client_id: client id to use (optional)\n");
     fprintf(
         stdout,
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
     bool useX509 = false;
 
     /*********************** Parse Arguments ***************************/
-    if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--topic")))
+    if (!s_cmdOptionExists(argv, argv + argc, "--endpoint"))
     {
         s_printHelp();
         return 1;

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char *argv[])
     String certificatePath;
     String keyPath;
     String caFile;
-    String topic;
+    String topic("test/topic");
     String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String signingRegion;
     String proxyHost;
@@ -132,8 +132,10 @@ int main(int argc, char *argv[])
         s_printHelp();
         return 1;
     }
-
-    topic = s_getCmdOption(argv, argv + argc, "--topic");
+    if (s_getCmdOption(argv, argv + argc, "--topic"))
+    {
+        topic = s_getCmdOption(argv, argv + argc, "--topic");
+    }
     if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
     {
         caFile = s_getCmdOption(argv, argv + argc, "--ca_file");

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -22,7 +22,7 @@ static void s_printHelp()
     fprintf(
         stdout,
         "raw-pub-sub --endpoint <endpoint> --cert <path to cert>"
-        " --key <path to key> --topic --ca_file <optional: path to custom ca>"
+        " --key <path to key> --topic <topic> --ca_file <optional: path to custom ca>"
         " --use_websocket --user_name <username> --password <password> --protocol_name <protocol> "
         " --auth_params=<comma delimited list> --proxy_host <host> --proxy_port <port>\n\n");
     fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
     String keyPath;
     String caFile;
     String topic;
-    String clientId(Aws::Crt::UUID().ToString());
+    String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String proxyHost;
     uint16_t proxyPort(8080);
     String userName;

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -28,7 +28,7 @@ static void s_printHelp()
     fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
     fprintf(stdout, "cert: path to your client certificate in PEM format. Don't use with use_websocket\n");
     fprintf(stdout, "key: path to your key in PEM format. Dont use with use_websocket\n");
-    fprintf(stdout, "topic: topic to publish, subscribe to.\n");
+    fprintf(stdout, "topic: topic to publish, subscribe to. (optional)\n");
     fprintf(stdout, "client_id: client id to use (optional)\n");
     fprintf(
         stdout,
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
     bool useWebSocket = false;
 
     /*********************** Parse Arguments ***************************/
-    if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--topic")))
+    if (!s_cmdOptionExists(argv, argv + argc, "--endpoint"))
     {
         s_printHelp();
         return 0;

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
     String certificatePath;
     String keyPath;
     String caFile;
-    String topic;
+    String topic("test/topic");
     String clientId(String("test-") + Aws::Crt::UUID().ToString());
     String proxyHost;
     uint16_t proxyPort(8080);
@@ -105,8 +105,10 @@ int main(int argc, char *argv[])
     {
         certificatePath = s_getCmdOption(argv, argv + argc, "--cert");
     }
-
-    topic = s_getCmdOption(argv, argv + argc, "--topic");
+    if (s_getCmdOption(argv, argv + argc, "--topic"))
+    {
+        topic = s_getCmdOption(argv, argv + argc, "--topic");
+    }
     if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
     {
         caFile = s_getCmdOption(argv, argv + argc, "--ca_file");

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -111,6 +111,7 @@ int main(int argc, char *argv[])
     String caFile;
     String thingName;
     String shadowProperty;
+    String clientId(String("test-") + Aws::Crt::UUID().ToString());
 
     /*********************** Parse Arguments ***************************/
     if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--cert") &&
@@ -245,7 +246,7 @@ int main(int argc, char *argv[])
      * Actually perform the connect dance.
      */
     fprintf(stdout, "Connecting...\n");
-    if (!connection->Connect("client_id12335456", true, 0))
+    if (!connection->Connect(clientId.c_str(), true, 0))
     {
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
         exit(-1);


### PR DESCRIPTION
ISSUE:
Currently, the "Getting Started Kit" vended by the IoT console vends a policy that doesn't match the strings used by any V2 SDK samples. So they fail right off the bat 😢

SOLUTION:
Let's get all the V2 SDKs using the same strings, then we can create a policy to fit them all. I'd like to put wildcards in the new policy so users can toy around a little bit, but include the word "test" everywhere so they feel inclined to change it before they ship.

Also, let's get all the samples putting randomness into the client-id, since colliding IDs are a frequent source of confusion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
