### PR TITLE
Greengrass IPC

### DIFF
--- a/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -258,7 +258,7 @@ namespace Aws
                 const Crt::Optional<Crt::ByteBuf> &payload,
                 OnMessageFlushCallback onMessageFlushCallback) noexcept;
 
-            ClientContinuation NewStream(ClientContinuationHandler *clientContinuationHandler) noexcept;
+            ClientContinuation NewStream(ClientContinuationHandler &clientContinuationHandler) noexcept;
 
             void Close() noexcept;
 
@@ -338,7 +338,7 @@ namespace Aws
           public:
             ClientContinuation(
                 ClientConnection *connection,
-                ClientContinuationHandler *handler,
+                ClientContinuationHandler &continuationHandler,
                 Crt::Allocator *allocator) noexcept;
             std::future<EventStreamRpcStatus> Activate(
                 const Crt::String &operation,
@@ -357,7 +357,7 @@ namespace Aws
 
           private:
             Crt::Allocator *m_allocator;
-            ClientContinuationHandler *m_handler;
+            ClientContinuationHandler &m_continuationHandler;
             struct aws_event_stream_rpc_client_continuation_token *m_continuationToken;
             static void s_onContinuationMessage(
                 struct aws_event_stream_rpc_client_continuation_token *continuationToken,
@@ -502,7 +502,7 @@ namespace Aws
             ClientOperation(
                 ClientConnection &connection,
                 StreamResponseHandler *streamHandler,
-                const ResponseRetriever *responseRetriever,
+                const ResponseRetriever &responseRetriever,
                 Crt::Allocator *allocator) noexcept;
             ~ClientOperation() noexcept;
             ClientOperation(const ClientOperation &clientOperation) noexcept = default;
@@ -519,7 +519,6 @@ namespace Aws
                 OperationRequest *shape,
                 OnMessageFlushCallback onMessageFlushCallback) noexcept;
             virtual Crt::String GetModelName() const noexcept = 0;
-            const ResponseRetriever *m_ResponseRetriever;
 
           private:
             int HandleData(const Crt::String &modelName, const Crt::Optional<Crt::ByteBuf> &payload);
@@ -549,8 +548,8 @@ namespace Aws
                 const Crt::String &name) noexcept;
             uint32_t m_messageCount;
             Crt::Allocator *m_allocator;
-            StreamResponseHandler *m_streamHandler;
-            const ResponseRetriever *m_responseRetriever;
+            StreamResponseHandler* m_streamHandler;
+            const ResponseRetriever& m_responseRetriever;
             ClientContinuation m_clientContinuation;
             ProtectedPromise<TaggedResponse> m_initialResponsePromise;
             /* ProtectedPromise not necessary because it's only ever being set by one thread. */

--- a/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -147,11 +147,10 @@ namespace Aws
             /// @private
             aws_host_resolver *GetUnderlyingHandle() noexcept override { return m_resolver; }
             /// @private
-            aws_host_resolution_config *GetConfig() noexcept override { return &m_config; }
+            aws_host_resolution_config *GetConfig() noexcept override { return NULL; }
 
           private:
             aws_host_resolver *m_resolver;
-            aws_host_resolution_config m_config;
             Crt::Allocator *m_allocator;
             bool m_initialized;
 

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -57,6 +57,38 @@ namespace Aws
 
         void MessageAmendment::SetPayload(const Crt::Optional<Crt::ByteBuf> &payload) noexcept { m_payload = payload; }
 
