### PR TITLE
Handle shutdown

### DIFF
--- a/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
+++ b/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
@@ -15,6 +15,7 @@ namespace Aws
     {
         // Client callback type definitions
         using OnConnectionComplete = std::function<void(void)>;
+        using OnConnectionShutdown = std::function<void(void)>;
         using OnSendDataComplete = std::function<void(int errorCode)>;
         using OnDataReceive = std::function<void(const Crt::ByteBuf &data)>;
         using OnStreamStart = std::function<void()>;
@@ -36,6 +37,7 @@ namespace Aws
                 const std::string &rootCa,       // Make a copy and save in this object
 
                 OnConnectionComplete onConnectionComplete,
+                OnConnectionShutdown onConnectionShutdown,
                 OnSendDataComplete onSendDataComplete,
                 OnDataReceive onDataReceive,
                 OnStreamStart onStreamStart,
@@ -64,6 +66,7 @@ namespace Aws
           private:
             // aws-c-iot callbacks
             static void s_OnConnectionComplete(void *user_data);
+            static void s_OnConnectionShutdown(void *user_data);
             static void s_OnSendDataComplete(int error_code, void *user_data);
             static void s_OnDataReceive(const struct aws_byte_buf *data, void *user_data);
             static void s_OnStreamStart(void *user_data);
@@ -72,6 +75,7 @@ namespace Aws
 
             // Client callbacks
             OnConnectionComplete m_OnConnectionComplete;
+            OnConnectionShutdown m_OnConnectionShutdown;
             OnSendDataComplete m_OnSendDataComplete;
             OnDataReceive m_OnDataReceive;
             OnStreamStart m_OnStreamStart;

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -20,6 +20,7 @@ namespace Aws
             const std::string &rootCa,
 
             OnConnectionComplete onConnectionComplete,
+            OnConnectionShutdown onConnectionShutdown,
             OnSendDataComplete onSendDataComplete,
             OnDataReceive onDataReceive,
             OnStreamStart onStreamStart,
@@ -28,6 +29,7 @@ namespace Aws
         {
             // Client callbacks
             m_OnConnectionComplete = onConnectionComplete;
+            m_OnConnectionShutdown = onConnectionShutdown;
             m_OnSendDataComplete = onSendDataComplete;
             m_OnDataReceive = onDataReceive;
             m_OnStreamStart = onStreamStart;
@@ -53,6 +55,7 @@ namespace Aws
             config.root_ca = m_rootCa.c_str();
 
             config.on_connection_complete = s_OnConnectionComplete;
+            config.on_connection_shutdown = s_OnConnectionShutdown;
             config.on_send_data_complete = s_OnSendDataComplete;
             config.on_data_receive = s_OnDataReceive;
             config.on_stream_start = s_OnStreamStart;
@@ -68,6 +71,7 @@ namespace Aws
         SecureTunnel::SecureTunnel(SecureTunnel &&other) noexcept
         {
             m_OnConnectionComplete = other.m_OnConnectionComplete;
+            m_OnConnectionShutdown = other.m_OnConnectionShutdown;
             m_OnSendDataComplete = other.m_OnSendDataComplete;
             m_OnDataReceive = other.m_OnDataReceive;
             m_OnStreamStart = other.m_OnStreamStart;
@@ -99,6 +103,7 @@ namespace Aws
                 this->~SecureTunnel();
 
                 m_OnConnectionComplete = other.m_OnConnectionComplete;
+                m_OnConnectionShutdown = other.m_OnConnectionShutdown;
                 m_OnSendDataComplete = other.m_OnSendDataComplete;
                 m_OnDataReceive = other.m_OnDataReceive;
                 m_OnStreamStart = other.m_OnStreamStart;
@@ -137,6 +142,12 @@ namespace Aws
         {
             auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
             secureTunnel->m_OnConnectionComplete();
+        }
+
+        void SecureTunnel::s_OnConnectionShutdown(void *user_data)
+        {
+            auto *secureTunnel = static_cast<SecureTunnel *>(user_data);
+            secureTunnel->m_OnConnectionShutdown();
         }
 
         void SecureTunnel::s_OnSendDataComplete(int error_code, void *user_data)

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -40,10 +40,7 @@ struct SecureTunnelingTestContext
 
     aws_secure_tunneling_local_proxy_mode localProxyMode;
 
-    SecureTunnelingTestContext()
-    {
-        localProxyMode = AWS_SECURE_TUNNELING_DESTINATION_MODE;
-    }
+    SecureTunnelingTestContext() { localProxyMode = AWS_SECURE_TUNNELING_DESTINATION_MODE; }
 };
 static SecureTunnelingTestContext s_testContext;
 
@@ -86,7 +83,8 @@ static int before(struct aws_allocator *allocator, void *ctx)
     testContext->deviceApiHandle = unique_ptr<DeviceApiHandle>(new DeviceApiHandle(allocator));
     testContext->elGroup = unique_ptr<EventLoopGroup>(new EventLoopGroup(1, allocator));
     testContext->resolver = unique_ptr<HostResolver>(new DefaultHostResolver(*testContext->elGroup, 8, 30, allocator));
-    testContext->clientBootstrap = unique_ptr<ClientBootstrap>(new ClientBootstrap(*testContext->elGroup, *testContext->resolver, allocator));
+    testContext->clientBootstrap =
+        unique_ptr<ClientBootstrap>(new ClientBootstrap(*testContext->elGroup, *testContext->resolver, allocator));
     testContext->secureTunnel = unique_ptr<SecureTunnel>(new SecureTunnel(
         allocator,
         testContext->clientBootstrap.get(),

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -108,9 +108,6 @@ static int after(struct aws_allocator *allocator, int setup_result, void *ctx)
 {
     auto *testContext = static_cast<SecureTunnelingTestContext *>(ctx);
 
-    // Normally this memory is released within the ping task.
-    aws_mem_release(allocator, testContext->secureTunnel->GetUnderlyingHandle()->ping_task_context);
-
     testContext->secureTunnel.reset();
     testContext->clientBootstrap.reset();
     testContext->resolver.reset();

--- a/secure_tunneling/tests/SecureTunnelTest.cpp
+++ b/secure_tunneling/tests/SecureTunnelTest.cpp
@@ -42,6 +42,7 @@ static SecureTunnelingTestContext s_testContext;
 
 // Client callbacks implementation
 static void s_OnConnectionComplete() {}
+static void s_OnConnectionShutdown() {}
 
 static void s_OnSendDataComplete(int errorCode) {}
 
@@ -85,6 +86,7 @@ static int before(struct aws_allocator *allocator, void *ctx)
         "endpoint",
         "",
         s_OnConnectionComplete,
+        s_OnConnectionShutdown,
         s_OnSendDataComplete,
         s_OnDataReceive,
         s_OnStreamStart,


### PR DESCRIPTION
### Description of changes:
The aws-c-iot SDK is updated to notify the client when a websocket is closed. This PR wires the callback in the C++ layer.

This PR depends on a PR in aws-c-iot:
https://github.com/awslabs/aws-c-iot/pull/42

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
