### PR TITLE
Wire root_ca to the C layer

### DIFF
--- a/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
+++ b/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
@@ -33,6 +33,7 @@ namespace Aws
                 const std::string &accessToken, // Make a copy and save in this object
                 aws_secure_tunneling_local_proxy_mode localProxyMode,
                 const std::string &endpointHost, // Make a copy and save in this object
+                const std::string &rootCa,       // Make a copy and save in this object
 
                 OnConnectionComplete onConnectionComplete,
                 OnSendDataComplete onSendDataComplete,
@@ -80,6 +81,7 @@ namespace Aws
             Aws::Crt::Io::SocketOptions m_socketOptions;
             std::string m_accessToken;
             std::string m_endpointHost;
+            std::string m_rootCa;
 
             aws_secure_tunnel *m_secure_tunnel;
         };

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -17,6 +17,7 @@ namespace Aws
             const std::string &accessToken,
             aws_secure_tunneling_local_proxy_mode localProxyMode,
             const std::string &endpointHost,
+            const std::string &rootCa,
 
             OnConnectionComplete onConnectionComplete,
             OnSendDataComplete onSendDataComplete,
@@ -36,6 +37,7 @@ namespace Aws
             m_socketOptions = socketOptions;
             m_accessToken = accessToken;
             m_endpointHost = endpointHost;
+            m_rootCa = rootCa;
 
             // Initialize aws_secure_tunneling_connection_config
             aws_secure_tunneling_connection_config config;
@@ -48,6 +50,7 @@ namespace Aws
             config.access_token = aws_byte_cursor_from_c_str(m_accessToken.c_str());
             config.local_proxy_mode = localProxyMode;
             config.endpoint_host = aws_byte_cursor_from_c_str(m_endpointHost.c_str());
+            config.root_ca = m_rootCa.c_str();
 
             config.on_connection_complete = s_OnConnectionComplete;
             config.on_send_data_complete = s_OnSendDataComplete;
@@ -74,6 +77,7 @@ namespace Aws
             m_socketOptions = other.m_socketOptions;
             m_accessToken = std::move(other.m_accessToken);
             m_endpointHost = std::move(other.m_endpointHost);
+            m_rootCa = std::move(other.m_rootCa);
 
             m_secure_tunnel = other.m_secure_tunnel;
 
@@ -104,6 +108,7 @@ namespace Aws
                 m_socketOptions = other.m_socketOptions;
                 m_accessToken = std::move(other.m_accessToken);
                 m_endpointHost = std::move(other.m_endpointHost);
+                m_rootCa = std::move(other.m_rootCa);
 
                 m_secure_tunnel = other.m_secure_tunnel;
 

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -83,6 +83,7 @@ static int before(struct aws_allocator *allocator, void *ctx)
         "access_token",
         testContext->localProxyMode,
         "endpoint",
+        "",
         s_OnConnectionComplete,
         s_OnSendDataComplete,
         s_OnDataReceive,


### PR DESCRIPTION
### Description of changes:
* Update `aws-c-iot` git submodule to include this [PR](https://github.com/awslabs/aws-c-iot/pull/39)
* Wire `root_ca` to the C layer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
