### PR TITLE
Make iot sdk target actually use CRT library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,6 @@ else()
 endif()
 
 aws_use_package(aws-crt-cpp)
-if (NOT BYO_CRYPTO)
-    aws_use_package(aws-c-iot)
-endif()
 
 add_subdirectory(jobs)
 add_subdirectory(shadow)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ else()
     set(IN_SOURCE_BUILD OFF)
 endif()
 
+aws_use_package(aws-crt-cpp)
+if (NOT BYO_CRYPTO)
+    aws_use_package(aws-c-iot)
+endif()
+
 add_subdirectory(jobs)
 add_subdirectory(shadow)
 add_subdirectory(discovery)


### PR DESCRIPTION
* Fixes brazil build, includes were not being found

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
