### PR TITLE
rename topic and client id of basic_pub_sub example

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -61,7 +61,7 @@ and receive.
         "iot:Receive"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/topic"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/sdk/test/cpp"
       ]
     },
     {
@@ -70,7 +70,7 @@ and receive.
         "iot:Subscribe"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/topic"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/sdk/test/cpp"
       ]
     },
     {
@@ -79,7 +79,7 @@ and receive.
         "iot:Connect"
       ],
       "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/basicPubSub"
       ]
     }
 
@@ -93,7 +93,6 @@ To run the basic MQTT Pub-Sub use the following command:
 ``` sh
 ./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
---topic <topic name>
 ```
 
 ## Raw MQTT Pub-Sub

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -94,8 +94,8 @@ int main(int argc, char *argv[])
     String certificatePath;
     String keyPath;
     String caFile;
-    String topic("test/topic");
-    String clientId(String("test-") + Aws::Crt::UUID().ToString());
+    String topic("sdk/test/cpp");
+    String clientId(String("basicPubSub"));
     String signingRegion;
     String proxyHost;
     uint16_t proxyPort(8080);


### PR DESCRIPTION
Rename the default topic and client id to match
the naming from other examples like the from python and java sdk.

*Issue #, if available:*

Background: One common way to use this SDK as newbie in AWS IoT is to use the Onboard -> Get started "tutorial". I used this option for Linux/Python. This created automatically a working example sending and receiving messages in python. The next step was to reproduce the same with C++ SDK. Trying to reproduce the same behavior in C++ is for someone new in the technology complicated due to 2 small differences addressed in this pr. I also saw multiple people having this similar issue googling for the error message:

> Connection failed with error libaws-c-mqtt: AWS_ERROR_MQTT_UNEXPECTED_HANGUP, The connection was closed unexpectedly.

This PR "as is" makes only sense if also the default policy created during "Onboard" -> Get started is extended adding: 

arn:aws:iot:<zone>:<id>:topicfilter/sdk/test/cpp"

if not the PR can be also adapted to use the topic sdk/test/Python or sdk/test/java.

*Description of changes:*

Rename topic and client id to match the naming of the policies created for python example using the Onboard -> Get started menu.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