+        UnixSocketResolver::UnixSocketResolver(
+            Crt::Io::EventLoopGroup &elGroup,
+            size_t maxHosts,
+            Crt::Allocator *allocator) noexcept
+            : m_resolver(nullptr), m_allocator(allocator), m_initialized(false)
+        {
+            AWS_ZERO_STRUCT(m_config);
+
+            struct aws_host_resolver_default_options resolver_options;
+            AWS_ZERO_STRUCT(resolver_options);
+            resolver_options.max_entries = maxHosts;
+            resolver_options.el_group = elGroup.GetUnderlyingHandle();
+
+            m_resolver = aws_host_resolver_new_default(allocator, &resolver_options);
+            if (m_resolver != nullptr)
+            {
+                m_initialized = true;
+            }
+        }
+
+        bool UnixSocketResolver::ResolveHost(const Crt::String &host, const Crt::Io::OnHostResolved &onResolved) noexcept
+        {
+            // Nothing to resolve
+            return true;
+        }
+
+        UnixSocketResolver::~UnixSocketResolver()
+        {
+            aws_host_resolver_release(m_resolver);
+            m_initialized = false;
+        }
+
         ClientConnectionOptions::ClientConnectionOptions()
             : Bootstrap(), SocketOptions(), TlsOptions(), HostName(), Port(0)
         {

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -536,10 +536,8 @@ namespace Aws
             thisConnection->m_clientState = DISCONNECTED;
             thisConnection->m_stateMutex.unlock();
 
-            if (thisConnection->m_lifecycleHandler.OnErrorCallback(errorCode))
-            {
-                thisConnection->Close();
-            }
+            /* No connection to close here, so no need to check return value. */
+            (void) thisConnection->m_lifecycleHandler.OnErrorCallback(errorCode);
         }
 
         void MessageAmendment::AddHeader(EventStreamHeader &&header) noexcept { m_headers.push_back(header); }

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -63,8 +63,6 @@ namespace Aws
             Crt::Allocator *allocator) noexcept
             : m_resolver(nullptr), m_allocator(allocator), m_initialized(false)
         {
-            AWS_ZERO_STRUCT(m_config);
-
             struct aws_host_resolver_default_options resolver_options;
             AWS_ZERO_STRUCT(resolver_options);
             resolver_options.max_entries = maxHosts;

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -212,7 +212,6 @@ namespace Aws
             Crt::Allocator *allocator) noexcept
             : m_allocator(allocator), m_lifecycleHandler(connectionLifecycleHandler)
         {
-            std::cout << aws_error_str(1059) << std::endl;
         }
 
         ClientConnection::~ClientConnection() noexcept

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -509,7 +509,9 @@ namespace Aws
                         Crt::String(EVENTSTREAM_VERSION_STRING),
                         thisConnection->m_allocator));
                     /* Note that we are prepending headers from the user-provided amender. */
-                    messageAmendmentHeaders.splice(messageAmendmentHeaders.end(), amenderHeaderList);
+                    if(amenderHeaderList.size() > 0) {
+                        messageAmendmentHeaders.splice(messageAmendmentHeaders.end(), amenderHeaderList);
+                    }
                     messageAmendment.SetPayload(connectAmendment.GetPayload());
                 }
 

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -182,6 +182,7 @@ namespace Aws
             Crt::Allocator *allocator) noexcept
             : m_allocator(allocator), m_lifecycleHandler(connectionLifecycleHandler)
         {
+            std::cout << aws_error_str(1059) << std::endl;
         }
 
         ClientConnection::~ClientConnection() noexcept

--- a/ipc/include/aws/ipc/GGCoreIpcClient.h
+++ b/ipc/include/aws/ipc/GGCoreIpcClient.h
@@ -118,7 +118,7 @@ namespace Aws
               public:
                 PublishToTopicOperation(
                     ClientConnection &connection,
-                    const GreengrassModelRetriever *greengrassModelRetriever,
+                    const GreengrassModelRetriever &greengrassModelRetriever,
                     Crt::Allocator *allocator) noexcept;
                 std::future<EventStreamRpcStatus> Activate(
                     const PublishToTopicRequest &request,
@@ -224,7 +224,7 @@ namespace Aws
                 SubscribeToTopicOperation(
                     ClientConnection &connection,
                     SubscribeToTopicStreamHandler *m_streamHandler,
-                    const GreengrassModelRetriever *greengrassModelRetriever,
+                    const GreengrassModelRetriever &greengrassModelRetriever,
                     Crt::Allocator *allocator) noexcept;
                 std::future<EventStreamRpcStatus> Activate(
                     const SubscribeToTopicRequest &request,
@@ -264,14 +264,13 @@ namespace Aws
                     const Crt::Optional<Crt::String> &authToken = Crt::Optional<Crt::String>()) noexcept;
                 void Close() noexcept;
                 PublishToTopicOperation NewPublishToTopic() noexcept;
-                SubscribeToTopicOperation NewSubscribeToTopic(SubscribeToTopicStreamHandler *streamHandler) noexcept;
+                SubscribeToTopicOperation NewSubscribeToTopic(SubscribeToTopicStreamHandler& streamHandler) noexcept;
                 ~GreengrassIpcClient() noexcept;
               private:
                 GreengrassModelRetriever m_greengrassModelRetriever;
                 ClientConnection m_connection;
                 Crt::Io::ClientBootstrap& m_clientBootstrap;
                 Crt::Allocator *m_allocator;
-                MessageAmendment m_connectionAmendment;
             };
         } // namespace Ipc
 

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -371,7 +371,7 @@ namespace Aws
                 Crt::StringStream authTokenPayloadSS;
                 authTokenPayloadSS << "{\"authToken\":\"" << finalAuthToken << "\"}";
 
