### PR TITLE
GG IPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_subdirectory(shadow)
 add_subdirectory(discovery)
 add_subdirectory(identity)
 add_subdirectory(eventstreamrpc)
+add_subdirectory(ipc)
 if (NOT BYO_CRYPTO)
     # TODO: get these working with BYO_CRYPTO
     add_subdirectory(iotdevicecommon)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ add_subdirectory(jobs)
 add_subdirectory(shadow)
 add_subdirectory(discovery)
 add_subdirectory(identity)
+add_subdirectory(eventstreamrpc)
 if (NOT BYO_CRYPTO)
     # TODO: get these working with BYO_CRYPTO
     add_subdirectory(iotdevicecommon)

--- a/eventstreamrpc/CMakeLists.txt
+++ b/eventstreamrpc/CMakeLists.txt
@@ -1,0 +1,123 @@
+cmake_minimum_required(VERSION 3.1)
+project(EventstreamRpc-cpp CXX)
+
+set(RUNTIME_DIRECTORY bin)
+
+if (UNIX AND NOT APPLE)
+    include(GNUInstallDirs)
+elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_LIBDIR "lib")
+
+    if (${CMAKE_INSTALL_LIBDIR} STREQUAL "lib64")
+        set(FIND_LIBRARY_USE_LIB64_PATHS true)
+    endif()
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_PREFIX_PATH}/${CMAKE_INSTALL_LIBDIR}/cmake")
+
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+file(GLOB AWS_EVENTSTREAMRPC_HEADERS
+        "include/aws/eventstreamrpc/*.h"
+)
+
+file(GLOB AWS_EVENTSTREAMRPC_SRC
+       "source/*.cpp"
+)
+
+file(GLOB AWS_EVENTSTREAMRPC_CPP_SRC
+        ${AWS_EVENTSTREAMRPC_SRC}
+)
+
+if (WIN32)
+    if (MSVC)
+        source_group("Header Files\\aws\\eventstreamrpc\\" FILES ${AWS_EVENTSTREAMRPC_HEADERS})
+
+        source_group("Source Files" FILES ${AWS_EVENTSTREAMRPC_SRC})
+    endif ()
+endif()
+
+add_library(EventstreamRpc-cpp ${AWS_EVENTSTREAMRPC_CPP_SRC})
+
+set_target_properties(EventstreamRpc-cpp PROPERTIES LINKER_LANGUAGE CXX)
+
+set(CMAKE_C_FLAGS_DEBUGOPT "")
+
+#set warnings
+if (MSVC)
+    target_compile_options(EventstreamRpc-cpp PRIVATE /W4 /WX)
+else ()
+    target_compile_options(EventstreamRpc-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
+endif ()
+
+if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
+    target_compile_definitions(EventstreamRpc-cpp PRIVATE "-DDEBUG_BUILD")
+endif ()
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(EventstreamRpc-cpp PUBLIC "-DAWS_EVENTSTREAMRPC_USE_IMPORT_EXPORT")
+    target_compile_definitions(EventstreamRpc-cpp PRIVATE "-DAWS_EVENTSTREAMRPC_EXPORTS")
+
+    install(TARGETS EventstreamRpc-cpp
+            EXPORT EventstreamRpc-cpp-targets
+            ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT Development
+            LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            NAMELINK_SKIP
+            COMPONENT Runtime
+            RUNTIME
+            DESTINATION ${RUNTIME_DIRECTORY}
+            COMPONENT Runtime)
+
+    install(TARGETS EventstreamRpc-cpp
+            EXPORT EventstreamRpc-cpp-targets
+            LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            NAMELINK_ONLY
+            COMPONENT Development)
+else()
+    install(TARGETS EventstreamRpc-cpp
+            EXPORT EventstreamRpc-cpp-targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT Development)
+endif()
+
+target_include_directories(EventstreamRpc-cpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+
+if (NOT IS_SUBDIRECTORY_INCLUDE)
+    aws_use_package(aws-crt-cpp)
+endif()
+
+
+target_link_libraries(EventstreamRpc-cpp ${DEP_AWS_LIBS})
+
+install(FILES ${AWS_EVENTSTREAMRPC_HEADERS} DESTINATION "include/aws/eventstreamrpc/" COMPONENT Development)
+
+if (BUILD_SHARED_LIBS)
+    set(TARGET_DIR "shared")
+else()
+    set(TARGET_DIR "static")
+endif()
+
+install(EXPORT "EventstreamRpc-cpp-targets"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/EventstreamRpc-cpp/cmake/${TARGET_DIR}"
+        NAMESPACE AWS::
+        COMPONENT Development)
+
+configure_file("cmake/eventstreamrpc-cpp-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/eventstreamrpc-cpp-config.cmake"
+        @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/eventstreamrpc-cpp-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/EventstreamRpc-cpp/cmake/"
+        COMPONENT Development)
+
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/eventstreamrpc/cmake/eventstreamrpc-cpp-config.cmake
+++ b/eventstreamrpc/cmake/eventstreamrpc-cpp-config.cmake
@@ -1,0 +1,9 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(aws-crt-cpp)
+
+if (BUILD_SHARED_LIBS)
+   include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
+else()
+   include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
+endif()

--- a/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstreamrpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -1,0 +1,464 @@
+#pragma once
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/eventstreamrpc/Exports.h>
+
+#include <aws/crt/DateTime.h>
+#include <aws/crt/StlAllocator.h>
+#include <aws/crt/Types.h>
+#include <aws/crt/UUID.h>
+#include <aws/crt/io/EventLoopGroup.h>
+#include <aws/crt/io/SocketOptions.h>
+#include <aws/crt/io/TlsOptions.h>
+
+#include <aws/event-stream/event_stream_rpc_client.h>
+
+#include <atomic>
+#include <functional>
+#include <future>
+#include <memory>
+
+namespace Aws
+{
+    namespace Crt
+    {
+        namespace Io
+        {
+            class ClientBootstrap;
+        }
+    } // namespace Crt
+    namespace Eventstreamrpc
+    {
+        class EventStreamHeader;
+        class EventStreamRpcClient;
+        class ClientConnection;
+        class ClientContinuation;
+        class MessageAmendment;
+
+        using HeaderValueType = aws_event_stream_header_value_type;
+        using MessageType = aws_event_stream_rpc_message_type;
+
+        using OnMessageFlushCallback = std::function<void(int errorCode)>;
+
+        /**
+         * Allows the application to append headers and change the payload of the CONNECT
+         * packet being sent out.
+         */
+        using ConnectMessageAmender = std::function<MessageAmendment &(void)>;
+
+        class AWS_EVENTSTREAMRPC_API EventStreamHeader final
+        {
+          public:
+            EventStreamHeader(const EventStreamHeader &lhs) noexcept;
+            EventStreamHeader(EventStreamHeader &&rhs) noexcept;
+            ~EventStreamHeader() noexcept;
+            EventStreamHeader(const struct aws_event_stream_header_value_pair &header);
+            EventStreamHeader(const Crt::String &name, bool value);
+            EventStreamHeader(const Crt::String &name, int8_t value);
+            EventStreamHeader(const Crt::String &name, int16_t value);
+            EventStreamHeader(const Crt::String &name, int32_t value);
+            EventStreamHeader(const Crt::String &name, int64_t value);
+            EventStreamHeader(const Crt::String &name, Crt::DateTime &value);
+            EventStreamHeader(
+                const Crt::String &name,
+                const Crt::String &value,
+                Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+            EventStreamHeader(const Crt::String &name, Crt::ByteBuf &value);
+            EventStreamHeader(const Crt::String &name, Crt::UUID value);
+
+            HeaderValueType GetHeaderValueType();
+            Crt::String GetHeaderName() const noexcept;
+            void SetHeaderName(const Crt::String &);
+
+            bool GetValueAsBoolean(bool &);
+            bool GetValueAsByte(int8_t &);
+            bool GetValueAsShort(int16_t &);
+            bool GetValueAsInt(int32_t &);
+            bool GetValueAsLong(int64_t &);
+            bool GetValueAsTimestamp(Crt::DateTime &);
+            bool GetValueAsString(Crt::String &) const noexcept;
+            bool GetValueAsBytes(Crt::ByteBuf &);
+            bool GetValueAsUUID(Crt::UUID &);
+
+            const struct aws_event_stream_header_value_pair *GetUnderlyingHandle() const;
+
+            bool operator==(const EventStreamHeader &other) const noexcept;
+
+          private:
+            Crt::Allocator *m_allocator;
+            Crt::ByteBuf m_valueByteBuf;
+            struct aws_event_stream_header_value_pair m_underlyingHandle;
+        };
+
+        class AWS_EVENTSTREAMRPC_API MessageAmendment final
+        {
+          public:
+            MessageAmendment() = default;
+            MessageAmendment(const MessageAmendment &lhs) = default;
+            MessageAmendment(MessageAmendment &&rhs) = default;
+            explicit MessageAmendment(
+                const Crt::List<EventStreamHeader> &headers,
+                Crt::Optional<Crt::ByteBuf> &payload) noexcept;
+            explicit MessageAmendment(const Crt::List<EventStreamHeader> &headers) noexcept;
+            explicit MessageAmendment(Crt::List<EventStreamHeader> &&headers) noexcept;
+            explicit MessageAmendment(const Crt::ByteBuf &payload) noexcept;
+            void AddHeader(EventStreamHeader &&header) noexcept;
+            void SetPayload(const Crt::Optional<Crt::ByteBuf> &payload) noexcept;
+            Crt::List<EventStreamHeader> &GetHeaders() noexcept;
+            const Crt::Optional<Crt::ByteBuf> &GetPayload() const noexcept;
+
+          private:
+            Crt::List<EventStreamHeader> m_headers;
+            Crt::Optional<Crt::ByteBuf> m_payload;
+        };
+
+        /**
+         * Configuration structure holding all options relating to eventstream RPC connection establishment
+         */
+        class AWS_EVENTSTREAMRPC_API ClientConnectionOptions final
+        {
+          public:
+            ClientConnectionOptions();
+            ClientConnectionOptions(const ClientConnectionOptions &rhs) = default;
+            ClientConnectionOptions(ClientConnectionOptions &&rhs) = default;
+
+            ~ClientConnectionOptions() = default;
+
+            ClientConnectionOptions &operator=(const ClientConnectionOptions &rhs) = default;
+            ClientConnectionOptions &operator=(ClientConnectionOptions &&rhs) = default;
+
+            Crt::Io::ClientBootstrap *Bootstrap;
+            Crt::Io::SocketOptions SocketOptions;
+            Crt::Optional<Crt::Io::TlsConnectionOptions> TlsOptions;
+            Crt::String HostName;
+            uint16_t Port;
+        };
+
+        class AWS_EVENTSTREAMRPC_API ConnectionLifecycleHandler
+        {
+          public:
+            /**
+             * This callback is only invoked upon receiving a CONNECT_ACK with the
+             * CONNECTION_ACCEPTED flag set by the server. Therefore, once this callback
+             * is invoked, the `ClientConnection` is ready to be used for sending messages.
+             */
+            virtual void OnConnectCallback();
+            /**
+             * Invoked upon connection shutdown. `errorCode` will specify
+             * shutdown reason. A graceful connection close will set `errorCode` to
+             * `AWS_ERROR_SUCCESS` or 0.
+             */
+            virtual void OnDisconnectCallback(int errorCode);
+            /**
+             * Invoked upon receiving an error. Use the return value to determine
+             * whether or not to force the connection to close. Keep in mind that once
+             * closed, the `ClientConnection` can no longer send messages.
+             */
+            virtual bool OnErrorCallback(int errorCode);
+            /**
+             * Invoked upon receiving a ping from the server. The `headers` and `payload`
+             * refer to what is contained in the ping message.
+             */
+            virtual void OnPingCallback(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload);
+        };
+
+        class AWS_EVENTSTREAMRPC_API ClientContinuationHandler
+        {
+          public:
+            /**
+             * Invoked when a message is received on this continuation.
+             */
+            virtual void OnContinuationMessage(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags) = 0;
+            /**
+             * Invoked when the continuation is closed.
+             *
+             * Once the continuation is closed, no more messages may be sent or received.
+             * The continuation is closed when a message is sent or received with
+             * the TERMINATE_STREAM flag, or when the connection shuts down.
+             */
+            virtual void OnContinuationClosed() = 0;
+        };
+
+        enum EventStreamErrors
+        {
+            /* If error messages are added to `aws_event_stream_errors`, this will need to be updated. */
+            AWS_ERROR_EVENT_STREAM_RPC_UNKNOWN_PROTOCOL_MESSAGE = AWS_ERROR_EVENT_STREAM_RPC_STREAM_NOT_ACTIVATED + 1,
+            AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA,
+            AWS_ERROR_EVENT_STREAM_RPC_UNSUPPORTED_CONTENT_TYPE,
+            AWS_ERROR_EVENT_STREAM_RPC_STREAM_CLOSED_ERROR
+        };
+
+        class AWS_EVENTSTREAMRPC_API ClientConnection final
+        {
+          public:
+            ClientConnection(Crt::Allocator *allocator) noexcept;
+            ~ClientConnection() noexcept;
+            ClientConnection(const ClientConnection &) = delete;
+            ClientConnection(ClientConnection &&) = delete;
+            ClientConnection &operator=(const ClientConnection &) = delete;
+            ClientConnection &operator=(ClientConnection &&) = delete;
+
+            bool Connect(
+                const ClientConnectionOptions &connectionOptions,
+                ConnectionLifecycleHandler *connectionLifecycleHandler,
+                ConnectMessageAmender connectMessageAmender) noexcept;
+
+            void SendPing(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+            void SendPingResponse(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+            ClientContinuation NewStream(ClientContinuationHandler *clientContinuationHandler) noexcept;
+
+            void Close() noexcept;
+            void Close(int errorCode) noexcept;
+
+            /**
+             * @return true if the instance is in a valid state, false otherwise.
+             */
+            operator bool() const noexcept;
+            /**
+             * @return the value of the last aws error encountered by operations on this instance.
+             */
+            int LastError() const noexcept;
+
+          private:
+            friend class ClientContinuation;
+            enum ClientState
+            {
+                DISCONNECTED = 1,
+                CONNECTING_TO_SOCKET,
+                WAITING_FOR_CONNECT_ACK,
+                CONNECTED,
+                DISCONNECTING,
+            };
+            Crt::Allocator *m_allocator;
+            struct aws_event_stream_rpc_client_connection *m_underlyingConnection;
+            ClientState m_clientState;
+            ConnectionLifecycleHandler *m_lifecycleHandler;
+            ConnectMessageAmender m_connectMessageAmender;
+            static void s_customDeleter(ClientConnection *connection) noexcept;
+            void SendProtocolMessage(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+            static void s_onConnectionShutdown(
+                struct aws_event_stream_rpc_client_connection *connection,
+                int errorCode,
+                void *userData) noexcept;
+            static void s_onConnectionSetup(
+                struct aws_event_stream_rpc_client_connection *connection,
+                int errorCode,
+                void *userData) noexcept;
+            static void s_onProtocolMessage(
+                struct aws_event_stream_rpc_client_connection *connection,
+                const struct aws_event_stream_rpc_message_args *messageArgs,
+                void *userData) noexcept;
+
+            static void s_protocolMessageCallback(int errorCode, void *userData) noexcept;
+            static void s_sendProtocolMessage(
+                ClientConnection *connection,
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+            static void s_sendPing(
+                ClientConnection *connection,
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+            static void s_sendPingResponse(
+                ClientConnection *connection,
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+        };
+
+        class AWS_EVENTSTREAMRPC_API ClientContinuation final
+        {
+          public:
+            ClientContinuation(
+                ClientConnection *connection,
+                ClientContinuationHandler *handler,
+                Crt::Allocator *allocator) noexcept;
+            ~ClientContinuation() noexcept;
+            void Activate(
+                const Crt::String &operation,
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+            bool IsClosed() noexcept;
+            void SendMessage(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+          private:
+            Crt::Allocator *m_allocator;
+            ClientContinuationHandler *m_handler;
+            struct aws_event_stream_rpc_client_continuation_token *m_continuationToken;
+            static void s_onContinuationMessage(
+                struct aws_event_stream_rpc_client_continuation_token *continuationToken,
+                const struct aws_event_stream_rpc_message_args *messageArgs,
+                void *userData) noexcept;
+            static void s_onContinuationClosed(
+                struct aws_event_stream_rpc_client_continuation_token *continuationToken,
+                void *userData) noexcept;
+        };
+
+        class AWS_EVENTSTREAMRPC_API AbstractShapeBase
+        {
+          public:
+            static void s_customDeleter(AbstractShapeBase *shape) noexcept;
+          private:
+            Crt::Allocator *m_allocator;
+        };
+
+        class AWS_EVENTSTREAMRPC_API OperationResponse : AbstractShapeBase
+        {
+          public:
+            bool IsStreaming();
+        };
+
+        class AWS_EVENTSTREAMRPC_API OperationError : AbstractShapeBase
+        {
+          public:
+            OperationError() noexcept;
+            OperationError(int errorCode) noexcept;
+            const Crt::Optional<int>& GetErrorCode() const noexcept;
+            void SetErrorCode(int errorCode) noexcept;
+            static void s_customDeleter(OperationError* shape) noexcept;
+          private:
+            Crt::Optional<int> m_errorCode;
+        };
+
+        /**
+         * Base class for all operation stream handlers.
+         * For operations with a streaming response (0+ messages that may arrive
+         * after the initial response).
+         */
+        class AWS_EVENTSTREAMRPC_API StreamResponseHandler
+        {
+          public:
+            /**
+             * Invoked when a message is received on this continuation.
+             */
+            virtual void OnStreamEvent(Crt::ScopedResource<OperationResponse> response);
+            /**
+             * Invoked when a message is received on this continuation but results in an error.
+             *
+             * This callback can return true so that the stream is closed afterwards.
+             */
+            virtual bool OnStreamError(Crt::ScopedResource<OperationError> error);
+            /**
+             * Invoked when stream is closed, so no more messages will be receivied.
+             */
+            virtual void OnStreamClosed();
+        };
+
+union AWS_EVENTSTREAMRPC_API ResponseResult
+{
+    ResponseResult() {}
+    ~ResponseResult() {}
+    Crt::ScopedResource<OperationResponse> response;
+    Crt::ScopedResource<OperationError> error;
+};
+
+enum AWS_EVENTSTREAMRPC_API ResponseType
+{
+    EXPECTED_RESPONSE,
+    ERROR_RESPONSE
+};
+
+struct TaggedResponse
+{
+    TaggedResponse() {}
+    TaggedResponse(TaggedResponse &&taggedResponse)
+    {
+        if (responseType == EXPECTED_RESPONSE)
+        {
+            responseResult.response = std::move(taggedResponse.responseResult.response);
+        }
+        else if (responseType == ERROR_RESPONSE)
+        {
+            responseResult.error = std::move(taggedResponse.responseResult.error);
+        }
+    }
+    ResponseType responseType;
+    ResponseResult responseResult;
+};
+
+        using ExpectedResponseFactory = std::function<Crt::ScopedResource<OperationResponse>(const Crt::StringView &payload)>;
+        using ErrorResponseFactory = std::function<Crt::ScopedResource<OperationError>(const Crt::StringView &payload)>;
+
+        class AWS_EVENTSTREAMRPC_API ClientOperation : private ClientContinuationHandler
+        {
+          public:
+            ClientOperation(ClientConnection &connection, StreamResponseHandler *streamHandler) noexcept;
+            std::future<void> Close(OnMessageFlushCallback onMessageFlushCallback = nullptr) noexcept;
+            //virtual bool IsStreaming() = 0;
+
+          protected:
+            void Activate(AbstractShapeBase *shape, OnMessageFlushCallback onMessageFlushCallback) noexcept;
+            void SendStreamEvent(AbstractShapeBase *shape, OnMessageFlushCallback onMessageFlushCallback) noexcept;
+            virtual const Crt::String &GetResponseName() = 0;
+            Crt::Map<Crt::String, ExpectedResponseFactory> m_SingleResponseNameToObject;
+            Crt::Map<Crt::String, ExpectedResponseFactory> m_StreamingResponseNameToObject;
+            Crt::Map<Crt::String, ErrorResponseFactory> m_ErrorNameToObject;
+
+          private:
+            int HandleData(const Crt::String &modelName, const Crt::Optional<Crt::ByteBuf> &payload);
+            int HandleError(const Crt::String &modelName, const Crt::Optional<Crt::ByteBuf> &payload, uint16_t messageFlags);
+            /**
+             * Invoked when a message is received on this continuation.
+             */
+            void OnContinuationMessage(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::Optional<Crt::ByteBuf> &payload,
+                MessageType messageType,
+                uint32_t messageFlags) override;
+            /**
+             * Invoked when the continuation is closed.
+             *
+             * Once the continuation is closed, no more messages may be sent or received.
+             * The continuation is closed when a message is sent or received with
+             * the TERMINATE_STREAM flag, or when the connection shuts down.
+             */
+            void OnContinuationClosed() override;
+
+            const EventStreamHeader *GetHeaderByName(
+                const Crt::List<EventStreamHeader> &headers,
+                const Crt::String &name) noexcept;
+            uint32_t m_messageCount;
+            Crt::Allocator* m_allocator;
+            StreamResponseHandler *m_streamHandler;
+            ClientContinuation m_clientContinuation;
+            std::promise<TaggedResponse> m_initialResponsePromise;
+            std::promise<void> m_closedPromise;
+        };
+    } // namespace Eventstreamrpc
+} // namespace Aws

--- a/eventstreamrpc/include/aws/eventstreamrpc/Exports.h
+++ b/eventstreamrpc/include/aws/eventstreamrpc/Exports.h
@@ -1,0 +1,20 @@
+#pragma once
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#if defined(AWS_EVENTSTREAMRPC_USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#    ifdef AWS_EVENTSTREAMRPC_USE_IMPORT_EXPORT
+#        ifdef AWS_EVENTSTREAMRPC_EXPORTS
+#            define AWS_EVENTSTREAMRPC_API __declspec(dllexport)
+#        else
+#            define AWS_EVENTSTREAMRPC_API __declspec(dllimport)
+#        endif /* AWS_EVENTSTREAMRPC_EXPORTS */
+#    else
+#        define AWS_EVENTSTREAMRPC_API
+#    endif /* AWS_EVENTSTREAMRPC_USE_IMPORT_EXPORT */
+
+#else /* defined (AWS_EVENTSTREAMRPC_USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */
+#    define AWS_EVENTSTREAMRPC_API
+#endif /* defined (AWS_EVENTSTREAMRPC__USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */

--- a/eventstreamrpc/source/EventStreamClient.cpp
+++ b/eventstreamrpc/source/EventStreamClient.cpp
@@ -1,0 +1,899 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/eventstreamrpc/EventStreamClient.h>
+
+#include <aws/crt/Api.h>
+#include <aws/crt/Config.h>
+#include <aws/crt/auth/Credentials.h>
+
+#include <algorithm>
+#include <iostream>
+
+#define EVENTSTREAM_VERSION_HEADER ":version"
+#define EVENTSTREAM_VERSION_STRING "0.1.0"
+#define CONTENT_TYPE_HEADER ":content-type"
+#define CONTENT_TYPE_APPLICATION_TEXT "text/plain"
+#define CONTENT_TYPE_APPLICATION_JSON "application/json"
+#define SERVICE_MODEL_TYPE_HEADER "service-model-type"
+
+namespace Aws
+{
+    namespace Eventstreamrpc
+    {
+        /* Because `std::function` cannot be typecasted to void *, we must contain it in a struct. */
+        struct OnMessageFlushCallbackContainer
+        {
+            explicit OnMessageFlushCallbackContainer(Crt::Allocator *allocator) : allocator(allocator) {}
+            Crt::Allocator *allocator;
+            OnMessageFlushCallback onMessageFlushCallback;
+        };
+
+        MessageAmendment::MessageAmendment(const Crt::ByteBuf &payload) noexcept : m_headers(), m_payload(payload) {}
+
+        MessageAmendment::MessageAmendment(const Crt::List<EventStreamHeader> &headers) noexcept
+            : m_headers(headers), m_payload()
+        {
+        }
+
+        MessageAmendment::MessageAmendment(Crt::List<EventStreamHeader> &&headers) noexcept
+            : m_headers(headers), m_payload()
+        {
+        }
+
+        MessageAmendment::MessageAmendment(
+            const Crt::List<EventStreamHeader> &headers,
+            Crt::Optional<Crt::ByteBuf> &payload) noexcept
+            : m_headers(headers), m_payload(payload)
+        {
+        }
+
+        Crt::List<EventStreamHeader> &MessageAmendment::GetHeaders() noexcept { return m_headers; }
+
+        const Crt::Optional<Crt::ByteBuf> &MessageAmendment::GetPayload() const noexcept { return m_payload; }
+
+        void MessageAmendment::SetPayload(const Crt::Optional<Crt::ByteBuf> &payload) noexcept { m_payload = payload; }
+
+        ClientConnectionOptions::ClientConnectionOptions()
+            : Bootstrap(), SocketOptions(), TlsOptions(), HostName(), Port(0)
+        {
+        }
+
+        class EventStreamCppToNativeCrtBuilder
+        {
+          private:
+            friend class ClientConnection;
+            friend class ClientContinuation;
+            static int s_fillNativeHeadersArray(
+                const Crt::List<EventStreamHeader> &headers,
+                struct aws_array_list *headersArray,
+                Crt::Allocator *m_allocator = Crt::g_allocator)
+            {
+                /* Check if the connection has expired before attempting to send. */
+                int errorCode = aws_event_stream_headers_list_init(headersArray, m_allocator);
+
+                if (!errorCode)
+                {
+                    /* Populate the array with the underlying handle of each EventStreamHeader. */
+                    for (auto &i : headers)
+                    {
+                        errorCode = aws_array_list_push_back(headersArray, i.GetUnderlyingHandle());
+
+                        if (errorCode)
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                return errorCode;
+            }
+        };
+
+        ClientConnection::ClientConnection(Crt::Allocator *allocator) noexcept : m_allocator(allocator) {}
+
+        ClientConnection::~ClientConnection() noexcept
+        {
+            if (m_underlyingConnection)
+            {
+                aws_event_stream_rpc_client_connection_release(m_underlyingConnection);
+                m_underlyingConnection = nullptr;
+            }
+        }
+
+        bool ConnectionLifecycleHandler::OnErrorCallback(int errorCode) { return true; }
+
+        void ConnectionLifecycleHandler::OnPingCallback(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload)
+        {
+            (void)headers;
+            (void)payload;
+        }
+
+        void ConnectionLifecycleHandler::OnConnectCallback() {}
+
+        void ConnectionLifecycleHandler::OnDisconnectCallback(int errorCode) { (void)errorCode; }
+
+        bool ClientConnection::Connect(
+            const ClientConnectionOptions &connectionOptions,
+            ConnectionLifecycleHandler *connectionLifecycleHandler,
+            ConnectMessageAmender connectMessageAmender) noexcept
+        {
+            if (connectionLifecycleHandler == NULL)
+            {
+                return false;
+            }
+
+            struct aws_event_stream_rpc_client_connection_options connOptions;
+            AWS_ZERO_STRUCT(connOptions);
+            connOptions.host_name = connectionOptions.HostName.c_str();
+            connOptions.port = connectionOptions.Port;
+            connOptions.socket_options = &connectionOptions.SocketOptions.GetImpl();
+            connOptions.bootstrap = connectionOptions.Bootstrap->GetUnderlyingHandle();
+            connOptions.on_connection_setup = ClientConnection::s_onConnectionSetup;
+            connOptions.on_connection_protocol_message = ClientConnection::s_onProtocolMessage;
+            connOptions.on_connection_shutdown = ClientConnection::s_onConnectionShutdown;
+            connOptions.user_data = reinterpret_cast<void *>(this);
+            m_lifecycleHandler = connectionLifecycleHandler;
+            m_connectMessageAmender = connectMessageAmender;
+
+            if (connectionOptions.TlsOptions.has_value())
+            {
+                connOptions.tls_options = connectionOptions.TlsOptions->GetUnderlyingHandle();
+            }
+
+            if (aws_event_stream_rpc_client_connection_connect(m_allocator, &connOptions))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        void ClientConnection::SendPing(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            s_sendPing(this, headers, payload, onMessageFlushCallback);
+        }
+
+        void ClientConnection::SendPingResponse(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            s_sendPingResponse(this, headers, payload, onMessageFlushCallback);
+        }
+
+        void ClientConnection::s_sendPing(
+            ClientConnection *connection,
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            s_sendProtocolMessage(
+                connection, headers, payload, AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PING, 0, onMessageFlushCallback);
+        }
+
+        void ClientConnection::s_sendPingResponse(
+            ClientConnection *connection,
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            s_sendProtocolMessage(
+                connection,
+                headers,
+                payload,
+                AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PING_RESPONSE,
+                0,
+                onMessageFlushCallback);
+        }
+
+        void ClientConnection::SendProtocolMessage(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            MessageType messageType,
+            uint32_t messageFlags,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            s_sendProtocolMessage(this, headers, payload, messageType, messageFlags, onMessageFlushCallback);
+        }
+
+        void ClientConnection::s_protocolMessageCallback(int errorCode, void *userData) noexcept
+        {
+            auto *callbackData = static_cast<OnMessageFlushCallbackContainer *>(userData);
+
+            /* Call the user-provided callback. */
+            if (callbackData->onMessageFlushCallback)
+            {
+                callbackData->onMessageFlushCallback(errorCode);
+            }
+
+            Crt::Delete(callbackData, callbackData->allocator);
+        }
+
+        void ClientConnection::s_sendProtocolMessage(
+            ClientConnection *connection,
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            MessageType messageType,
+            uint32_t messageFlags,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            /* Check if the connection has expired before attempting to send. */
+            if (connection)
+            {
+                struct aws_array_list headersArray;
+                AWS_ZERO_STRUCT(headersArray);
+                OnMessageFlushCallbackContainer *callbackContainer = nullptr;
+                int errorCode = EventStreamCppToNativeCrtBuilder::s_fillNativeHeadersArray(
+                    headers, &headersArray, connection->m_allocator);
+
+                if (!errorCode)
+                {
+                    struct aws_event_stream_rpc_message_args msg_args;
+                    msg_args.headers = (struct aws_event_stream_header_value_pair *)headersArray.data;
+                    msg_args.headers_count = headers.size();
+                    msg_args.payload = payload.has_value() ? (aws_byte_buf *)(&(payload.value())) : nullptr;
+                    msg_args.message_type = messageType;
+                    msg_args.message_flags = messageFlags;
+
+                    /* This heap allocation is necessary so that the callback can still be invoked after this function
+                     * returns. */
+                    callbackContainer =
+                        Crt::New<OnMessageFlushCallbackContainer>(connection->m_allocator, connection->m_allocator);
+                    callbackContainer->onMessageFlushCallback = onMessageFlushCallback;
+
+                    errorCode = aws_event_stream_rpc_client_connection_send_protocol_message(
+                        connection->m_underlyingConnection,
+                        &msg_args,
+                        s_protocolMessageCallback,
+                        reinterpret_cast<void *>(callbackContainer));
+                }
+
+                /* Cleanup. */
+                if (errorCode)
+                {
+                    onMessageFlushCallback(errorCode);
+                    Crt::Delete(callbackContainer, connection->m_allocator);
+                }
+
+                if (aws_array_list_is_valid(&headersArray))
+                {
+                    aws_array_list_clean_up(&headersArray);
+                }
+            }
+        }
+
+        void ClientConnection::Close() noexcept
+        {
+            aws_event_stream_rpc_client_connection_close(this->m_underlyingConnection, AWS_OP_SUCCESS);
+            this->m_clientState = DISCONNECTED;
+        }
+
+        void ClientConnection::Close(int errorCode) noexcept
+        {
+            aws_event_stream_rpc_client_connection_close(this->m_underlyingConnection, errorCode);
+            this->m_clientState = DISCONNECTED;
+        }
+
+        EventStreamHeader::EventStreamHeader(const struct aws_event_stream_header_value_pair &header)
+            : m_underlyingHandle(header)
+        {
+        }
+
+        EventStreamHeader::EventStreamHeader(
+            const Crt::String &name,
+            const Crt::String &value,
+            Crt::Allocator *allocator) noexcept
+            : m_allocator(allocator)
+        {
+            m_underlyingHandle.header_name_len = (uint8_t)name.length();
+            (void)strncpy(m_underlyingHandle.header_name, name.c_str(), std::min((int)name.length(), INT8_MAX));
+            m_underlyingHandle.header_value_type = AWS_EVENT_STREAM_HEADER_STRING;
+            m_valueByteBuf = Crt::ByteBufNewCopy(allocator, (uint8_t *)value.c_str(), value.length());
+            m_underlyingHandle.header_value.variable_len_val = m_valueByteBuf.buffer;
+            m_underlyingHandle.header_value_len = (uint16_t)m_valueByteBuf.len;
+        }
+
+        EventStreamHeader::~EventStreamHeader() { Crt::ByteBufDelete(m_valueByteBuf); }
+
+        EventStreamHeader::EventStreamHeader(const EventStreamHeader &lhs) noexcept
+            : m_allocator(lhs.m_allocator),
+              m_valueByteBuf(
+                  Crt::ByteBufNewCopy(lhs.m_valueByteBuf.allocator, lhs.m_valueByteBuf.buffer, lhs.m_valueByteBuf.len)),
+              m_underlyingHandle(lhs.m_underlyingHandle)
+        {
+            m_underlyingHandle.header_value.variable_len_val = m_valueByteBuf.buffer;
+            m_underlyingHandle.header_value_len = m_valueByteBuf.len;
+        }
+
+        EventStreamHeader::EventStreamHeader(EventStreamHeader &&rhs) noexcept
+            : m_allocator(rhs.m_allocator), m_valueByteBuf(rhs.m_valueByteBuf),
+              m_underlyingHandle(rhs.m_underlyingHandle)
+        {
+            rhs.m_valueByteBuf.allocator = NULL;
+            rhs.m_valueByteBuf.buffer = NULL;
+        }
+
+        const struct aws_event_stream_header_value_pair *EventStreamHeader::GetUnderlyingHandle() const
+        {
+            return &m_underlyingHandle;
+        }
+
+        Crt::String EventStreamHeader::GetHeaderName() const noexcept
+        {
+            return Crt::String(m_underlyingHandle.header_name, m_underlyingHandle.header_name_len);
+        }
+
+        bool EventStreamHeader::GetValueAsString(Crt::String &value) const noexcept
+        {
+            if(m_underlyingHandle.header_value_type != AWS_EVENT_STREAM_HEADER_STRING)
+            {
+                return false;
+            }
+            Crt::StringView viewFromHere = Crt::ByteCursorToStringView(Crt::ByteCursorFromByteBuf(m_valueByteBuf));
+            value = {viewFromHere.begin(), viewFromHere.end()};
+        
+            return true;
+        }
+
+        ClientContinuation ClientConnection::NewStream(ClientContinuationHandler *clientContinuationHandler) noexcept
+        {
+            return ClientContinuation(this, clientContinuationHandler, m_allocator);
+        }
+
+        void ClientConnection::s_onConnectionSetup(
+            struct aws_event_stream_rpc_client_connection *connection,
+            int errorCode,
+            void *userData) noexcept
+        {
+            /* The `userData` pointer is used to pass `this` of a `ClientConnection` object. */
+            auto *thisConnection = static_cast<ClientConnection *>(userData);
+
+            if (!errorCode)
+            {
+                thisConnection->m_underlyingConnection = connection;
+                MessageAmendment messageAmendment;
+                auto &messageAmendmentHeaders = messageAmendment.GetHeaders();
+
+                if (thisConnection->m_connectMessageAmender)
+                {
+                    MessageAmendment &connectAmendment = thisConnection->m_connectMessageAmender();
+                    auto &amenderHeaderList = connectAmendment.GetHeaders();
+                    /* The version header is necessary for establishing the connection. */
+                    messageAmendment.AddHeader(EventStreamHeader(
+                        Crt::String(EVENTSTREAM_VERSION_HEADER),
+                        Crt::String(EVENTSTREAM_VERSION_STRING),
+                        thisConnection->m_allocator));
+                    /* Note that we are prepending headers from the user-provided amender. */
+                    messageAmendmentHeaders.splice(messageAmendmentHeaders.end(), amenderHeaderList);
+                    messageAmendment.SetPayload(connectAmendment.GetPayload());
+                }
+
+                /* Send a CONNECT packet to the server. */
+                s_sendProtocolMessage(
+                    thisConnection,
+                    messageAmendment.GetHeaders(),
+                    messageAmendment.GetPayload(),
+                    AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT,
+                    0,
+                    nullptr);
+                thisConnection->m_clientState = WAITING_FOR_CONNECT_ACK;
+                return;
+
+                /* Release if we're unable to allocate the connection's containing object. */
+                aws_event_stream_rpc_client_connection_release(connection);
+                errorCode = aws_last_error();
+            }
+
+            thisConnection->m_clientState = DISCONNECTED;
+
+            if (thisConnection->m_lifecycleHandler->OnErrorCallback(errorCode))
+            {
+                thisConnection->Close(errorCode);
+            }
+        }
+
+        void MessageAmendment::AddHeader(EventStreamHeader &&header) noexcept { m_headers.push_back(header); }
+
+        void ClientConnection::s_onConnectionShutdown(
+            struct aws_event_stream_rpc_client_connection *connection,
+            int errorCode,
+            void *userData) noexcept
+        {
+            (void)connection;
+            /* The `userData` pointer is used to pass `this` of a `ClientConnection` object. */
+            auto *thisConnection = static_cast<ClientConnection *>(userData);
+
+            thisConnection->m_lifecycleHandler->OnDisconnectCallback(errorCode);
+        }
+
+        void ClientConnection::s_onProtocolMessage(
+            struct aws_event_stream_rpc_client_connection *connection,
+            const struct aws_event_stream_rpc_message_args *messageArgs,
+            void *userData) noexcept
+        {
+            AWS_FATAL_ASSERT(messageArgs);
+            (void)connection;
+
+            /* The `userData` pointer is used to pass `this` of a `ClientConnection` object. */
+            auto *thisConnection = static_cast<ClientConnection *>(userData);
+            Crt::List<EventStreamHeader> pingHeaders;
+
+            switch (messageArgs->message_type)
+            {
+                case AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_CONNECT_ACK:
+
+                    if (thisConnection->m_clientState == WAITING_FOR_CONNECT_ACK)
+                    {
+                        if (messageArgs->message_flags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_CONNECTION_ACCEPTED)
+                        {
+                            thisConnection->m_clientState = CONNECTED;
+                            thisConnection->m_lifecycleHandler->OnConnectCallback();
+                        }
+                        else
+                        {
+                            thisConnection->m_clientState = DISCONNECTING;
+                            thisConnection->Close(AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED);
+                        }
+                    }
+
+                    break;
+
+                case AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PING:
+
+                    for (size_t i = 0; i < messageArgs->headers_count; ++i)
+                    {
+                        pingHeaders.push_back(EventStreamHeader(messageArgs->headers[i]));
+                    }
+
+                    if (messageArgs->payload)
+                    {
+                        thisConnection->m_lifecycleHandler->OnPingCallback(pingHeaders, *messageArgs->payload);
+                    }
+                    else
+                    {
+                        thisConnection->m_lifecycleHandler->OnPingCallback(pingHeaders, Crt::Optional<Crt::ByteBuf>());
+                    }
+
+                    break;
+
+                case AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PING_RESPONSE:
+                    return;
+                    break;
+
+                case AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_PROTOCOL_ERROR:
+                case AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_INTERNAL_ERROR:
+
+                    if (thisConnection->m_lifecycleHandler->OnErrorCallback(AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR))
+                    {
+                        thisConnection->Close(AWS_ERROR_EVENT_STREAM_RPC_PROTOCOL_ERROR);
+                    }
+
+                    break;
+
+                default:
+                    return;
+
+                    if (thisConnection->m_lifecycleHandler->OnErrorCallback(
+                            AWS_ERROR_EVENT_STREAM_RPC_UNKNOWN_PROTOCOL_MESSAGE))
+                    {
+                        thisConnection->Close(AWS_ERROR_EVENT_STREAM_RPC_UNKNOWN_PROTOCOL_MESSAGE);
+                    }
+
+                    break;
+            }
+        }
+
+        void AbstractShapeBase::s_customDeleter(AbstractShapeBase *shape) noexcept
+        {
+            Crt::Delete<AbstractShapeBase>(shape, shape->m_allocator);
+        }
+
+        ClientContinuation::ClientContinuation(
+            ClientConnection *connection,
+            ClientContinuationHandler *handler,
+            Crt::Allocator *allocator) noexcept
+            : m_allocator(allocator), m_handler(handler)
+        {
+            struct aws_event_stream_rpc_client_stream_continuation_options options;
+            options.on_continuation = ClientContinuation::s_onContinuationMessage;
+            options.on_continuation_closed = ClientContinuation::s_onContinuationClosed;
+            options.user_data = reinterpret_cast<void *>(connection);
+
+            m_continuationToken =
+                aws_event_stream_rpc_client_connection_new_stream(connection->m_underlyingConnection, &options);
+        }
+
+        void ClientContinuation::s_onContinuationMessage(
+            struct aws_event_stream_rpc_client_continuation_token *continuationToken,
+            const struct aws_event_stream_rpc_message_args *messageArgs,
+            void *userData) noexcept
+        {
+            (void)continuationToken;
+            /* The `userData` pointer is used to pass `this` of a `ClientContinuation` object. */
+            auto *thisContinuationToken = static_cast<ClientContinuation *>(userData);
+
+            Crt::List<EventStreamHeader> continuationMessageHeaders;
+            for (size_t i = 0; i < messageArgs->headers_count; ++i)
+            {
+                continuationMessageHeaders.push_back(EventStreamHeader(messageArgs->headers[i]));
+            }
+
+            Crt::Optional<Crt::ByteBuf> payload;
+
+            if (messageArgs->payload)
+            {
+                payload = Crt::Optional<Crt::ByteBuf>(*messageArgs->payload);
+            }
+            else
+            {
+                payload = Crt::Optional<Crt::ByteBuf>();
+            }
+
+            thisContinuationToken->m_handler->OnContinuationMessage(
+                continuationMessageHeaders, payload, messageArgs->message_type, messageArgs->message_flags);
+        }
+
+        void ClientContinuation::s_onContinuationClosed(
+            struct aws_event_stream_rpc_client_continuation_token *continuationToken,
+            void *userData) noexcept
+        {
+            (void)continuationToken;
+            /* The `userData` pointer is used to pass `this` of a `ClientContinuation` object. */
+            auto *thisContinuationToken = static_cast<ClientContinuation *>(userData);
+
+            thisContinuationToken->m_handler->OnContinuationClosed();
+        }
+
+        void ClientContinuation::Activate(
+            const Crt::String &operationName,
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            MessageType messageType,
+            uint32_t messageFlags,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            struct aws_array_list headersArray;
+            OnMessageFlushCallbackContainer *callbackContainer = nullptr;
+            int errorCode = AWS_OP_SUCCESS;
+
+            if (m_continuationToken == nullptr)
+            {
+                errorCode = AWS_ERROR_INVALID_STATE;
+            }
+
+            if (!errorCode)
+            {
+                AWS_ZERO_STRUCT(headersArray);
+                errorCode =
+                    EventStreamCppToNativeCrtBuilder::s_fillNativeHeadersArray(headers, &headersArray, m_allocator);
+            }
+
+            if (!errorCode)
+            {
+                struct aws_event_stream_rpc_message_args msg_args;
+                msg_args.headers = (struct aws_event_stream_header_value_pair *)headersArray.data;
+                msg_args.headers_count = headers.size();
+                msg_args.payload = payload.has_value() ? (aws_byte_buf *)(&(payload.value())) : nullptr;
+                msg_args.message_type = messageType;
+                msg_args.message_flags = messageFlags;
+
+                /* This heap allocation is necessary so that the callback can still be invoked after this function
+                 * returns. */
+                callbackContainer = Crt::New<OnMessageFlushCallbackContainer>(m_allocator, m_allocator);
+                callbackContainer->onMessageFlushCallback = onMessageFlushCallback;
+                errorCode = aws_event_stream_rpc_client_continuation_activate(
+                    m_continuationToken,
+                    Crt::ByteCursorFromCString(operationName.c_str()),
+                    &msg_args,
+                    ClientConnection::s_protocolMessageCallback,
+                    reinterpret_cast<void *>(callbackContainer));
+            }
+
+            /* Cleanup. */
+            if (errorCode)
+            {
+                onMessageFlushCallback(errorCode);
+                Crt::Delete(callbackContainer, m_allocator);
+            }
+
+            if (aws_array_list_is_valid(&headersArray))
+            {
+                aws_array_list_clean_up(&headersArray);
+            }
+        }
+
+        void ClientContinuation::SendMessage(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            MessageType messageType,
+            uint32_t messageFlags,
+            OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            struct aws_array_list headersArray;
+            OnMessageFlushCallbackContainer *callbackContainer = nullptr;
+            int errorCode = AWS_OP_SUCCESS;
+
+            if (m_continuationToken == nullptr)
+            {
+                errorCode = AWS_ERROR_INVALID_STATE;
+            }
+
+            if (!errorCode)
+            {
+                AWS_ZERO_STRUCT(headersArray);
+                errorCode =
+                    EventStreamCppToNativeCrtBuilder::s_fillNativeHeadersArray(headers, &headersArray, m_allocator);
+            }
+
+            if (!errorCode)
+            {
+                struct aws_event_stream_rpc_message_args msg_args;
+                msg_args.headers = (struct aws_event_stream_header_value_pair *)headersArray.data;
+                msg_args.headers_count = headers.size();
+                msg_args.payload = payload.has_value() ? (aws_byte_buf *)(&(payload.value())) : nullptr;
+                msg_args.message_type = messageType;
+                msg_args.message_flags = messageFlags;
+
+                /* This heap allocation is necessary so that the callback can still be invoked after this function
+                 * returns. */
+                callbackContainer = Crt::New<OnMessageFlushCallbackContainer>(m_allocator, m_allocator);
+                callbackContainer->onMessageFlushCallback = onMessageFlushCallback;
+
+                errorCode = aws_event_stream_rpc_client_continuation_send_message(
+                    m_continuationToken,
+                    &msg_args,
+                    ClientConnection::s_protocolMessageCallback,
+                    reinterpret_cast<void *>(callbackContainer));
+            }
+
+            /* Cleanup. */
+            if (errorCode)
+            {
+                onMessageFlushCallback(errorCode);
+                Crt::Delete(callbackContainer, m_allocator);
+            }
+
+            if (aws_array_list_is_valid(&headersArray))
+            {
+                aws_array_list_clean_up(&headersArray);
+            }
+        }
+
+        bool ClientContinuation::IsClosed() noexcept
+        {
+            return aws_event_stream_rpc_client_continuation_is_closed(m_continuationToken);
+        }
+
+        OperationError::OperationError() noexcept : m_errorCode(0) {}
+        OperationError::OperationError(int errorCode) noexcept : m_errorCode(errorCode) {}
+
+        ClientOperation::ClientOperation(ClientConnection &connection, StreamResponseHandler *streamHandler) noexcept
+            : m_SingleResponseNameToObject({}), m_StreamingResponseNameToObject({}), m_ErrorNameToObject({}), 
+            m_streamHandler(streamHandler), m_clientContinuation(connection.NewStream(this))
+        {
+        }
+
+        const EventStreamHeader *ClientOperation::GetHeaderByName(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::String &name) noexcept
+        {
+            for (auto it = headers.begin(); it != headers.end(); ++it)
+            {
+                if (name == it->GetHeaderName())
+                {
+                    return &(*it);
+                }
+            }
+            return nullptr;
+        }
+
+        int ClientOperation::HandleData(const Crt::String &modelName, const Crt::Optional<Crt::ByteBuf> &payload)
+        {
+            const Crt::Map<Crt::String, ExpectedResponseFactory> *mapToUse;
+
+            /* Responses after the first message don't necessarily have the same shape as the first. */
+            if (m_messageCount == 1)
+            {
+                mapToUse = &m_SingleResponseNameToObject;
+            }
+            else
+            {
+                mapToUse = &m_StreamingResponseNameToObject;
+            }
+
+            auto got = mapToUse->find(this->GetResponseName());
+            if (got == mapToUse->end())
+            {
+                return AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+            }
+            else
+            {
+                if (modelName != got->first)
+                {
+                    /* TODO: Log an error */
+                    return AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+                }
+                Crt::StringView payloadStringView;
+                if (payload.has_value())
+                {
+                    payloadStringView = Crt::ByteCursorToStringView(Crt::ByteCursorFromByteBuf(payload.value()));
+                }
+                /* The value of this hashmap contains the function that generates the response object from the
+                 * payload. */
+                Crt::ScopedResource<OperationResponse> response = got->second(payloadStringView);
+                if (m_messageCount == 1)
+                {
+                    TaggedResponse taggedResponse;
+                    taggedResponse.responseType = EXPECTED_RESPONSE;
+                    taggedResponse.responseResult.response = std::move(response);
+                    m_initialResponsePromise.set_value(std::move(taggedResponse));
+                }
+                else
+                {
+                    m_streamHandler->OnStreamEvent(std::move(response));
+                }
+            }
+            return AWS_OP_SUCCESS;
+        }
+
+        int ClientOperation::HandleError(
+            const Crt::String &modelName,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            uint16_t messageFlags)
+        {
+            bool streamAlreadyTerminated = messageFlags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM;
+            auto *mapToUse = &m_ErrorNameToObject;
+            auto got = mapToUse->find(this->GetResponseName());
+            if (got == mapToUse->end())
+            {
+                return AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+            }
+            else
+            {
+                if (modelName != got->first)
+                {
+                    /* TODO: Log an error */
+                    return AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+                }
+
+                Crt::StringView payloadStringView;
+                if (payload.has_value())
+                {
+                    payloadStringView = Crt::ByteCursorToStringView(Crt::ByteCursorFromByteBuf(payload.value()));
+                }
+
+                /* The value of this hashmap contains the function that generates the error from the
+                 * payload. */
+                Crt::ScopedResource<OperationError> error = got->second(payloadStringView);
+                TaggedResponse taggedResponse;
+                taggedResponse.responseType = ERROR_RESPONSE;
+                taggedResponse.responseResult.error = std::move(error);
+
+                if (m_messageCount == 1)
+                {
+                    m_initialResponsePromise.set_value(std::move(taggedResponse));
+                    /* Close the stream unless the server already closed it for us. This condition is checked
+                     * so that TERMINATE_STREAM messages aren't resent by the client. */
+                    if (!streamAlreadyTerminated)
+                    {
+                        Close();
+                    }
+                }
+                else
+                {
+                    if (!streamAlreadyTerminated && m_streamHandler->OnStreamError(std::move(error)))
+                    {
+                        Close();
+                    }
+                }
+
+                m_streamHandler->OnStreamError(std::move(error));
+            }
+            return AWS_OP_SUCCESS;
+        }
+
+        void ClientOperation::OnContinuationMessage(
+            const Crt::List<EventStreamHeader> &headers,
+            const Crt::Optional<Crt::ByteBuf> &payload,
+            MessageType messageType,
+            uint32_t messageFlags)
+        {
+            int errorCode = AWS_OP_SUCCESS;
+            const EventStreamHeader *modelHeader = nullptr;
+            const EventStreamHeader *contentHeader = nullptr;
+
+            m_messageCount += 1;
+
+            modelHeader = GetHeaderByName(headers, Crt::String(SERVICE_MODEL_TYPE_HEADER));
+            if (modelHeader == nullptr)
+            {
+                /* TERMINATE_STREAM message can be empty. */
+                if (messageFlags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM)
+                    return;
+                /* Missing required service model type header. */
+                errorCode = AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+            }
+
+            if (!errorCode)
+            {
+                Crt::String contentType;
+                contentHeader = GetHeaderByName(headers, Crt::String(CONTENT_TYPE_HEADER));
+                if (contentHeader == nullptr)
+                {
+                    /* Missing required content type header. */
+                    errorCode = AWS_ERROR_EVENT_STREAM_RPC_UNMAPPED_DATA;
+                }
+                else if (contentHeader->GetValueAsString(contentType) && contentType != CONTENT_TYPE_APPLICATION_JSON)
+                {
+                    errorCode = AWS_ERROR_EVENT_STREAM_RPC_UNSUPPORTED_CONTENT_TYPE;
+                }
+            }
+
+            if (!errorCode)
+            {
+                Crt::String modelName;
+                modelHeader->GetValueAsString(modelName);
+                if (messageType == AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_APPLICATION_MESSAGE)
+                {
+                    errorCode = HandleData(modelName, payload);
+                }
+                else
+                {
+                    errorCode = HandleError(modelName, payload, messageFlags);
+                }
+            }
+
+            /* Cleanup. */
+            if (errorCode)
+            {
+                /* Generate an error code here. */
+                Crt::ScopedResource<OperationError> operationError(
+                    Crt::New<OperationError>(m_allocator, errorCode), OperationError::s_customDeleter);
+                if (m_streamHandler->OnStreamError(std::move(operationError)))
+                {
+                    this->Close();
+                }
+            }
+        }
+
+        void ClientOperation::OnContinuationClosed()
+        {
+            auto future = m_initialResponsePromise.get_future();
+            /* Unfortunately, there's no better way in C++11 to check if a promise has been fulfilled. */
+            if(future.valid() && future.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+            {
+                Crt::ScopedResource<OperationError> operationError(
+                    Crt::New<OperationError>(m_allocator, AWS_ERROR_EVENT_STREAM_RPC_STREAM_CLOSED_ERROR), OperationError::s_customDeleter);
+                TaggedResponse taggedResponse;
+                taggedResponse.responseType = ERROR_RESPONSE;
+                taggedResponse.responseResult.error = std::move(operationError);
+                m_initialResponsePromise.set_value(std::move(taggedResponse));
+            }
+
+            m_closedPromise.set_value();
+
+            if(m_streamHandler)
+            {
+                m_streamHandler->OnStreamClosed();
+            }
+        }
+
+        std::future<void> ClientOperation::Close(OnMessageFlushCallback onMessageFlushCallback) noexcept
+        {
+            m_clientContinuation.SendMessage(Crt::List<EventStreamHeader>(), Crt::Optional<Crt::ByteBuf>(), AWS_EVENT_STREAM_RPC_MESSAGE_TYPE_APPLICATION_MESSAGE, AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM, onMessageFlushCallback);
+            return m_closedPromise.get_future();
+        }
+
+        void OperationError::s_customDeleter(OperationError *shape) noexcept
+        {
+            AbstractShapeBase::s_customDeleter(shape);
+        }
+    } /* namespace Eventstreamrpc */
+} // namespace Aws

--- a/eventstreamrpc/tests/CMakeLists.txt
+++ b/eventstreamrpc/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(AwsTestHarness)
+enable_testing()
+include(CTest)
+
+file(GLOB TEST_SRC "*.cpp")
+file(GLOB TEST_HDRS "*.h")
+file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
+
+set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
+
+aws_use_package(aws-crt-cpp)
+aws_use_package(EventstreamRpc-cpp)
+
+if (UNIX AND NOT APPLE)
+    add_net_test_case(EventStreamConnect)
+    generate_cpp_test_driver(${TEST_BINARY_NAME})
+endif()

--- a/eventstreamrpc/tests/EventStreamClientTest.cpp
+++ b/eventstreamrpc/tests/EventStreamClientTest.cpp
@@ -1,0 +1,128 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/crt/Api.h>
+
+#include <aws/eventstreamrpc/EventStreamClient.h>
+
+#include <aws/testing/aws_test_harness.h>
+
+#include <iostream>
+#include <sstream>
+
+using namespace Aws::Eventstreamrpc;
+
+static int s_TestEventStreamConnect(struct aws_allocator *allocator, void *ctx);
+
+class TestLifecycleHandler : public ConnectionLifecycleHandler
+{
+  public:
+    TestLifecycleHandler()
+    {
+        semaphoreULock = std::unique_lock<std::mutex>(semaphoreLock);
+        isConnected = false;
+        lastErrorCode = AWS_OP_ERR;
+    }
+
+    void OnConnectCallback() override
+    {
+        std::lock_guard<std::mutex> lockGuard(semaphoreLock);
+
+        isConnected = true;
+
+        semaphore.notify_one();
+    }
+
+    void OnDisconnectCallback(int errorCode) override
+    {
+        std::lock_guard<std::mutex> lockGuard(semaphoreLock);
+
+        lastErrorCode = errorCode;
+
+        semaphore.notify_one();
+    }
+
+    void WaitOnCondition(std::function<bool(void)> condition) { semaphore.wait(semaphoreULock, condition); }
+
+  private:
+    friend int s_TestEventStreamConnect(struct aws_allocator *allocator, void *ctx);
+    std::condition_variable semaphore;
+    std::mutex semaphoreLock;
+    std::unique_lock<std::mutex> semaphoreULock;
+    int isConnected;
+    int lastErrorCode;
+};
+
+static int s_TestEventStreamConnect(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    {
+        Aws::Crt::ApiHandle apiHandle(allocator);
+        Aws::Crt::Io::TlsContextOptions tlsCtxOptions = Aws::Crt::Io::TlsContextOptions::InitDefaultClient();
+        Aws::Crt::Io::TlsContext tlsContext(tlsCtxOptions, Aws::Crt::Io::TlsMode::CLIENT, allocator);
+        ASSERT_TRUE(tlsContext);
+
+        Aws::Crt::Io::TlsConnectionOptions tlsConnectionOptions = tlsContext.NewConnectionOptions();
+        Aws::Crt::Io::SocketOptions socketOptions;
+        socketOptions.SetConnectTimeoutMs(1000);
+
+        Aws::Crt::Io::EventLoopGroup eventLoopGroup(0, allocator);
+        ASSERT_TRUE(eventLoopGroup);
+
+        Aws::Crt::Io::DefaultHostResolver defaultHostResolver(eventLoopGroup, 8, 30, allocator);
+        ASSERT_TRUE(defaultHostResolver);
+
+        Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, defaultHostResolver, allocator);
+        ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
+        MessageAmendment connectionAmendment;
+        auto messageAmender = [&](void) -> MessageAmendment & { return connectionAmendment; };
+
+        ClientConnectionOptions options;
+        options.Bootstrap = &clientBootstrap;
+        options.SocketOptions = socketOptions;
+        options.HostName = Aws::Crt::String("127.0.0.1");
+        options.Port = 8033;
+
+        ClientConnection connection(allocator);
+
+        /* Happy path case. */
+        {
+            TestLifecycleHandler lifecycleHandler;
+            connectionAmendment.AddHeader(EventStreamHeader(
+                Aws::Crt::String("client-name"), Aws::Crt::String("accepted.testy_mc_testerson"), allocator));
+            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
+            lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.isConnected; });
+            /* Test all protocol messages. */
+            connection.SendPing(Aws::Crt::List<EventStreamHeader>(), Aws::Crt::Optional<Aws::Crt::ByteBuf>(), nullptr);
+            connection.SendPingResponse(
+                Aws::Crt::List<EventStreamHeader>(), Aws::Crt::Optional<Aws::Crt::ByteBuf>(), nullptr);
+            /* Close connection gracefully. */
+            connection.Close();
+            lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.lastErrorCode == AWS_OP_SUCCESS; });
+        }
+
+        /* Empty amendment headers. */
+        {
+            TestLifecycleHandler lifecycleHandler;
+            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
+            lifecycleHandler.WaitOnCondition(
+                [&]() { return lifecycleHandler.lastErrorCode == AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED; });
+        }
+
+        /* Rejected client-name header. */
+        {
+            TestLifecycleHandler lifecycleHandler;
+            connectionAmendment.AddHeader(EventStreamHeader(
+                Aws::Crt::String("client-name"), Aws::Crt::String("rejected.testy_mc_testerson"), allocator));
+            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
+            lifecycleHandler.WaitOnCondition(
+                [&]() { return lifecycleHandler.lastErrorCode == AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED; });
+        }
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(EventStreamConnect, s_TestEventStreamConnect)

--- a/eventstreamrpc/tests/EventStreamClientTest.cpp
+++ b/eventstreamrpc/tests/EventStreamClientTest.cpp
@@ -85,19 +85,22 @@ static int s_TestEventStreamConnect(struct aws_allocator *allocator, void *ctx)
         options.HostName = Aws::Crt::String("127.0.0.1");
         options.Port = 8033;
 
-        ClientConnection connection(allocator);
-
         /* Happy path case. */
         {
             TestLifecycleHandler lifecycleHandler;
+            ClientConnection connection(lifecycleHandler, allocator);
             connectionAmendment.AddHeader(EventStreamHeader(
                 Aws::Crt::String("client-name"), Aws::Crt::String("accepted.testy_mc_testerson"), allocator));
-            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
+            auto future = connection.Connect(options, lifecycleHandler, messageAmender);
+            ASSERT_TRUE(future.get().baseStatus == EVENT_STREAM_RPC_SUCCESS);
             lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.isConnected; });
             /* Test all protocol messages. */
-            connection.SendPing(Aws::Crt::List<EventStreamHeader>(), Aws::Crt::Optional<Aws::Crt::ByteBuf>(), nullptr);
-            connection.SendPingResponse(
+            future = connection.SendPing(
                 Aws::Crt::List<EventStreamHeader>(), Aws::Crt::Optional<Aws::Crt::ByteBuf>(), nullptr);
+            ASSERT_TRUE(future.get().baseStatus == EVENT_STREAM_RPC_SUCCESS);
+            future = connection.SendPingResponse(
+                Aws::Crt::List<EventStreamHeader>(), Aws::Crt::Optional<Aws::Crt::ByteBuf>(), nullptr);
+            ASSERT_TRUE(future.get().baseStatus == EVENT_STREAM_RPC_SUCCESS);
             /* Close connection gracefully. */
             connection.Close();
             lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.lastErrorCode == AWS_OP_SUCCESS; });
@@ -106,19 +109,21 @@ static int s_TestEventStreamConnect(struct aws_allocator *allocator, void *ctx)
         /* Empty amendment headers. */
         {
             TestLifecycleHandler lifecycleHandler;
-            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
-            lifecycleHandler.WaitOnCondition(
-                [&]() { return lifecycleHandler.lastErrorCode == AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED; });
+            ClientConnection connection(lifecycleHandler, allocator);
+            auto future = connection.Connect(options, lifecycleHandler, messageAmender);
+            ASSERT_TRUE(future.get().baseStatus == EVENT_STREAM_RPC_CONNECTION_CLOSED_BEFORE_CONNACK);
+            lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.lastErrorCode == AWS_OP_SUCCESS; });
         }
 
         /* Rejected client-name header. */
         {
             TestLifecycleHandler lifecycleHandler;
+            ClientConnection connection(lifecycleHandler, allocator);
             connectionAmendment.AddHeader(EventStreamHeader(
                 Aws::Crt::String("client-name"), Aws::Crt::String("rejected.testy_mc_testerson"), allocator));
-            ASSERT_TRUE(connection.Connect(options, &lifecycleHandler, messageAmender));
-            lifecycleHandler.WaitOnCondition(
-                [&]() { return lifecycleHandler.lastErrorCode == AWS_ERROR_EVENT_STREAM_RPC_CONNECTION_CLOSED; });
+            auto future = connection.Connect(options, lifecycleHandler, messageAmender);
+            ASSERT_TRUE(future.get().baseStatus == EVENT_STREAM_RPC_CONNECTION_CLOSED_BEFORE_CONNACK);
+            lifecycleHandler.WaitOnCondition([&]() { return lifecycleHandler.lastErrorCode == AWS_OP_SUCCESS; });
         }
     }
 

--- a/ipc/CMakeLists.txt
+++ b/ipc/CMakeLists.txt
@@ -1,0 +1,124 @@
+cmake_minimum_required(VERSION 3.1)
+project(GreengrassIpc-cpp CXX)
+
+set(RUNTIME_DIRECTORY bin)
+
+if (UNIX AND NOT APPLE)
+    include(GNUInstallDirs)
+elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_LIBDIR "lib")
+
+    if (${CMAKE_INSTALL_LIBDIR} STREQUAL "lib64")
+        set(FIND_LIBRARY_USE_LIB64_PATHS true)
+    endif()
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_PREFIX_PATH}/${CMAKE_INSTALL_LIBDIR}/cmake")
+
+if (NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 11)
+endif()
+
+file(GLOB AWS_GREENGRASSIPC_HEADERS
+        "include/aws/ipc/*.h"
+)
+
+file(GLOB AWS_GREENGRASSIPC_SRC
+       "source/*.cpp"
+)
+
+file(GLOB AWS_GREENGRASSIPC_CPP_SRC
+        ${AWS_GREENGRASSIPC_SRC}
+)
+
+if (WIN32)
+    if (MSVC)
+        source_group("Header Files\\aws\\ipc\\" FILES ${AWS_GREENGRASSIPC_HEADERS})
+
+        source_group("Source Files" FILES ${AWS_GREENGRASSIPC_SRC})
+    endif ()
+endif()
+
+add_library(GreengrassIpc-cpp ${AWS_GREENGRASSIPC_CPP_SRC})
+target_link_libraries(GreengrassIpc-cpp EventstreamRpc-cpp)
+
+set_target_properties(GreengrassIpc-cpp PROPERTIES LINKER_LANGUAGE CXX)
+
+set(CMAKE_C_FLAGS_DEBUGOPT "")
+
+#set warnings
+if (MSVC)
+    target_compile_options(GreengrassIpc-cpp PRIVATE /W4 /WX)
+else ()
+    target_compile_options(GreengrassIpc-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
+endif ()
+
+if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
+    target_compile_definitions(GreengrassIpc-cpp PRIVATE "-DDEBUG_BUILD")
+endif ()
+
+if (BUILD_SHARED_LIBS)
+    target_compile_definitions(GreengrassIpc-cpp PUBLIC "-DAWS_GREENGRASSIPC_USE_IMPORT_EXPORT")
+    target_compile_definitions(GreengrassIpc-cpp PRIVATE "-DAWS_GREENGRASSIPC_EXPORTS")
+
+    install(TARGETS GreengrassIpc-cpp
+            EXPORT GreengrassIpc-cpp-targets
+            ARCHIVE
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT Development
+            LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            NAMELINK_SKIP
+            COMPONENT Runtime
+            RUNTIME
+            DESTINATION ${RUNTIME_DIRECTORY}
+            COMPONENT Runtime)
+
+    install(TARGETS GreengrassIpc-cpp
+            EXPORT GreengrassIpc-cpp-targets
+            LIBRARY
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            NAMELINK_ONLY
+            COMPONENT Development)
+else()
+    install(TARGETS GreengrassIpc-cpp
+            EXPORT GreengrassIpc-cpp-targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            COMPONENT Development)
+endif()
+
+target_include_directories(GreengrassIpc-cpp PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>)
+
+if (NOT IS_SUBDIRECTORY_INCLUDE)
+    aws_use_package(aws-crt-cpp)
+endif()
+
+
+target_link_libraries(GreengrassIpc-cpp ${DEP_AWS_LIBS})
+
+install(FILES ${AWS_GREENGRASSIPC_HEADERS} DESTINATION "include/aws/ipc/" COMPONENT Development)
+
+if (BUILD_SHARED_LIBS)
+    set(TARGET_DIR "shared")
+else()
+    set(TARGET_DIR "static")
+endif()
+
+install(EXPORT "GreengrassIpc-cpp-targets"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/GreengrassIpc-cpp/cmake/${TARGET_DIR}"
+        NAMESPACE AWS::
+        COMPONENT Development)
+
+configure_file("cmake/greengrassipc-cpp-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/greengrassipc-cpp-config.cmake"
+        @ONLY)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/greengrassipc-cpp-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/GreengrassIpc-cpp/cmake/"
+        COMPONENT Development)
+
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif()

--- a/ipc/cmake/greengrassipc-cpp-config.cmake
+++ b/ipc/cmake/greengrassipc-cpp-config.cmake
@@ -1,0 +1,9 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(aws-crt-cpp)
+
+if (BUILD_SHARED_LIBS)
+   include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)
+else()
+   include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
+endif()

--- a/ipc/include/aws/ipc/Exports.h
+++ b/ipc/include/aws/ipc/Exports.h
@@ -1,0 +1,20 @@
+#pragma once
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#if defined(AWS_GREENGRASSIPC_USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#    ifdef AWS_GREENGRASSIPC_USE_IMPORT_EXPORT
+#        ifdef AWS_GREENGRASSIPC_EXPORTS
+#            define AWS_GREENGRASSIPC_API __declspec(dllexport)
+#        else
+#            define AWS_GREENGRASSIPC_API __declspec(dllimport)
+#        endif /* AWS_GREENGRASSIPC_EXPORTS */
+#    else
+#        define AWS_GREENGRASSIPC_API
+#    endif /* AWS_GREENGRASSIPC_USE_IMPORT_EXPORT */
+
+#else /* defined (AWS_GREENGRASSIPC_USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */
+#    define AWS_GREENGRASSIPC_API
+#endif /* defined (AWS_GREENGRASSIPC__USE_WINDOWS_DLL_SEMANTICS) || defined (WIN32) */

--- a/ipc/include/aws/ipc/GGCoreIpcClient.h
+++ b/ipc/include/aws/ipc/GGCoreIpcClient.h
@@ -1,0 +1,278 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/eventstreamrpc/EventStreamClient.h>
+
+#include <aws/ipc/Exports.h>
+
+#include <aws/crt/JsonObject.h>
+#include <aws/crt/StlAllocator.h>
+
+namespace Aws
+{
+    namespace Eventstreamrpc
+    {
+        namespace Ipc
+        {
+            class GreengrassModelRetriever;
+            class BinaryMessage : public AbstractShapeBase
+            {
+              public:
+                BinaryMessage(
+                    const Crt::Optional<Crt::Vector<uint8_t>> &message,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                BinaryMessage(
+                    Crt::Optional<Crt::Vector<uint8_t>> &&message,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                BinaryMessage(const BinaryMessage &binaryMessage) = default;
+                BinaryMessage(BinaryMessage &&binaryMessage) = default;
+                void SerializeToJsonObject(Crt::JsonObject &payloadObject) const override;
+                static void LoadFromJsonView(BinaryMessage &message, const Crt::JsonView &payloadView) noexcept;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<Crt::Vector<uint8_t>> m_message;
+            };
+            class JsonMessage : public AbstractShapeBase
+            {
+              public:
+                JsonMessage(Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                JsonMessage(
+                    Crt::Optional<Crt::JsonObject> &&jsonObject,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                JsonMessage(
+                    const Crt::Optional<Crt::JsonObject> &jsonObject,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                JsonMessage(const JsonMessage &jsonMessage) = default;
+                JsonMessage(JsonMessage &&jsonMessage) = default;
+                void SerializeToJsonObject(Crt::JsonObject &payloadObject) const override;
+                static void LoadFromJsonView(JsonMessage &message, const Crt::JsonView &payloadView) noexcept;
+                void SetJsonObject();
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<Crt::JsonObject> m_jsonObject;
+            };
+            class PublishMessage : public AbstractShapeBase
+            {
+              public:
+                PublishMessage(Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                PublishMessage(const PublishMessage &publishMessage) = default;
+                PublishMessage(PublishMessage &&publishMessage) = default;
+                PublishMessage(
+                    const Crt::Optional<BinaryMessage> &binaryMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                PublishMessage(
+                    const Crt::Optional<JsonMessage> &jsonMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                void SerializeToJsonObject(Crt::JsonObject &payloadObject) const override;
+
+              private:
+                Crt::Optional<JsonMessage> m_jsonMessage;
+                Crt::Optional<BinaryMessage> m_binaryMessage;
+            };
+            class PublishToTopicRequest : public OperationRequest
+            {
+              public:
+                PublishToTopicRequest(const PublishToTopicRequest &) noexcept = default;
+                PublishToTopicRequest(PublishToTopicRequest &&) noexcept = default;
+                PublishToTopicRequest(
+                    const Crt::Optional<Crt::String> &topic,
+                    const Crt::Optional<PublishMessage> &publishMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                PublishToTopicRequest(
+                    Crt::Optional<Crt::String> &&topic,
+                    Crt::Optional<PublishMessage> &&publishMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                void SerializeToJsonObject(Crt::JsonObject &payloadObject) const override;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<Crt::String> m_topic;
+                Crt::Optional<PublishMessage> m_publishMessage;
+            };
+
+            class PublishToTopicResponse : public OperationResponse
+            {
+              public:
+                PublishToTopicResponse(Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                static Crt::ScopedResource<OperationResponse> s_loadFromPayload(
+                    Crt::StringView stringView,
+                    Crt::Allocator *allocator) noexcept;
+                static void s_customDeleter(PublishToTopicResponse *response) noexcept;
+
+              private:
+                Crt::String GetModelName() const noexcept override;
+            };
+
+            class PublishToTopicOperation : public ClientOperation
+            {
+              public:
+                PublishToTopicOperation(
+                    ClientConnection &connection,
+                    const GreengrassModelRetriever &greengrassModelRetriever,
+                    Crt::Allocator *allocator) noexcept;
+                std::future<EventStreamRpcStatus> Activate(
+                    const PublishToTopicRequest &request,
+                    OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+              private:
+                Crt::String GetModelName() const noexcept override;
+            };
+
+            class SubscriptionResponseMessage : public OperationResponse
+            {
+              public:
+                SubscriptionResponseMessage(Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscriptionResponseMessage(const SubscriptionResponseMessage &publishMessage) = default;
+                SubscriptionResponseMessage(SubscriptionResponseMessage &&publishMessage) = default;
+                SubscriptionResponseMessage(
+                    const Crt::Optional<JsonMessage> &jsonMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscriptionResponseMessage(
+                    const Crt::Optional<BinaryMessage> &binaryMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscriptionResponseMessage(
+                    Crt::Optional<JsonMessage> &&jsonMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscriptionResponseMessage(
+                    Crt::Optional<BinaryMessage> &&binaryMessage,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                static Crt::ScopedResource<OperationResponse> s_loadFromPayload(
+                    Crt::StringView stringView,
+                    Crt::Allocator *allocator) noexcept;
+                static void s_customDeleter(SubscriptionResponseMessage *response) noexcept;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<JsonMessage> m_jsonMessage;
+                Crt::Optional<BinaryMessage> m_binaryMessage;
+            };
+
+            class SubscribeToTopicStreamHandler : public StreamResponseHandler
+            {
+              public:
+                virtual void OnStreamEvent(SubscriptionResponseMessage *response);
+                /* TODO: Overload OnStreamError for every error type. */
+              private:
+                /**
+                 * Invoked when a message is received on this continuation.
+                 */
+                void OnStreamEvent(Crt::ScopedResource<OperationResponse> response) override;
+                /**
+                 * Invoked when a message is received on this continuation but results in an error.
+                 *
+                 * This callback can return true so that the stream is closed afterwards.
+                 */
+                bool OnStreamError(Crt::ScopedResource<OperationError> error) override;
+            };
+
+            class SubscribeToTopicRequest : public OperationRequest
+            {
+              public:
+                SubscribeToTopicRequest(const SubscribeToTopicRequest &) noexcept = default;
+                SubscribeToTopicRequest(SubscribeToTopicRequest &&) noexcept = default;
+                SubscribeToTopicRequest(
+                    const Crt::Optional<Crt::String> &topic,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscribeToTopicRequest(
+                    Crt::Optional<Crt::String> &&topic,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                void SerializeToJsonObject(Crt::JsonObject &payloadObject) const override;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<Crt::String> m_topic;
+            };
+
+            class SubscribeToTopicResponse : public OperationResponse
+            {
+              public:
+                SubscribeToTopicResponse(
+                    const Crt::Optional<Crt::String> &topic,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                SubscribeToTopicResponse(
+                    Crt::Optional<Crt::String> &&topic,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                static Crt::ScopedResource<OperationResponse> s_loadFromPayload(
+                    Crt::StringView stringView,
+                    Crt::Allocator *allocator) noexcept;
+                static void s_customDeleter(SubscribeToTopicResponse *response) noexcept;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+
+              private:
+                Crt::Optional<Crt::String> m_topic;
+            };
+
+            class SubscribeToTopicOperation : public ClientOperation
+            {
+              public:
+                SubscribeToTopicOperation(
+                    ClientConnection &connection,
+                    SubscribeToTopicStreamHandler *m_streamHandler,
+                    const GreengrassModelRetriever &greengrassModelRetriever,
+                    Crt::Allocator *allocator) noexcept;
+                std::future<EventStreamRpcStatus> Activate(
+                    const SubscribeToTopicRequest &request,
+                    OnMessageFlushCallback onMessageFlushCallback) noexcept;
+
+              protected:
+                Crt::String GetModelName() const noexcept override;
+            };
+
+            class GreengrassModelRetriever : public ResponseRetriever
+            {
+              public:
+                ExpectedResponseFactory GetLoneResponseFromModelName(
+                    const Crt::String &modelName) const noexcept override;
+                ExpectedResponseFactory GetStreamingResponseFromModelName(
+                    const Crt::String &modelName) const noexcept override;
+                ErrorResponseFactory GetErrorResponseFromModelName(
+                    const Crt::String &modelName) const noexcept override;
+
+              private:
+                friend class GreengrassIpcClient;
+                Crt::Map<Crt::String, ExpectedResponseFactory> m_ModelNameToSoleResponseMap;
+                Crt::Map<Crt::String, ExpectedResponseFactory> m_ModelNameToStreamingResponseMap;
+                Crt::Map<Crt::String, ErrorResponseFactory> m_ModelNameToErrorResponse;
+            };
+
+            class GreengrassIpcClient
+            {
+              public:
+                GreengrassIpcClient(
+                    ConnectionLifecycleHandler &lifecycleHandler,
+                    Crt::Io::ClientBootstrap &clientBootstrap,
+                    Crt::Allocator *allocator = Crt::g_allocator) noexcept;
+                std::future<EventStreamRpcStatus> Connect(
+                    ConnectionLifecycleHandler &lifecycleHandler,
+                    const Crt::Optional<Crt::String> &ipcSocket = Crt::Optional<Crt::String>(),
+                    const Crt::Optional<Crt::String> &authToken = Crt::Optional<Crt::String>()) noexcept;
+                void Close() noexcept;
+                PublishToTopicOperation NewPublishToTopic() noexcept;
+                SubscribeToTopicOperation NewSubscribeToTopic(SubscribeToTopicStreamHandler& streamHandler) noexcept;
+                ~GreengrassIpcClient() noexcept;
+              private:
+                GreengrassModelRetriever m_greengrassModelRetriever;
+                ClientConnection m_connection;
+                Crt::Io::ClientBootstrap& m_clientBootstrap;
+                Crt::Allocator *m_allocator;
+            };
+        } // namespace Ipc
+
+    } // namespace Eventstreamrpc
+} // namespace Aws

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -1,0 +1,511 @@
+#include <aws/crt/Api.h>
+#include <aws/ipc/GGCoreIpcClient.h>
+
+#include <sstream>
+
+namespace Aws
+{
+    namespace Eventstreamrpc
+    {
+        namespace Ipc
+        {
+            BinaryMessage::BinaryMessage(
+                Crt::Optional<Crt::Vector<uint8_t>> &&message,
+                Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_message(message)
+            {
+            }
+
+            BinaryMessage::BinaryMessage(
+                const Crt::Optional<Crt::Vector<uint8_t>> &message,
+                Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_message(message)
+            {
+            }
+
+            void BinaryMessage::SerializeToJsonObject(Crt::JsonObject &payloadObject) const
+            {
+                if (m_message.has_value())
+                {
+                    payloadObject.WithString("message", Crt::Base64Encode(m_message.value()));
+                }
+            }
+
+            void BinaryMessage::LoadFromJsonView(BinaryMessage &message, const Crt::JsonView &jsonView) noexcept
+            {
+                if (jsonView.ValueExists("message"))
+                {
+                    message.m_message =
+                        Crt::Optional<Crt::Vector<uint8_t>>(Crt::Base64Decode(jsonView.GetString("message")));
+                }
+            }
+
+            Crt::String BinaryMessage::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#BinaryMessage");
+            }
+
+            JsonMessage::JsonMessage(Crt::Allocator *allocator) noexcept : AbstractShapeBase(allocator) {}
+
+            JsonMessage::JsonMessage(Crt::Optional<Crt::JsonObject> &&jsonObject, Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_jsonObject(jsonObject)
+            {
+            }
+
+            JsonMessage::JsonMessage(
+                const Crt::Optional<Crt::JsonObject> &jsonObject,
+                Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_jsonObject(jsonObject)
+            {
+            }
+
+            Crt::String JsonMessage::GetModelName() const noexcept { return Crt::String("aws.greengrass#JsonMessage"); }
+
+            void JsonMessage::SerializeToJsonObject(Crt::JsonObject &payloadObject) const
+            {
+                /* May want to std::move(m_jsonObject) instead, but ideally, it should be up to the application. */
+                if (m_jsonObject.has_value())
+                {
+                    payloadObject.WithObject("message", m_jsonObject.value());
+                }
+            }
+
+            void JsonMessage::LoadFromJsonView(JsonMessage &message, const Crt::JsonView &jsonView) noexcept
+            {
+                if (jsonView.ValueExists("message"))
+                {
+                    message.m_jsonObject =
+                        Crt::Optional<Crt::JsonObject>(Crt::JsonObject(jsonView.GetString("message")));
+                }
+            }
+
+            PublishMessage::PublishMessage(Crt::Allocator *allocator) noexcept : AbstractShapeBase(allocator) {}
+
+            PublishMessage::PublishMessage(
+                const Crt::Optional<JsonMessage> &jsonMessage,
+                Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_jsonMessage(jsonMessage), m_binaryMessage()
+            {
+            }
+
+            PublishMessage::PublishMessage(
+                const Crt::Optional<BinaryMessage> &binaryMessage,
+                Crt::Allocator *allocator) noexcept
+                : AbstractShapeBase(allocator), m_jsonMessage(), m_binaryMessage(binaryMessage)
+            {
+            }
+
+            PublishToTopicOperation::PublishToTopicOperation(
+                ClientConnection &connection,
+                const GreengrassModelRetriever &greengrassModelRetriever,
+                Crt::Allocator *allocator) noexcept
+                : ClientOperation(connection, nullptr, greengrassModelRetriever, allocator)
+            {
+            }
+
+            std::future<EventStreamRpcStatus> PublishToTopicOperation::Activate(
+                const PublishToTopicRequest &request,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept
+            {
+                return ClientOperation::Activate((const OperationRequest *)&request, onMessageFlushCallback);
+            }
+
+            SubscribeToTopicOperation::SubscribeToTopicOperation(
+                ClientConnection &connection,
+                SubscribeToTopicStreamHandler *streamHandler,
+                const GreengrassModelRetriever &greengrassModelRetriever,
+                Crt::Allocator *allocator) noexcept
+                : ClientOperation(connection, streamHandler, greengrassModelRetriever, allocator)
+            {
+            }
+
+            std::future<EventStreamRpcStatus> SubscribeToTopicOperation::Activate(
+                const SubscribeToTopicRequest &request,
+                OnMessageFlushCallback onMessageFlushCallback) noexcept
+            {
+                return ClientOperation::Activate((const OperationRequest *)&request, onMessageFlushCallback);
+            }
+
+            Crt::String SubscribeToTopicOperation::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#SubscribeToTopic");
+            }
+
+            void PublishMessage::SerializeToJsonObject(Crt::JsonObject &payloadObject) const
+            {
+                if (m_jsonMessage.has_value())
+                {
+                    Aws::Crt::JsonObject jsonObject;
+                    m_jsonMessage.value().SerializeToJsonObject(jsonObject);
+                    payloadObject.WithObject("jsonMessage", std::move(jsonObject));
+                    return;
+                }
+                if (m_binaryMessage.has_value())
+                {
+                    Aws::Crt::JsonObject jsonObject;
+                    m_binaryMessage.value().SerializeToJsonObject(jsonObject);
+                    payloadObject.WithObject("binaryMessage", std::move(jsonObject));
+                }
+            }
+
+            Crt::String PublishToTopicRequest::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#PublishToTopicRequest");
+            }
+
+            PublishToTopicRequest::PublishToTopicRequest(
+                const Crt::Optional<Crt::String> &topic,
+                const Crt::Optional<PublishMessage> &publishMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationRequest(allocator), m_topic(topic), m_publishMessage(publishMessage)
+            {
+            }
+            PublishToTopicRequest::PublishToTopicRequest(
+                Crt::Optional<Crt::String> &&topic,
+                Crt::Optional<PublishMessage> &&publishMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationRequest(allocator), m_topic(topic), m_publishMessage(publishMessage)
+            {
+            }
+
+            void PublishToTopicRequest::SerializeToJsonObject(Crt::JsonObject &payloadObject) const
+            {
+                if (m_topic.has_value())
+                {
+                    payloadObject.WithString("topic", m_topic.value());
+                }
+                if (m_publishMessage.has_value())
+                {
+                    Aws::Crt::JsonObject jsonObject;
+                    m_publishMessage.value().SerializeToJsonObject(jsonObject);
+                    payloadObject.WithObject("publishMessage", std::move(jsonObject));
+                }
+            }
+
+            Crt::String PublishToTopicOperation::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#PublishToTopic");
+            }
+
+            PublishToTopicResponse::PublishToTopicResponse(Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator)
+            {
+            }
+
+            Crt::String PublishToTopicResponse::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#PublishToTopicResponse");
+            }
+
+            Crt::ScopedResource<OperationResponse> PublishToTopicResponse::s_loadFromPayload(
+                Crt::StringView stringView,
+                Crt::Allocator *allocator) noexcept
+            {
+                Crt::ScopedResource<PublishToTopicResponse> derivedResponse(
+                    Crt::New<PublishToTopicResponse>(allocator), PublishToTopicResponse::s_customDeleter);
+                auto operationResponse = static_cast<OperationResponse *>(derivedResponse.release());
+                return Crt::ScopedResource<OperationResponse>(operationResponse);
+            }
+
+            void PublishToTopicResponse::s_customDeleter(PublishToTopicResponse *response) noexcept
+            {
+                OperationResponse::s_customDeleter((OperationResponse *)response);
+            }
+
+            void SubscribeToTopicResponse::s_customDeleter(SubscribeToTopicResponse *response) noexcept
+            {
+                OperationResponse::s_customDeleter((OperationResponse *)response);
+            }
+
+            Crt::String SubscribeToTopicRequest::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#SubscribeToTopicRequest");
+            }
+
+            SubscribeToTopicRequest::SubscribeToTopicRequest(
+                const Crt::Optional<Crt::String> &topic,
+                Crt::Allocator *allocator) noexcept
+                : OperationRequest(allocator), m_topic(topic)
+            {
+            }
+            SubscribeToTopicRequest::SubscribeToTopicRequest(
+                Crt::Optional<Crt::String> &&topic,
+                Crt::Allocator *allocator) noexcept
+                : OperationRequest(allocator), m_topic(topic)
+            {
+            }
+
+            void SubscribeToTopicRequest::SerializeToJsonObject(Crt::JsonObject &payloadObject) const
+            {
+                if (m_topic.has_value())
+                {
+                    payloadObject.WithString("topic", m_topic.value());
+                }
+            }
+
+            Crt::String SubscribeToTopicResponse::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#SubscribeToTopicResponse");
+            }
+
+            SubscribeToTopicResponse::SubscribeToTopicResponse(
+                const Crt::Optional<Crt::String> &topic,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_topic(topic)
+            {
+            }
+            SubscribeToTopicResponse::SubscribeToTopicResponse(
+                Crt::Optional<Crt::String> &&topic,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_topic(topic)
+            {
+            }
+
+            Crt::ScopedResource<OperationResponse> SubscribeToTopicResponse::s_loadFromPayload(
+                Crt::StringView stringView,
+                Crt::Allocator *allocator) noexcept
+            {
+                Crt::String payload = {stringView.begin(), stringView.end()};
+                Crt::JsonObject jsonObject(payload);
+                Crt::JsonView jsonView(jsonObject);
+                JsonMessage jsonMessage(allocator);
+
+                Crt::ScopedResource<SubscribeToTopicResponse> derivedResponse(nullptr);
+
+                if (jsonView.ValueExists("topic"))
+                {
+                    Crt::ScopedResource<SubscribeToTopicResponse> unionResponse(
+                        Crt::New<SubscribeToTopicResponse>(allocator, jsonView.GetString("topic"), allocator),
+                        SubscribeToTopicResponse::s_customDeleter);
+                    derivedResponse = std::move(unionResponse);
+                }
+
+                auto operationResponse = static_cast<OperationResponse *>(derivedResponse.release());
+                return Crt::ScopedResource<OperationResponse>(operationResponse);
+            }
+
+            SubscriptionResponseMessage::SubscriptionResponseMessage(Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator)
+            {
+            }
+
+            SubscriptionResponseMessage::SubscriptionResponseMessage(
+                const Crt::Optional<JsonMessage> &jsonMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_jsonMessage(jsonMessage), m_binaryMessage()
+            {
+            }
+
+            SubscriptionResponseMessage::SubscriptionResponseMessage(
+                const Crt::Optional<BinaryMessage> &binaryMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_jsonMessage(), m_binaryMessage(binaryMessage)
+            {
+            }
+
+            SubscriptionResponseMessage::SubscriptionResponseMessage(
+                Crt::Optional<JsonMessage> &&jsonMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_jsonMessage(jsonMessage), m_binaryMessage()
+            {
+            }
+
+            SubscriptionResponseMessage::SubscriptionResponseMessage(
+                Crt::Optional<BinaryMessage> &&binaryMessage,
+                Crt::Allocator *allocator) noexcept
+                : OperationResponse(allocator), m_jsonMessage(), m_binaryMessage(binaryMessage)
+            {
+            }
+
+            void SubscriptionResponseMessage::s_customDeleter(SubscriptionResponseMessage *response) noexcept
+            {
+                OperationResponse::s_customDeleter((OperationResponse *)response);
+            }
+
+            GreengrassIpcClient::GreengrassIpcClient(
+                ConnectionLifecycleHandler &lifecycleHandler,
+                Crt::Io::ClientBootstrap &clientBootstrap,
+                Crt::Allocator *allocator) noexcept
+                : m_connection(lifecycleHandler, allocator), m_clientBootstrap(clientBootstrap), m_allocator(allocator)
+            {
+                aws_event_stream_library_init(m_allocator);
+
+                m_greengrassModelRetriever.m_ModelNameToSoleResponseMap[Crt::String("aws.greengrass#PublishToTopic")] =
+                    PublishToTopicResponse::s_loadFromPayload;
+                m_greengrassModelRetriever
+                    .m_ModelNameToSoleResponseMap[Crt::String("aws.greengrass#SubscribeToTopic")] =
+                    SubscribeToTopicResponse::s_loadFromPayload;
+                m_greengrassModelRetriever
+                    .m_ModelNameToStreamingResponseMap[Crt::String("aws.greengrass#SubscribeToTopic")] =
+                    SubscriptionResponseMessage::s_loadFromPayload;
+            }
+
+            std::future<EventStreamRpcStatus> GreengrassIpcClient::Connect(
+                ConnectionLifecycleHandler &lifecycleHandler,
+                const Crt::Optional<Crt::String> &ipcSocket,
+                const Crt::Optional<Crt::String> &authToken) noexcept
+            {
+                std::promise<EventStreamRpcStatus> initializationPromise;
+
+                Crt::String finalIpcSocket;
+                if (ipcSocket.has_value())
+                {
+                    finalIpcSocket = ipcSocket.value();
+                }
+                else
+                {
+                    finalIpcSocket = Crt::String(std::getenv("AWS_GG_NUCLEUS_DOMAIN_SOCKET_FILEPATH_FOR_COMPONENT"));
+                }
+
+                Crt::String finalAuthToken;
+                if (authToken.has_value())
+                {
+                    finalAuthToken = authToken.value();
+                }
+                else
+                {
+                    finalAuthToken = Crt::String(std::getenv("SVCUID"));
+                }
+
+                /* Encode authToken as JSON. */
+                Crt::StringStream authTokenPayloadSS;
+                authTokenPayloadSS << "{\"authToken\":\"" << finalAuthToken << "\"}";
+
+                if(!m_clientBootstrap)
+                {
+                    initializationPromise.set_value({EVENT_STREAM_RPC_INITIALIZATION_ERROR, 0});
+                    return initializationPromise.get_future();
+                }
+
+                Crt::Io::SocketOptions socketOptions;
+                socketOptions.SetSocketDomain(Crt::Io::SocketDomain::Local);
+                socketOptions.SetSocketType(Crt::Io::SocketType::Stream);
+
+                ClientConnectionOptions connectionOptions;
+                connectionOptions.Bootstrap = &m_clientBootstrap;
+                connectionOptions.SocketOptions = std::move(socketOptions);
+                connectionOptions.HostName = finalIpcSocket;
+                connectionOptions.Port = 0;
+
+                MessageAmendment connectionAmendment(Crt::ByteBufFromCString(authTokenPayloadSS.str().c_str()));
+                auto messageAmender = [&](void) -> MessageAmendment & { return connectionAmendment; };
+
+                return m_connection.Connect(connectionOptions, lifecycleHandler, messageAmender);
+            }
+
+            void GreengrassIpcClient::Close() noexcept
+            {
+                m_connection.Close();
+            }
+
+            GreengrassIpcClient::~GreengrassIpcClient() noexcept
+            {
+                Close();
+                aws_event_stream_library_clean_up();
+            }
+
+            ExpectedResponseFactory GreengrassModelRetriever::GetLoneResponseFromModelName(
+                const Crt::String &modelName) const noexcept
+            {
+                auto it = m_ModelNameToSoleResponseMap.find(modelName);
+                if (it == m_ModelNameToSoleResponseMap.end())
+                {
+                    return nullptr;
+                }
+                else
+                {
+                    return it->second;
+                }
+            }
+
+            ExpectedResponseFactory GreengrassModelRetriever::GetStreamingResponseFromModelName(
+                const Crt::String &modelName) const noexcept
+            {
+                auto it = m_ModelNameToStreamingResponseMap.find(modelName);
+                if (it == m_ModelNameToStreamingResponseMap.end())
+                {
+                    return nullptr;
+                }
+                else
+                {
+                    return it->second;
+                }
+            }
+
+            ErrorResponseFactory GreengrassModelRetriever::GetErrorResponseFromModelName(
+                const Crt::String &modelName) const noexcept
+            {
+                auto it = m_ModelNameToErrorResponse.find(modelName);
+                if (it == m_ModelNameToErrorResponse.end())
+                {
+                    return nullptr;
+                }
+                else
+                {
+                    return it->second;
+                }
+            }
+
+            PublishToTopicOperation GreengrassIpcClient::NewPublishToTopic() noexcept
+            {
+                return PublishToTopicOperation(m_connection, m_greengrassModelRetriever, m_allocator);
+            }
+
+            SubscribeToTopicOperation GreengrassIpcClient::NewSubscribeToTopic(
+                SubscribeToTopicStreamHandler& streamHandler) noexcept
+            {
+                return SubscribeToTopicOperation(m_connection, &streamHandler, m_greengrassModelRetriever, m_allocator);
+            }
+
+            void SubscribeToTopicStreamHandler::OnStreamEvent(Crt::ScopedResource<OperationResponse> response)
+            {
+                OnStreamEvent(static_cast<SubscriptionResponseMessage *>(response.get()));
+            }
+
+            void SubscribeToTopicStreamHandler::OnStreamEvent(SubscriptionResponseMessage *response) {}
+
+            bool SubscribeToTopicStreamHandler::OnStreamError(Crt::ScopedResource<OperationError> response)
+            {
+                // TODO: return OnStreamError(static_cast<SubscriptionResponseError *> response.get());
+                return true;
+            }
+
+            Crt::String SubscriptionResponseMessage::GetModelName() const noexcept
+            {
+                return Crt::String("aws.greengrass#SubscriptionResponseMessage");
+            }
+
+            Crt::ScopedResource<OperationResponse> SubscriptionResponseMessage::s_loadFromPayload(
+                Crt::StringView stringView,
+                Crt::Allocator *allocator) noexcept
+            {
+                Crt::String payload = {stringView.begin(), stringView.end()};
+                Crt::JsonObject jsonObject(payload);
+                Crt::JsonView jsonView(jsonObject);
+                JsonMessage jsonMessage(allocator);
+
+                Crt::ScopedResource<SubscriptionResponseMessage> derivedResponse;
+
+                if (jsonView.ValueExists("jsonMessage"))
+                {
+                    JsonMessage jsonMessage(jsonView.GetJsonObject("jsonMessage").Materialize(), allocator);
+                    Crt::ScopedResource<SubscriptionResponseMessage> unionResponse(
+                        Crt::New<SubscriptionResponseMessage>(allocator, std::move(jsonMessage), allocator),
+                        SubscriptionResponseMessage::s_customDeleter);
+                    derivedResponse = std::move(unionResponse);
+                }
+                else if (jsonView.ValueExists("binaryMessage"))
+                {
+                    BinaryMessage binaryMessage(Crt::Base64Decode(jsonView.GetString("binaryMessage")), allocator);
+                    Crt::ScopedResource<SubscriptionResponseMessage> unionResponse(
+                        Crt::New<SubscriptionResponseMessage>(allocator, binaryMessage, allocator),
+                        SubscriptionResponseMessage::s_customDeleter);
+                    derivedResponse = std::move(unionResponse);
+                }
+
+                auto operationResponse = static_cast<OperationResponse *>(derivedResponse.release());
+                return Crt::ScopedResource<OperationResponse>(operationResponse);
+            }
+        } // namespace Ipc
+    }     // namespace Eventstreamrpc
+} // namespace Aws

--- a/ipc/source/GGCoreIpcClient.cpp
+++ b/ipc/source/GGCoreIpcClient.cpp
@@ -371,7 +371,7 @@ namespace Aws
                 Crt::StringStream authTokenPayloadSS;
                 authTokenPayloadSS << "{\"authToken\":\"" << finalAuthToken << "\"}";
 
-                if(!m_clientBootstrap)
+                if (!m_clientBootstrap)
                 {
                     initializationPromise.set_value({EVENT_STREAM_RPC_INITIALIZATION_ERROR, 0});
                     return initializationPromise.get_future();
@@ -393,10 +393,7 @@ namespace Aws
                 return m_connection.Connect(connectionOptions, lifecycleHandler, messageAmender);
             }
 
-            void GreengrassIpcClient::Close() noexcept
-            {
-                m_connection.Close();
-            }
+            void GreengrassIpcClient::Close() noexcept { m_connection.Close(); }
 
             GreengrassIpcClient::~GreengrassIpcClient() noexcept
             {
@@ -452,7 +449,7 @@ namespace Aws
             }
 
             SubscribeToTopicOperation GreengrassIpcClient::NewSubscribeToTopic(
-                SubscribeToTopicStreamHandler& streamHandler) noexcept
+                SubscribeToTopicStreamHandler &streamHandler) noexcept
             {
                 return SubscribeToTopicOperation(m_connection, &streamHandler, m_greengrassModelRetriever, m_allocator);
             }

--- a/ipc/tests/CMakeLists.txt
+++ b/ipc/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(AwsTestHarness)
+enable_testing()
+include(CTest)
+
+file(GLOB TEST_SRC "*.cpp")
+file(GLOB TEST_HDRS "*.h")
+file(GLOB TESTS ${TEST_HDRS} ${TEST_SRC})
+
+set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
+
+aws_use_package(aws-crt-cpp)
+aws_use_package(GreengrassIpc-cpp)
+
+if (UNIX AND NOT APPLE)
+    add_net_test_case(EventStreamConnect)
+    generate_cpp_test_driver(${TEST_BINARY_NAME})
+endif()

--- a/ipc/tests/GGCoreIpcClientTest.cpp
+++ b/ipc/tests/GGCoreIpcClientTest.cpp
@@ -1,0 +1,75 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include <aws/crt/Api.h>
+
+#include <aws/ipc/GGCoreIpcClient.h>
+
+#include <aws/testing/aws_test_harness.h>
+
+#include <iostream>
+#include <sstream>
+
+using namespace Aws::Eventstreamrpc;
+
+static int s_PublishToIoTCore(struct aws_allocator *allocator, void *ctx);
+
+static int s_PublishToIoTCore(struct aws_allocator *allocator, void *ctx)
+{
+    (void)ctx;
+    {
+        Aws::Crt::ApiHandle apiHandle(allocator);
+        Aws::Crt::Io::TlsContextOptions tlsCtxOptions = Aws::Crt::Io::TlsContextOptions::InitDefaultClient();
+        Aws::Crt::Io::TlsContext tlsContext(tlsCtxOptions, Aws::Crt::Io::TlsMode::CLIENT, allocator);
+        ASSERT_TRUE(tlsContext);
+
+        Aws::Crt::Io::TlsConnectionOptions tlsConnectionOptions = tlsContext.NewConnectionOptions();
+
+        Aws::Crt::Io::EventLoopGroup eventLoopGroup(0, allocator);
+        ASSERT_TRUE(eventLoopGroup);
+
+        UnixSocketResolver unixSocketResolver(eventLoopGroup, 8, allocator);
+        ASSERT_TRUE(unixSocketResolver);
+
+        Aws::Crt::Io::ClientBootstrap clientBootstrap(eventLoopGroup, unixSocketResolver, allocator);
+        ASSERT_TRUE(clientBootstrap);
+        clientBootstrap.EnableBlockingShutdown();
+        MessageAmendment connectionAmendment;
+        auto messageAmender = [&](void) -> MessageAmendment & { return connectionAmendment; };
+
+        ConnectionLifecycleHandler lifecycleHandler;
+        Ipc::GreengrassIpcClient client(lifecycleHandler, clientBootstrap);
+        auto connectedStatus = client.Connect(lifecycleHandler);
+        ASSERT_TRUE(connectedStatus.get().baseStatus == EVENT_STREAM_RPC_SUCCESS);
+
+        /* Subscribe to Topic */
+        {
+            Ipc::SubscribeToTopicStreamHandler streamHandler;
+            Ipc::SubscribeToTopicOperation operation = client.NewSubscribeToTopic(streamHandler);
+            Ipc::SubscribeToTopicRequest request(Aws::Crt::String("topic"), allocator);
+            auto activate = operation.Activate(request, nullptr);
+            activate.wait();
+            auto response = operation.GetResponse();
+            response.wait();
+        }
+
+        /* Publish to Topic */
+        {
+            Ipc::PublishToTopicOperation operation = client.NewPublishToTopic();
+            Ipc::PublishMessage publishMessage(allocator);
+            Ipc::PublishToTopicRequest request(
+                Aws::Crt::String("example"), Ipc::PublishMessage(publishMessage), allocator);
+            auto activate = operation.Activate(request, nullptr);
+            activate.wait();
+            auto response = operation.GetResponse();
+            response.get();
+        }
+
+        client.Close();
+    }
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(EventStreamConnect, s_PublishToIoTCore)


### PR DESCRIPTION
- Fixes the definition of the flush callback along with futures returning the expected result of the operation
- Introduces a few mechanisms such as `ProtectedPromise` and mutexes to handle synchronization across multiple threads
- Avoids usage of pointers wherever possible in place of references
### TODO
- When the connection is no longer active or valid, trying to open a new stream or active an operation should return an error
- Code gen will be updated to have setters and getters for each member rather than having multiple constructors for each operation payload

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
