### PR TITLE
Fix shared libs for Windows MSVC.

### DIFF
--- a/jobs/include/aws/iotjobs/JobStatus.h
+++ b/jobs/include/aws/iotjobs/JobStatus.h
@@ -27,8 +27,8 @@ namespace Aws
 
         namespace JobStatusMarshaller
         {
-            const char *AWS_IOTJOBS_API ToString(JobStatus val);
-            JobStatus AWS_IOTJOBS_API FromString(const Aws::Crt::String &val);
+            AWS_IOTJOBS_API const char *ToString(JobStatus val);
+            AWS_IOTJOBS_API JobStatus FromString(const Aws::Crt::String &val);
         } // namespace JobStatusMarshaller
     }     // namespace Iotjobs
 } // namespace Aws

--- a/jobs/include/aws/iotjobs/RejectedErrorCode.h
+++ b/jobs/include/aws/iotjobs/RejectedErrorCode.h
@@ -28,8 +28,8 @@ namespace Aws
 
         namespace RejectedErrorCodeMarshaller
         {
-            const char *AWS_IOTJOBS_API ToString(RejectedErrorCode val);
-            RejectedErrorCode AWS_IOTJOBS_API FromString(const Aws::Crt::String &val);
+            AWS_IOTJOBS_API const char *ToString(RejectedErrorCode val);
+            AWS_IOTJOBS_API RejectedErrorCode FromString(const Aws::Crt::String &val);
         } // namespace RejectedErrorCodeMarshaller
     }     // namespace Iotjobs
 } // namespace Aws


### PR DESCRIPTION
*Issue:*
Encountered issues when building aws-iot-device-sdk-cpp-v2 as shared libraries (`-DBUILD_SHARED_LIBS`) on Windows with Visual Studio.

*Description of changes:*
1. Update git submodule for aws-crt-cpp.
2. Fix issue with `const char *AWS_IOTJOBS_API`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