-                if(!m_clientBootstrap)
+                if (!m_clientBootstrap)
                 {
                     initializationPromise.set_value({EVENT_STREAM_RPC_INITIALIZATION_ERROR, 0});
                     return initializationPromise.get_future();
@@ -393,10 +393,7 @@ namespace Aws
                 return m_connection.Connect(connectionOptions, lifecycleHandler, messageAmender);
             }
 
-            void GreengrassIpcClient::Close() noexcept
-            {
-                m_connection.Close();
-            }
+            void GreengrassIpcClient::Close() noexcept { m_connection.Close(); }
 
             GreengrassIpcClient::~GreengrassIpcClient() noexcept
             {
@@ -452,7 +449,7 @@ namespace Aws
             }
 
             SubscribeToTopicOperation GreengrassIpcClient::NewSubscribeToTopic(
-                SubscribeToTopicStreamHandler& streamHandler) noexcept
+                SubscribeToTopicStreamHandler &streamHandler) noexcept
             {
                 return SubscribeToTopicOperation(m_connection, &streamHandler, m_greengrassModelRetriever, m_allocator);
             }

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -95,7 +95,7 @@ namespace Aws
 
             PublishToTopicOperation::PublishToTopicOperation(
                 ClientConnection &connection,
-                const GreengrassModelRetriever *greengrassModelRetriever,
+                const GreengrassModelRetriever &greengrassModelRetriever,
                 Crt::Allocator *allocator) noexcept
                 : ClientOperation(connection, nullptr, greengrassModelRetriever, allocator)
             {
@@ -111,7 +111,7 @@ namespace Aws
             SubscribeToTopicOperation::SubscribeToTopicOperation(
                 ClientConnection &connection,
                 SubscribeToTopicStreamHandler *streamHandler,
-                const GreengrassModelRetriever *greengrassModelRetriever,
+                const GreengrassModelRetriever &greengrassModelRetriever,
                 Crt::Allocator *allocator) noexcept
                 : ClientOperation(connection, streamHandler, greengrassModelRetriever, allocator)
             {
@@ -378,8 +378,7 @@ namespace Aws
                 connectionOptions.Port = 0;
 
                 MessageAmendment connectionAmendment(Crt::ByteBufFromCString(finalAuthToken));
-                m_connectionAmendment.SetPayload(Crt::ByteBufFromCString(finalAuthToken));
-                auto messageAmender = [&](void) -> MessageAmendment & { return m_connectionAmendment; };
+                auto messageAmender = [&](void) -> MessageAmendment & { return connectionAmendment; };
 
                 return m_connection.Connect(connectionOptions, lifecycleHandler, messageAmender);
             }
@@ -439,13 +438,13 @@ namespace Aws
 
             PublishToTopicOperation GreengrassIpcClient::NewPublishToTopic() noexcept
             {
-                return PublishToTopicOperation(m_connection, &m_greengrassModelRetriever, m_allocator);
+                return PublishToTopicOperation(m_connection, m_greengrassModelRetriever, m_allocator);
             }
 
             SubscribeToTopicOperation GreengrassIpcClient::NewSubscribeToTopic(
-                SubscribeToTopicStreamHandler *streamHandler) noexcept
+                SubscribeToTopicStreamHandler& streamHandler) noexcept
             {
-                return SubscribeToTopicOperation(m_connection, streamHandler, &m_greengrassModelRetriever, m_allocator);
+                return SubscribeToTopicOperation(m_connection, &streamHandler, m_greengrassModelRetriever, m_allocator);
             }
 
             void SubscribeToTopicStreamHandler::OnStreamEvent(Crt::ScopedResource<OperationResponse> response)

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -345,14 +345,14 @@ namespace Aws
             {
                 std::promise<EventStreamRpcStatus> initializationPromise;
 
-                const char *finalIpcSocket;
+                Crt::String finalIpcSocket;
                 if (ipcSocket.has_value())
                 {
-                    finalIpcSocket = ipcSocket.value().c_str();
+                    finalIpcSocket = ipcSocket.value();
                 }
                 else
                 {
-                    finalIpcSocket = std::getenv("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT");
+                    finalIpcSocket = Crt::String(std::getenv("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT"));
                 }
 
                 const char *finalAuthToken;

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -371,9 +371,13 @@ namespace Aws
                     return initializationPromise.get_future();
                 }
 
