### PR TITLE
guard include directory statements with condition on whether or not d…

### DIFF
--- a/devicedefender/CMakeLists.txt
+++ b/devicedefender/CMakeLists.txt
@@ -90,11 +90,12 @@ target_include_directories(IotDeviceDefender-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+        endif()
+	aws_use_package(aws-c-iot)
 endif()
-
-aws_use_package(aws-c-iot)
 
 if (BUILD_TESTING)
     aws_use_package(IotDeviceCommon-cpp)

--- a/discovery/CMakeLists.txt
+++ b/discovery/CMakeLists.txt
@@ -90,8 +90,10 @@ target_include_directories(Discovery-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
 endif()
 
 target_link_libraries(Discovery-cpp ${DEP_AWS_LIBS})

--- a/identity/CMakeLists.txt
+++ b/identity/CMakeLists.txt
@@ -90,8 +90,10 @@ target_include_directories(IotIdentity-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
 endif()
 
 target_link_libraries(IotIdentity-cpp ${DEP_AWS_LIBS})

--- a/iotdevicecommon/CMakeLists.txt
+++ b/iotdevicecommon/CMakeLists.txt
@@ -90,11 +90,12 @@ target_include_directories(IotDeviceCommon-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
+	aws_use_package(aws-c-iot)
 endif()
-
-aws_use_package(aws-c-iot)
 
 target_link_libraries(IotDeviceCommon-cpp ${DEP_AWS_LIBS})
 

--- a/jobs/CMakeLists.txt
+++ b/jobs/CMakeLists.txt
@@ -90,8 +90,10 @@ target_include_directories(IotJobs-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
 endif()
 
 target_link_libraries(IotJobs-cpp ${DEP_AWS_LIBS})

--- a/secure_tunneling/CMakeLists.txt
+++ b/secure_tunneling/CMakeLists.txt
@@ -90,11 +90,12 @@ target_include_directories(IotSecureTunneling-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
+	aws_use_package(aws-c-iot)
 endif()
-
-aws_use_package(aws-c-iot)
 
 if (BUILD_TESTING)
     aws_use_package(IotDeviceCommon-cpp)

--- a/shadow/CMakeLists.txt
+++ b/shadow/CMakeLists.txt
@@ -90,8 +90,10 @@ target_include_directories(IotShadow-cpp PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-if (NOT IS_SUBDIRECTORY_INCLUDE)
-    aws_use_package(aws-crt-cpp)
+if (BUILD_DEPS)
+	if (NOT IS_SUBDIRECTORY_INCLUDE)
+		aws_use_package(aws-crt-cpp)
+	endif()
 endif()
 
 target_link_libraries(IotShadow-cpp ${DEP_AWS_LIBS})


### PR DESCRIPTION
…ependencies are being built

*Issue #, if available:*

Not available.

*Description of changes:*

Make guards for dependent cmake scripts for subcomponents so when you run a build with all dependencies already installed you can just use those - like a Yocto based build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
