### PR TITLE
Updated DeviceDefender task interface changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
-[submodule "aws-common-runtime/aws-crt-cpp"]
+[submodule "crt/aws-crt-cpp"]
 	path = crt/aws-crt-cpp
 	url = https://github.com/awslabs/aws-crt-cpp.git
 [submodule "crt/aws-c-iot"]

--- a/devicedefender/include/aws/iotdevicedefender/DeviceDefender.h
+++ b/devicedefender/include/aws/iotdevicedefender/DeviceDefender.h
@@ -51,9 +51,7 @@ namespace Aws
           public:
             ~ReportTask();
             ReportTask(const ReportTask &) = delete;
-            ReportTask(ReportTask &&) noexcept;
             ReportTask &operator=(const ReportTask &) = delete;
-            ReportTask &operator=(ReportTask &&) noexcept;
 
             /**
              * Initiates stopping of the Defender V1 task.
@@ -143,7 +141,7 @@ namespace Aws
             /**
              * Builds a device defender v1 task object from the set options.
              */
-            ReportTask Build() noexcept;
+            std::shared_ptr<ReportTask> Build() noexcept;
 
           private:
             Crt::Allocator *m_allocator;

--- a/devicedefender/include/aws/iotdevicedefender/DeviceDefender.h
+++ b/devicedefender/include/aws/iotdevicedefender/DeviceDefender.h
@@ -82,9 +82,11 @@ namespace Aws
           private:
             Crt::Allocator *m_allocator;
             ReportTaskStatus m_status;
-            aws_iotdevice_defender_report_task_config m_taskConfig;
-            aws_iotdevice_defender_v1_task *m_owningTask;
+            aws_iotdevice_defender_task_config *m_taskConfig;
+            aws_iotdevice_defender_task *m_owningTask;
             int m_lastError;