+                Crt::Io::SocketOptions socketOptions;
+                socketOptions.SetSocketDomain(Crt::Io::SocketDomain::Local);
+                socketOptions.SetSocketType(Crt::Io::SocketType::Stream);
+
                 ClientConnectionOptions connectionOptions;
                 connectionOptions.Bootstrap = &m_clientBootstrap;
-                connectionOptions.SocketOptions = Crt::Io::SocketOptions();
+                connectionOptions.SocketOptions = std::move(socketOptions);
                 connectionOptions.HostName = finalIpcSocket;
                 connectionOptions.Port = 0;
 

--- a/ipc/tests/GGCoreIpcClientTest.cpp
+++ b/ipc/tests/GGCoreIpcClientTest.cpp
@@ -46,7 +46,7 @@ static int s_PublishToIoTCore(struct aws_allocator *allocator, void *ctx)
         /* Subscribe to Topic */
         {
             Ipc::SubscribeToTopicStreamHandler streamHandler;
-            Ipc::SubscribeToTopicOperation operation = client.NewSubscribeToTopic(&streamHandler);
+            Ipc::SubscribeToTopicOperation operation = client.NewSubscribeToTopic(streamHandler);
             Ipc::SubscribeToTopicRequest request(Aws::Crt::String("topic"), allocator);
             auto activate = operation.Activate(request, nullptr);
             activate.wait();

--- a/ipc/tests/GGCoreIpcClientTest.cpp
+++ b/ipc/tests/GGCoreIpcClientTest.cpp
@@ -29,10 +29,10 @@ static int s_PublishToIoTCore(struct aws_allocator *allocator, void *ctx)
         Aws::Crt::Io::EventLoopGroup eventLoopGroup(0, allocator);
         ASSERT_TRUE(eventLoopGroup);
 
-        Aws::Crt::Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 8, 30, allocator);
-        ASSERT_TRUE(defaultHostResolver);
+        UnixSocketResolver unixSocketResolver(eventLoopGroup, 8, allocator);
+        ASSERT_TRUE(unixSocketResolver);
 
-        Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
+        Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, unixSocketResolver, allocator);
         ASSERT_TRUE(clientBootstrap);
         clientBootstrap.EnableBlockingShutdown();
         MessageAmendment connectionAmendment;

--- a/ipc/tests/GGCoreIpcClientTest.cpp
+++ b/ipc/tests/GGCoreIpcClientTest.cpp
@@ -41,7 +41,7 @@ static int s_PublishToIoTCore(struct aws_allocator *allocator, void *ctx)
         ConnectionLifecycleHandler lifecycleHandler;
         Ipc::GreengrassIpcClient client(lifecycleHandler, clientBootstrap);
         auto connectedStatus = client.Connect(lifecycleHandler);
-        connectedStatus.get();
+        ASSERT_TRUE(connectedStatus.get().baseStatus == EVENT_STREAM_RPC_SUCCESS);
 
         /* Subscribe to Topic */
         {


### PR DESCRIPTION
- Fixes the definition of the flush callback along with futures returning the expected result of the operation
- Introduces a few mechanisms such as `ProtectedPromise` and mutexes to handle synchronization across multiple threads
- Avoids usage of pointers wherever possible in place of references

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
