### PR TITLE
Make copy if need to pass address to C layer

### DIFF
--- a/secure_tunneling/CMakeLists.txt
+++ b/secure_tunneling/CMakeLists.txt
@@ -94,7 +94,6 @@ if (NOT IS_SUBDIRECTORY_INCLUDE)
     aws_use_package(aws-crt-cpp)
 endif()
 
-target_link_libraries(IotSecureTunneling-cpp ${DEP_AWS_LIBS})
 aws_use_package(aws-c-iot)
 
 if (BUILD_TESTING)

--- a/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
+++ b/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
@@ -26,13 +26,13 @@ namespace Aws
           public:
             SecureTunnel(
                 // Parameters map to aws_secure_tunneling_connection_config
-                Crt::Allocator *allocator,
-                Aws::Crt::Io::ClientBootstrap *clientBootstrap,
-                Aws::Crt::Io::SocketOptions *socketOptions,
+                Crt::Allocator *allocator,                        // Should out live this object
+                Aws::Crt::Io::ClientBootstrap *clientBootstrap,   // Should out live this object
+                const Aws::Crt::Io::SocketOptions &socketOptions, // Make a copy and save in this object
 
-                std::string accessToken,
+                const std::string &accessToken, // Make a copy and save in this object
                 aws_secure_tunneling_local_proxy_mode localProxyMode,
-                std::string endpointHost,
+                const std::string &endpointHost, // Make a copy and save in this object
 
                 OnConnectionComplete onConnectionComplete,
                 OnSendDataComplete onSendDataComplete,
@@ -76,6 +76,10 @@ namespace Aws
             OnStreamStart m_OnStreamStart;
             OnStreamReset m_OnStreamReset;
             OnSessionReset m_OnSessionReset;
+
+            Aws::Crt::Io::SocketOptions m_socketOptions;
+            std::string m_accessToken;
+            std::string m_endpointHost;
 
             aws_secure_tunnel *m_secure_tunnel;
         };

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -12,11 +12,11 @@ namespace Aws
         SecureTunnel::SecureTunnel(
             Crt::Allocator *allocator,
             Aws::Crt::Io::ClientBootstrap *clientBootstrap,
-            Aws::Crt::Io::SocketOptions *socketOptions,
+            const Aws::Crt::Io::SocketOptions &socketOptions,
 
-            std::string accessToken,
+            const std::string &accessToken,
             aws_secure_tunneling_local_proxy_mode localProxyMode,
-            std::string endpointHost,
+            const std::string &endpointHost,
 
             OnConnectionComplete onConnectionComplete,
             OnSendDataComplete onSendDataComplete,
@@ -33,17 +33,21 @@ namespace Aws
             m_OnStreamReset = onStreamReset;
             m_OnSessionReset = onSessionReset;
 
+            m_socketOptions = socketOptions;
+            m_accessToken = accessToken;
+            m_endpointHost = endpointHost;
+
             // Initialize aws_secure_tunneling_connection_config
             aws_secure_tunneling_connection_config config;
             AWS_ZERO_STRUCT(config);
 
             config.allocator = allocator;
             config.bootstrap = clientBootstrap ? clientBootstrap->GetUnderlyingHandle() : nullptr;
-            config.socket_options = socketOptions ? &socketOptions->GetImpl() : nullptr;
+            config.socket_options = &m_socketOptions.GetImpl();
 
-            config.access_token = aws_byte_cursor_from_c_str(accessToken.c_str());
+            config.access_token = aws_byte_cursor_from_c_str(m_accessToken.c_str());
             config.local_proxy_mode = localProxyMode;
-            config.endpoint_host = aws_byte_cursor_from_c_str(endpointHost.c_str());
+            config.endpoint_host = aws_byte_cursor_from_c_str(m_endpointHost.c_str());
 
             config.on_connection_complete = s_OnConnectionComplete;
             config.on_send_data_complete = s_OnSendDataComplete;
@@ -102,37 +106,37 @@ namespace Aws
 
         void SecureTunnel::s_OnConnectionComplete(void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnConnectionComplete();
         }
 
         void SecureTunnel::s_OnSendDataComplete(int error_code, void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnSendDataComplete(error_code);
         }
 
         void SecureTunnel::s_OnDataReceive(const struct aws_byte_buf *data, void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnDataReceive(*data);
         }
 
         void SecureTunnel::s_OnStreamStart(void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnStreamStart();
         }
 
         void SecureTunnel::s_OnStreamReset(void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnStreamReset();
         }
 
         void SecureTunnel::s_OnSessionReset(void *user_data)
         {
-            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnSessionReset();
         }
 

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -106,37 +106,37 @@ namespace Aws
 
         void SecureTunnel::s_OnConnectionComplete(void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnConnectionComplete();
         }
 
         void SecureTunnel::s_OnSendDataComplete(int error_code, void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnSendDataComplete(error_code);
         }
 
         void SecureTunnel::s_OnDataReceive(const struct aws_byte_buf *data, void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnDataReceive(*data);
         }
 
         void SecureTunnel::s_OnStreamStart(void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnStreamStart();
         }
 
         void SecureTunnel::s_OnStreamReset(void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnStreamReset();
         }
 
         void SecureTunnel::s_OnSessionReset(void *user_data)
         {
-            auto *secureTunnel = reinterpret_cast<SecureTunnel *>(user_data);
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnSessionReset();
         }
 

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -4,6 +4,7 @@
  */
 
 #include <aws/common/byte_buf.h>
+#include <aws/crt/io/SocketOptions.h>
 #include <aws/http/http.h>
 #include <aws/iotdevice/private/serializer.h>
 #include <aws/iotdevicecommon/IotDevice.h>
@@ -38,7 +39,6 @@ struct SecureTunnelingTestContext
     }
 };
 static SecureTunnelingTestContext s_testContext;
-static Aws::Crt::Io::SocketOptions s_socketOptions;
 
 // Client callbacks implementation
 static void s_OnConnectionComplete() {}
@@ -79,7 +79,7 @@ static int before(struct aws_allocator *allocator, void *ctx)
     testContext->secureTunnel = new Aws::Iotsecuretunneling::SecureTunnel(
         allocator,
         nullptr,
-        s_socketOptions,
+        Aws::Crt::Io::SocketOptions(),
         "access_token",
         testContext->localProxyMode,
         "endpoint",

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -38,6 +38,7 @@ struct SecureTunnelingTestContext
     }
 };
 static SecureTunnelingTestContext s_testContext;
+static Aws::Crt::Io::SocketOptions s_socketOptions;
 
 // Client callbacks implementation
 static void s_OnConnectionComplete() {}
@@ -78,7 +79,7 @@ static int before(struct aws_allocator *allocator, void *ctx)
     testContext->secureTunnel = new Aws::Iotsecuretunneling::SecureTunnel(
         allocator,
         nullptr,
-        nullptr,
+        s_socketOptions,
         "access_token",
         testContext->localProxyMode,
         "endpoint",


### PR DESCRIPTION
For memory that will be passed into the C layer, make a copy and store within the C++ secure tunnel object.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