+            std::shared_ptr<Crt::Mqtt::MqttConnection> m_mqttConnection;
+            Crt::Io::EventLoopGroup &m_eventLoopGroup;
 
             ReportTask(
                 Crt::Allocator *allocator,

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -131,6 +131,7 @@ namespace Aws
             {
                 aws_iotdevice_defender_task_clean_up(this->m_owningTask);
                 this->m_owningTask = nullptr;
+                m_status = ReportTaskStatus::Stopped;
             }
         }
 

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -103,6 +103,7 @@ namespace Aws
 
         int ReportTask::StartTask() noexcept
         {
+            int return_code = AWS_OP_ERR;
             if (m_taskConfig != nullptr && !m_lastError &&
                 (this->GetStatus() == ReportTaskStatus::Ready || this->GetStatus() == ReportTaskStatus::Stopped))
             {
@@ -114,14 +115,14 @@ namespace Aws
                 {
                     this->m_lastError = aws_last_error();
                     aws_raise_error(this->m_lastError);
-                    return AWS_OP_ERR;
                 }
                 else
                 {
                     this->m_status = ReportTaskStatus::Running;
+                    return_code = AWS_OP_SUCCESS;
                 }
             }
-            return AWS_OP_ERR;
+            return return_code;
         }
 
         void ReportTask::StopTask() noexcept

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -42,6 +42,7 @@ namespace Aws
               m_allocator(allocator), m_status(ReportTaskStatus::Ready), m_taskConfig{nullptr}, m_owningTask{nullptr},
               m_lastError(0), m_mqttConnection{mqttConnection}, m_eventLoopGroup{eventLoopGroup}
         {
+            (void)networkConnectionSamplePeriodSeconds;
             struct aws_byte_cursor thingNameCursor = Crt::ByteCursorFromString(thingName);
             m_lastError =
                 aws_iotdevice_defender_config_create(&m_taskConfig, allocator, &thingNameCursor, reportFormat);

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -162,7 +162,7 @@ namespace Aws
 
         std::shared_ptr<ReportTask> ReportTaskBuilder::Build() noexcept
         {
-          return std::shared_ptr<ReportTask>(new ReportTask(
+            return std::shared_ptr<ReportTask>(new ReportTask(
                 m_allocator,
                 m_mqttConnection,
                 m_thingName,

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -106,7 +106,8 @@ namespace Aws
                 (this->GetStatus() == ReportTaskStatus::Ready || this->GetStatus() == ReportTaskStatus::Stopped))
             {
                 if (AWS_OP_SUCCESS != aws_iotdevice_defender_task_create(
-                                          &m_owningTask, this->m_taskConfig,
+                                          &m_owningTask,
+                                          this->m_taskConfig,
                                           m_mqttConnection->GetUnderlyingConnection(),
                                           aws_event_loop_group_get_next_loop(m_eventLoopGroup.GetUnderlyingHandle())))
                 {

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -40,7 +40,7 @@ namespace Aws
             void *cancellationUserdata) noexcept
             : OnTaskCancelled(std::move(onCancelled)), cancellationUserdata(cancellationUserdata),
               m_allocator(allocator), m_status(ReportTaskStatus::Ready), m_taskConfig{nullptr}, m_owningTask{nullptr},
-              m_lastError(0), m_mqttConnection{mqttConnection}, m_eventLoopGroup{eventLoopGroup}
+              m_lastError(0), m_mqttConnection{mqttConnection}, m_eventLoopGroup(eventLoopGroup)
         {
             (void)networkConnectionSamplePeriodSeconds;
             struct aws_byte_cursor thingNameCursor = Crt::ByteCursorFromString(thingName);

--- a/devicedefender/source/DeviceDefender.cpp
+++ b/devicedefender/source/DeviceDefender.cpp
@@ -45,9 +45,9 @@ namespace Aws
         {
             (void)networkConnectionSamplePeriodSeconds;
             struct aws_byte_cursor thingNameCursor = Crt::ByteCursorFromString(thingName);
-            m_lastError =
+            int return_code =
                 aws_iotdevice_defender_config_create(&m_taskConfig, allocator, &thingNameCursor, reportFormat);
-            if (AWS_OP_SUCCESS == m_lastError)
+            if (AWS_OP_SUCCESS == return_code)
             {
                 aws_iotdevice_defender_config_set_task_cancelation_fn(m_taskConfig, s_onDefenderV1TaskCancelled);
                 aws_iotdevice_defender_config_set_callback_userdata(m_taskConfig, this);

--- a/devicedefender/tests/DeviceDefenderTest.cpp
+++ b/devicedefender/tests/DeviceDefenderTest.cpp
@@ -8,7 +8,6 @@
 #include <aws/iotdevicedefender/DeviceDefender.h>
 #include <aws/testing/aws_test_harness.h>
 #include <utility>
-#include <iostream>
 
 static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)
 {

--- a/devicedefender/tests/DeviceDefenderTest.cpp
+++ b/devicedefender/tests/DeviceDefenderTest.cpp
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+#include "aws/common/error.h"
 #include <aws/crt/Api.h>
 
 #include <aws/iotdevicecommon/IotDevice.h>
@@ -61,15 +62,17 @@ static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, vo
             .WithTaskCancelledHandler(onCancelled)
             .WithTaskCancellationUserData(&callbackSuccess);
 
-        Aws::Iotdevicedefenderv1::ReportTask task = taskBuilder.Build();
+        std::shared_ptr<Aws::Iotdevicedefenderv1::ReportTask> task = taskBuilder.Build();
 
-        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Ready, (int)task.GetStatus());
+        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Ready, (int)task->GetStatus());
 
-        ASSERT_SUCCESS(task.StartTask());
-        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Running, (int)task.GetStatus());
-        task.StopTask();
+        ASSERT_SUCCESS(task->StartTask());
+        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Running, (int)task->GetStatus());
+        ASSERT_FAILS(task->StartTask());
+        ASSERT_TRUE(aws_last_error() == AWS_ERROR_INVALID_STATE);
+        task->StopTask();
 
-        ASSERT_TRUE(task.GetStatus() == Aws::Iotdevicedefenderv1::ReportTaskStatus::Stopped);
+        ASSERT_TRUE(task->GetStatus() == Aws::Iotdevicedefenderv1::ReportTaskStatus::Stopped);
 
         {
             std::unique_lock<std::mutex> lock(mutex);
@@ -83,7 +86,7 @@ static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, vo
 
         ASSERT_FALSE(mqttClient);
 
-        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Stopped, (int)task.GetStatus());
+        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Stopped, (int)task->GetStatus());
     }
 
     return AWS_ERROR_SUCCESS;
@@ -131,12 +134,13 @@ static int s_TestDeviceDefenderFailedTest(Aws::Crt::Allocator *allocator, void *
             .WithTaskPeriodSeconds((uint32_t)1UL)
             .WithReportFormat(Aws::Iotdevicedefenderv1::ReportFormat::AWS_IDDRF_SHORT_JSON);
 
-        Aws::Iotdevicedefenderv1::ReportTask task = taskBuilder.Build();
+        std::shared_ptr<Aws::Iotdevicedefenderv1::ReportTask> task = taskBuilder.Build();
 
-        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Ready, (int)task.GetStatus());
+        ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Ready, (int)task->GetStatus());
 
-        ASSERT_INT_EQUALS(AWS_OP_ERR, task.StartTask());
-        ASSERT_INT_EQUALS(AWS_ERROR_IOTDEVICE_DEFENDER_UNSUPPORTED_REPORT_FORMAT, task.LastError());
+        ASSERT_INT_EQUALS(AWS_ERROR_IOTDEVICE_DEFENDER_UNSUPPORTED_REPORT_FORMAT, task->LastError());
+        ASSERT_FAILS(task->StartTask());
+        ASSERT_TRUE(aws_last_error() == AWS_ERROR_INVALID_STATE);
 
         mqttConnection->Disconnect();
         ASSERT_TRUE(mqttConnection);

--- a/devicedefender/tests/DeviceDefenderTest.cpp
+++ b/devicedefender/tests/DeviceDefenderTest.cpp
@@ -69,6 +69,8 @@ static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, vo
         ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Running, (int)task.GetStatus());
         task.StopTask();
 
+        ASSERT_TRUE(task.GetStatus() == Aws::Iotdevicedefenderv1::ReportTaskStatus::Stopped);
+
         {
             std::unique_lock<std::mutex> lock(mutex);
             cv.wait(lock, [&]() { return taskStopped; });

--- a/devicedefender/tests/DeviceDefenderTest.cpp
+++ b/devicedefender/tests/DeviceDefenderTest.cpp
@@ -8,6 +8,7 @@
 #include <aws/iotdevicedefender/DeviceDefender.h>
 #include <aws/testing/aws_test_harness.h>
 #include <utility>
+#include <iostream>
 
 static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, void *ctx)
 {

--- a/devicedefender/tests/DeviceDefenderTest.cpp
+++ b/devicedefender/tests/DeviceDefenderTest.cpp
@@ -65,7 +65,7 @@ static int s_TestDeviceDefenderResourceSafety(Aws::Crt::Allocator *allocator, vo
 
         ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Ready, (int)task.GetStatus());
 
-        task.StartTask();
+        ASSERT_SUCCESS(task.StartTask());
         ASSERT_INT_EQUALS((int)Aws::Iotdevicedefenderv1::ReportTaskStatus::Running, (int)task.GetStatus());
         task.StopTask();
 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
* These changes are downstream of these changes: https://github.com/awslabs/aws-c-iot/pull/48 and remain in draft until it is pushed and given a pre-release tag
* The interface to start a DeviceDefender task has been updated for better safety and extensibility to include custom metrics. This device SDK needed updates to adhere to the new interface
* No functionality for custom metrics has been added yet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
