### PR TITLE
Continuation activation race condition fix

### DIFF
--- a/eventstream_rpc/source/EventStreamClient.cpp
+++ b/eventstream_rpc/source/EventStreamClient.cpp
@@ -966,8 +966,13 @@ namespace Aws
             int errorCode =
                 EventStreamCppToNativeCrtBuilder::s_fillNativeHeadersArray(headers, &headersArray, m_allocator);
 
-            // regardless of how the promise gets moved around (or not), this future should stay valid as a return
-            // value.
+            /*
+             * Regardless of how the promise gets moved around (or not), this future should stay valid as a return
+             * value.
+             *
+             * We pull it out early because the call to aws_event_stream_rpc_client_continuation_activate() may complete
+             * and delete the promise before we pull out the future afterwords.
+             */
             std::future<RpcError> retValue = onFlushPromise.get_future();
 
             if (!errorCode)


### PR DESCRIPTION
Pull out the future before initiating async operations, otherwise the promise may already be destroyed by the time you try and pull out the future

https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/327

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
