### PR TITLE
Updated GCC minimum in README from 4.4 to 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ to C++ by the [aws-crt-cpp](https://github.com/awslabs/aws-crt-cpp) package.
 
 * C++ 11 or higher
 * CMake 3.1+
-* Clang 3.9+ or GCC 4.4+ or MSVC 2015+
+* Clang 3.9+ or GCC 4.8+ or MSVC 2015+
 
 ### Build from source
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

README incorrectly specifies GCC4.4 as the minimum required version. Full C++11 support requires at least 4.8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
