### PR TITLE
Update sample to consider the connection failed if a non-accepted mqtt return code is seen

### DIFF
--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
      * This will execute when an mqtt connect has completed or failed.
      */
     auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
-        if (errorCode)
+        if (errorCode || returnCode != AWS_MQTT_CONNECT_ACCEPTED)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
             std::lock_guard<std::mutex> lockGuard(mutex);

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -232,9 +232,15 @@ int main(int argc, char *argv[])
      * This will execute when an mqtt connect has completed or failed.
      */
     auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
-        if (errorCode || returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+        if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
+            std::lock_guard<std::mutex> lockGuard(mutex);
+            connectionSucceeded = false;
+        }
+        else if (returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+        {
+            fprintf(stdout, "Connection failed with mqtt return code %d\n", (int)returnCode);
             std::lock_guard<std::mutex> lockGuard(mutex);
             connectionSucceeded = false;
         }

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -286,9 +286,15 @@ int main(int argc, char *argv[])
      * This will execute when an mqtt connect has completed or failed.
      */
     auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
-        if (errorCode || returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+        if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
+            std::lock_guard<std::mutex> lockGuard(mutex);
+            connectionSucceeded = false;
+        }
+        else if (returnCode != AWS_MQTT_CONNECT_ACCEPTED)
+        {
+            fprintf(stdout, "Connection failed with mqtt return code %d\n", (int)returnCode);
             std::lock_guard<std::mutex> lockGuard(mutex);
             connectionSucceeded = false;
         }

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
      * This will execute when an mqtt connect has completed or failed.
      */
     auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
-        if (errorCode)
+        if (errorCode || returnCode != AWS_MQTT_CONNECT_ACCEPTED)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
             std::lock_guard<std::mutex> lockGuard(mutex);


### PR DESCRIPTION
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/38

* Updates pub sub samples to also treat non-accepted return codes as errors


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
