### PR TITLE
Greengrass IPC API updates

### DIFF
--- a/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -292,7 +292,7 @@ namespace Aws
              * the TERMINATE_STREAM flag, or when the connection shuts down.
              */
             virtual void OnContinuationClosed() = 0;
-            ~ClientContinuationHandler() noexcept;
+            virtual ~ClientContinuationHandler() noexcept;
 
           private:
             friend class ClientContinuation;
@@ -487,7 +487,7 @@ namespace Aws
             const ServiceModel &m_serviceModel;
         };
 
-        class AWS_EVENTSTREAMRPC_API ClientOperation : private ClientContinuationHandler
+        class AWS_EVENTSTREAMRPC_API ClientOperation : public ClientContinuationHandler
         {
           public:
             ClientOperation(

--- a/eventstream_rpc/tests/EchoTestRpcClient.cpp
+++ b/eventstream_rpc/tests/EchoTestRpcClient.cpp
@@ -1,3 +1,4 @@
+#include <aws/crt/Types.h>
 #include <aws/crt/io/Bootstrap.h>
 #include <awstest/EchoTestRpcClient.h>
 
@@ -28,11 +29,25 @@ namespace Awstest
         return GetAllProductsOperation(
             m_connection, m_echoTestRpcServiceModel.m_getAllProductsOperationContext, m_allocator);
     }
+
+    std::unique_ptr<GetAllProductsOperation> EchoTestRpcClient::NewPtrGetAllProducts() noexcept
+    {
+        return std::unique_ptr<GetAllProductsOperation>(Aws::Crt::New<GetAllProductsOperation>(
+            m_allocator, m_connection, m_echoTestRpcServiceModel.m_getAllProductsOperationContext, m_allocator));
+    }
+
     CauseServiceErrorOperation EchoTestRpcClient::NewCauseServiceError() noexcept
     {
         return CauseServiceErrorOperation(
             m_connection, m_echoTestRpcServiceModel.m_causeServiceErrorOperationContext, m_allocator);
     }
+
+    std::unique_ptr<CauseServiceErrorOperation> EchoTestRpcClient::NewPtrCauseServiceError() noexcept
+    {
+        return std::unique_ptr<CauseServiceErrorOperation>(Aws::Crt::New<CauseServiceErrorOperation>(
+            m_allocator, m_connection, m_echoTestRpcServiceModel.m_causeServiceErrorOperationContext, m_allocator));
+    }
+
     CauseStreamServiceToErrorOperation EchoTestRpcClient::NewCauseStreamServiceToError(
         CauseStreamServiceToErrorStreamHandler &streamHandler) noexcept
     {
@@ -42,20 +57,57 @@ namespace Awstest
             m_echoTestRpcServiceModel.m_causeStreamServiceToErrorOperationContext,
             m_allocator);
     }
+
+    std::unique_ptr<CauseStreamServiceToErrorOperation> EchoTestRpcClient::NewPtrCauseStreamServiceToError(
+        std::shared_ptr<CauseStreamServiceToErrorStreamHandler> streamHandler) noexcept
+    {
+        return std::unique_ptr<CauseStreamServiceToErrorOperation>(Aws::Crt::New<CauseStreamServiceToErrorOperation>(
+            m_allocator,
+            m_connection,
+            std::move(streamHandler),
+            m_echoTestRpcServiceModel.m_causeStreamServiceToErrorOperationContext,
+            m_allocator));
+    }
+
     EchoStreamMessagesOperation EchoTestRpcClient::NewEchoStreamMessages(
         EchoStreamMessagesStreamHandler &streamHandler) noexcept
     {
         return EchoStreamMessagesOperation(
             m_connection, &streamHandler, m_echoTestRpcServiceModel.m_echoStreamMessagesOperationContext, m_allocator);
     }
+
+    std::unique_ptr<EchoStreamMessagesOperation> EchoTestRpcClient::NewPtrEchoStreamMessages(
+        std::shared_ptr<EchoStreamMessagesStreamHandler> streamHandler) noexcept
+    {
+        return std::unique_ptr<EchoStreamMessagesOperation>(Aws::Crt::New<EchoStreamMessagesOperation>(
+            m_allocator,
+            m_connection,
+            std::move(streamHandler),
+            m_echoTestRpcServiceModel.m_echoStreamMessagesOperationContext,
+            m_allocator));
+    }
+
     EchoMessageOperation EchoTestRpcClient::NewEchoMessage() noexcept
     {
         return EchoMessageOperation(m_connection, m_echoTestRpcServiceModel.m_echoMessageOperationContext, m_allocator);
     }
+
+    std::unique_ptr<EchoMessageOperation> EchoTestRpcClient::NewPtrEchoMessage() noexcept
+    {
+        return std::unique_ptr<EchoMessageOperation>(Aws::Crt::New<EchoMessageOperation>(
+            m_allocator, m_connection, m_echoTestRpcServiceModel.m_echoMessageOperationContext, m_allocator));
+    }
+
     GetAllCustomersOperation EchoTestRpcClient::NewGetAllCustomers() noexcept
     {
         return GetAllCustomersOperation(
             m_connection, m_echoTestRpcServiceModel.m_getAllCustomersOperationContext, m_allocator);
+    }
+
+    std::unique_ptr<GetAllCustomersOperation> EchoTestRpcClient::NewPtrGetAllCustomers() noexcept
+    {
+        return std::unique_ptr<GetAllCustomersOperation>(Aws::Crt::New<GetAllCustomersOperation>(
+            m_allocator, m_connection, m_echoTestRpcServiceModel.m_getAllCustomersOperationContext, m_allocator));
     }
 
 } // namespace Awstest

--- a/eventstream_rpc/tests/EchoTestRpcModel.cpp
+++ b/eventstream_rpc/tests/EchoTestRpcModel.cpp
@@ -1150,6 +1150,16 @@ namespace Awstest
     {
     }
 
+    CauseStreamServiceToErrorOperation::CauseStreamServiceToErrorOperation(
+        ClientConnection &connection,
+        std::shared_ptr<CauseStreamServiceToErrorStreamHandler> streamHandler,
+        const CauseStreamServiceToErrorOperationContext &operationContext,
+        Aws::Crt::Allocator *allocator) noexcept
+        : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+          pinnedHandler(std::move(streamHandler))
+    {
+    }
+
     std::future<RpcError> CauseStreamServiceToErrorOperation::Activate(
         const EchoStreamingRequest &request,
         OnMessageFlushCallback onMessageFlushCallback) noexcept
@@ -1234,6 +1244,16 @@ namespace Awstest
         const EchoStreamMessagesOperationContext &operationContext,
         Aws::Crt::Allocator *allocator) noexcept
         : ClientOperation(connection, streamHandler, operationContext, allocator)
+    {
+    }
+
+    EchoStreamMessagesOperation::EchoStreamMessagesOperation(
+        ClientConnection &connection,
+        std::shared_ptr<EchoStreamMessagesStreamHandler> streamHandler,
+        const EchoStreamMessagesOperationContext &operationContext,
+        Aws::Crt::Allocator *allocator) noexcept
+        : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+          pinnedHandler(std::move(streamHandler))
     {
     }
 

--- a/eventstream_rpc/tests/include/awstest/EchoTestRpcClient.h
+++ b/eventstream_rpc/tests/include/awstest/EchoTestRpcClient.h
@@ -8,6 +8,8 @@
 
 #include <awstest/EchoTestRpcModel.h>
 
+#include <memory>
+
 using namespace Aws::Eventstreamrpc;
 
 namespace Awstest
@@ -26,10 +28,12 @@ namespace Awstest
             Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
         /**
          * Connect the client to the server
-         * @param lifecycleHandler An interface that is called upon when lifecycle events relating to the connection
-         * occur.
-         * @param connectionConfig The configuration parameters used for establishing the connection.
-         * @return An `RpcError` that can be used to check whether the connection was established.
+         * @param lifecycleHandler An interface that is called upon when lifecycle
+         * events relating to the connection occur.
+         * @param connectionConfig The configuration parameters used for establishing
+         * the connection.
+         * @return An `RpcError` that can be used to check whether the connection was
+         * established.
          */
         std::future<RpcError> Connect(
             ConnectionLifecycleHandler &lifecycleHandler,
@@ -37,12 +41,26 @@ namespace Awstest
         bool IsConnected() const noexcept { return m_connection.IsOpen(); }
         void Close() noexcept;
         GetAllProductsOperation NewGetAllProducts() noexcept;
+        std::unique_ptr<GetAllProductsOperation> NewPtrGetAllProducts() noexcept;
+
         CauseServiceErrorOperation NewCauseServiceError() noexcept;
+        std::unique_ptr<CauseServiceErrorOperation> NewPtrCauseServiceError() noexcept;
+
         CauseStreamServiceToErrorOperation NewCauseStreamServiceToError(
-            CauseStreamServiceToErrorStreamHandler &) noexcept;
-        EchoStreamMessagesOperation NewEchoStreamMessages(EchoStreamMessagesStreamHandler &) noexcept;
+            CauseStreamServiceToErrorStreamHandler &streamHandler) noexcept;
+        std::unique_ptr<CauseStreamServiceToErrorOperation> NewPtrCauseStreamServiceToError(
+            std::shared_ptr<CauseStreamServiceToErrorStreamHandler> streamHandler) noexcept;
+
+        EchoStreamMessagesOperation NewEchoStreamMessages(EchoStreamMessagesStreamHandler &streamHandler) noexcept;
+        std::unique_ptr<EchoStreamMessagesOperation> NewPtrEchoStreamMessages(
+            std::shared_ptr<EchoStreamMessagesStreamHandler> streamHandler) noexcept;
+
         EchoMessageOperation NewEchoMessage() noexcept;
+        std::unique_ptr<EchoMessageOperation> NewPtrEchoMessage() noexcept;
+
         GetAllCustomersOperation NewGetAllCustomers() noexcept;
+        std::unique_ptr<GetAllCustomersOperation> NewPtrGetAllCustomers() noexcept;
+
         ~EchoTestRpcClient() noexcept;
 
       private:

--- a/eventstream_rpc/tests/include/awstest/EchoTestRpcModel.h
+++ b/eventstream_rpc/tests/include/awstest/EchoTestRpcModel.h
@@ -11,6 +11,8 @@
 #include <aws/crt/DateTime.h>
 #include <awstest/Exports.h>
 
+#include <memory>
+
 using namespace Aws::Eventstreamrpc;
 
 namespace Awstest
@@ -61,7 +63,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(Customer *) noexcept;
-        /* This needs to be defined so that `Customer` can be used as a key in maps. */
+        /* This needs to be defined so that `Customer` can be used as a key in maps.
+         */
         bool operator<(const Customer &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -156,7 +159,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(MessageData *) noexcept;
-        /* This needs to be defined so that `MessageData` can be used as a key in maps. */
+        /* This needs to be defined so that `MessageData` can be used as a key in
+         * maps. */
         bool operator<(const MessageData &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -219,7 +223,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(EchoStreamingMessage *) noexcept;
-        /* This needs to be defined so that `EchoStreamingMessage` can be used as a key in maps. */
+        /* This needs to be defined so that `EchoStreamingMessage` can be used as a
+         * key in maps. */
         bool operator<(const EchoStreamingMessage &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -249,7 +254,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(GetAllProductsResponse *) noexcept;
-        /* This needs to be defined so that `GetAllProductsResponse` can be used as a key in maps. */
+        /* This needs to be defined so that `GetAllProductsResponse` can be used as a
+         * key in maps. */
         bool operator<(const GetAllProductsResponse &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -271,7 +277,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(GetAllProductsRequest *) noexcept;
-        /* This needs to be defined so that `GetAllProductsRequest` can be used as a key in maps. */
+        /* This needs to be defined so that `GetAllProductsRequest` can be used as a
+         * key in maps. */
         bool operator<(const GetAllProductsRequest &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -294,7 +301,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(GetAllCustomersResponse *) noexcept;
-        /* This needs to be defined so that `GetAllCustomersResponse` can be used as a key in maps. */
+        /* This needs to be defined so that `GetAllCustomersResponse` can be used as a
+         * key in maps. */
         bool operator<(const GetAllCustomersResponse &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -316,7 +324,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(GetAllCustomersRequest *) noexcept;
-        /* This needs to be defined so that `GetAllCustomersRequest` can be used as a key in maps. */
+        /* This needs to be defined so that `GetAllCustomersRequest` can be used as a
+         * key in maps. */
         bool operator<(const GetAllCustomersRequest &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -339,7 +348,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(EchoMessageResponse *) noexcept;
-        /* This needs to be defined so that `EchoMessageResponse` can be used as a key in maps. */
+        /* This needs to be defined so that `EchoMessageResponse` can be used as a key
+         * in maps. */
         bool operator<(const EchoMessageResponse &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -363,7 +373,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(EchoMessageRequest *) noexcept;
-        /* This needs to be defined so that `EchoMessageRequest` can be used as a key in maps. */
+        /* This needs to be defined so that `EchoMessageRequest` can be used as a key
+         * in maps. */
         bool operator<(const EchoMessageRequest &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -385,7 +396,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(EchoStreamingResponse *) noexcept;
-        /* This needs to be defined so that `EchoStreamingResponse` can be used as a key in maps. */
+        /* This needs to be defined so that `EchoStreamingResponse` can be used as a
+         * key in maps. */
         bool operator<(const EchoStreamingResponse &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -406,7 +418,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(EchoStreamingRequest *) noexcept;
-        /* This needs to be defined so that `EchoStreamingRequest` can be used as a key in maps. */
+        /* This needs to be defined so that `EchoStreamingRequest` can be used as a
+         * key in maps. */
         bool operator<(const EchoStreamingRequest &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -431,7 +444,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(ServiceError *) noexcept;
-        /* This needs to be defined so that `ServiceError` can be used as a key in maps. */
+        /* This needs to be defined so that `ServiceError` can be used as a key in
+         * maps. */
         bool operator<(const ServiceError &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -454,7 +468,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(CauseServiceErrorResponse *) noexcept;
-        /* This needs to be defined so that `CauseServiceErrorResponse` can be used as a key in maps. */
+        /* This needs to be defined so that `CauseServiceErrorResponse` can be used as
+         * a key in maps. */
         bool operator<(const CauseServiceErrorResponse &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -475,7 +490,8 @@ namespace Awstest
             Aws::Crt::StringView,
             Aws::Crt::Allocator *) noexcept;
         static void s_customDeleter(CauseServiceErrorRequest *) noexcept;
-        /* This needs to be defined so that `CauseServiceErrorRequest` can be used as a key in maps. */
+        /* This needs to be defined so that `CauseServiceErrorRequest` can be used as
+         * a key in maps. */
         bool operator<(const CauseServiceErrorRequest &) const noexcept;
         static const char *MODEL_NAME;
 
@@ -533,8 +549,10 @@ namespace Awstest
         /**
          * Used to activate a stream for the `GetAllProductsOperation`
          * @param request The request used for the `GetAllProductsOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const GetAllProductsRequest &request,
@@ -596,8 +614,10 @@ namespace Awstest
         /**
          * Used to activate a stream for the `CauseServiceErrorOperation`
          * @param request The request used for the `CauseServiceErrorOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const CauseServiceErrorRequest &request,
@@ -617,8 +637,10 @@ namespace Awstest
         virtual void OnStreamEvent(EchoStreamingMessage *response) { (void)response; }
 
         /**
-         * A callback that is invoked when an error occurs while parsing a message from the stream.
-         * @param rpcError The RPC error containing the status and possibly a CRT error.
+         * A callback that is invoked when an error occurs while parsing a message
+         * from the stream.
+         * @param rpcError The RPC error containing the status and possibly a CRT
+         * error.
          */
         virtual bool OnStreamError(RpcError rpcError)
         {
@@ -637,7 +659,8 @@ namespace Awstest
         }
 
         /**
-         * A callback that is invoked upon receiving ANY error response from the server.
+         * A callback that is invoked upon receiving ANY error response from the
+         * server.
          * @param operationError The error message being received.
          */
         virtual bool OnStreamError(OperationError *operationError)
@@ -652,7 +675,8 @@ namespace Awstest
          */
         void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
         /**
-         * Invoked when a message is received on this continuation but results in an error.
+         * Invoked when a message is received on this continuation but results in an
+         * error.
          *
          * This callback can return true so that the stream is closed afterwards.
          */
@@ -706,11 +730,19 @@ namespace Awstest
             CauseStreamServiceToErrorStreamHandler *streamHandler,
             const CauseStreamServiceToErrorOperationContext &operationContext,
             Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+        CauseStreamServiceToErrorOperation(
+            ClientConnection &connection,
+            std::shared_ptr<CauseStreamServiceToErrorStreamHandler> streamHandler,
+            const CauseStreamServiceToErrorOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
         /**
          * Used to activate a stream for the `CauseStreamServiceToErrorOperation`
-         * @param request The request used for the `CauseStreamServiceToErrorOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param request The request used for the
+         * `CauseStreamServiceToErrorOperation`
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const EchoStreamingRequest &request,
@@ -722,6 +754,9 @@ namespace Awstest
 
       protected:
         Aws::Crt::String GetModelName() const noexcept override;
+
+      private:
+        std::shared_ptr<CauseStreamServiceToErrorStreamHandler> pinnedHandler;
     };
 
     class EchoStreamMessagesStreamHandler : public StreamResponseHandler
@@ -730,8 +765,10 @@ namespace Awstest
         virtual void OnStreamEvent(EchoStreamingMessage *response) { (void)response; }
 
         /**
-         * A callback that is invoked when an error occurs while parsing a message from the stream.
-         * @param rpcError The RPC error containing the status and possibly a CRT error.
+         * A callback that is invoked when an error occurs while parsing a message
+         * from the stream.
+         * @param rpcError The RPC error containing the status and possibly a CRT
+         * error.
          */
         virtual bool OnStreamError(RpcError rpcError)
         {
@@ -740,7 +777,8 @@ namespace Awstest
         }
 
         /**
-         * A callback that is invoked upon receiving ANY error response from the server.
+         * A callback that is invoked upon receiving ANY error response from the
+         * server.
          * @param operationError The error message being received.
          */
         virtual bool OnStreamError(OperationError *operationError)
@@ -755,7 +793,8 @@ namespace Awstest
          */
         void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
         /**
-         * Invoked when a message is received on this continuation but results in an error.
+         * Invoked when a message is received on this continuation but results in an
+         * error.
          *
          * This callback can return true so that the stream is closed afterwards.
          */
@@ -807,11 +846,18 @@ namespace Awstest
             EchoStreamMessagesStreamHandler *streamHandler,
             const EchoStreamMessagesOperationContext &operationContext,
             Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+        EchoStreamMessagesOperation(
+            ClientConnection &connection,
+            std::shared_ptr<EchoStreamMessagesStreamHandler> streamHandler,
+            const EchoStreamMessagesOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
         /**
          * Used to activate a stream for the `EchoStreamMessagesOperation`
          * @param request The request used for the `EchoStreamMessagesOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const EchoStreamingRequest &request,
@@ -823,6 +869,9 @@ namespace Awstest
 
       protected:
         Aws::Crt::String GetModelName() const noexcept override;
+
+      private:
+        std::shared_ptr<EchoStreamMessagesStreamHandler> pinnedHandler;
     };
 
     class EchoMessageOperationContext : public OperationModelContext
@@ -873,8 +922,10 @@ namespace Awstest
         /**
          * Used to activate a stream for the `EchoMessageOperation`
          * @param request The request used for the `EchoMessageOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const EchoMessageRequest &request,
@@ -936,8 +987,10 @@ namespace Awstest
         /**
          * Used to activate a stream for the `GetAllCustomersOperation`
          * @param request The request used for the `GetAllCustomersOperation`
-         * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-         * @return An `RpcError` that can be used to check whether the stream was activated.
+         * @param onMessageFlushCallback An optional callback that is invoked when the
+         * request is flushed.
+         * @return An `RpcError` that can be used to check whether the stream was
+         * activated.
          */
         std::future<RpcError> Activate(
             const GetAllCustomersRequest &request,

--- a/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcClient.h
+++ b/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcClient.h
@@ -39,6 +39,10 @@ namespace Aws
             bool IsConnected() const noexcept { return m_connection.IsOpen(); }
             void Close() noexcept;
             SubscribeToIoTCoreOperation NewSubscribeToIoTCore(SubscribeToIoTCoreStreamHandler &) noexcept;
+
+            std::unique_ptr<SubscribeToIoTCoreOperation> NewPtrSubscribeToIoTCore(
+                std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler) noexcept;
+
             ResumeComponentOperation NewResumeComponent() noexcept;
             PublishToIoTCoreOperation NewPublishToIoTCore() noexcept;
             SubscribeToConfigurationUpdateOperation NewSubscribeToConfigurationUpdate(

--- a/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcClient.h
+++ b/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcClient.h
@@ -8,6 +8,8 @@
 
 #include <aws/greengrass/GreengrassCoreIpcModel.h>
 
+#include <memory>
+
 using namespace Aws::Eventstreamrpc;
 
 namespace Aws
@@ -28,51 +30,111 @@ namespace Aws
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
              * Connect the client to the server
-             * @param lifecycleHandler An interface that is called upon when lifecycle events relating to the connection
-             * occur.
-             * @param connectionConfig The configuration parameters used for establishing the connection.
-             * @return An `RpcError` that can be used to check whether the connection was established.
+             * @param lifecycleHandler An interface that is called upon when lifecycle
+             * events relating to the connection occur.
+             * @param connectionConfig The configuration parameters used for establishing
+             * the connection.
+             * @return An `RpcError` that can be used to check whether the connection was
+             * established.
              */
             std::future<RpcError> Connect(
                 ConnectionLifecycleHandler &lifecycleHandler,
                 const ConnectionConfig &connectionConfig = DefaultConnectionConfig()) noexcept;
             bool IsConnected() const noexcept { return m_connection.IsOpen(); }
             void Close() noexcept;
-            SubscribeToIoTCoreOperation NewSubscribeToIoTCore(SubscribeToIoTCoreStreamHandler &) noexcept;
-
+            SubscribeToIoTCoreOperation NewSubscribeToIoTCore(SubscribeToIoTCoreStreamHandler &streamHandler) noexcept;
             std::unique_ptr<SubscribeToIoTCoreOperation> NewPtrSubscribeToIoTCore(
                 std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler) noexcept;
 
             ResumeComponentOperation NewResumeComponent() noexcept;
+            std::unique_ptr<ResumeComponentOperation> NewPtrResumeComponent() noexcept;
+
             PublishToIoTCoreOperation NewPublishToIoTCore() noexcept;
+            std::unique_ptr<PublishToIoTCoreOperation> NewPtrPublishToIoTCore() noexcept;
+
             SubscribeToConfigurationUpdateOperation NewSubscribeToConfigurationUpdate(
-                SubscribeToConfigurationUpdateStreamHandler &) noexcept;
+                SubscribeToConfigurationUpdateStreamHandler &streamHandler) noexcept;
+            std::unique_ptr<SubscribeToConfigurationUpdateOperation> NewPtrSubscribeToConfigurationUpdate(
+                std::shared_ptr<SubscribeToConfigurationUpdateStreamHandler> streamHandler) noexcept;
+
             DeleteThingShadowOperation NewDeleteThingShadow() noexcept;
+            std::unique_ptr<DeleteThingShadowOperation> NewPtrDeleteThingShadow() noexcept;
+
             DeferComponentUpdateOperation NewDeferComponentUpdate() noexcept;
+            std::unique_ptr<DeferComponentUpdateOperation> NewPtrDeferComponentUpdate() noexcept;
+
             SubscribeToValidateConfigurationUpdatesOperation NewSubscribeToValidateConfigurationUpdates(
-                SubscribeToValidateConfigurationUpdatesStreamHandler &) noexcept;
+                SubscribeToValidateConfigurationUpdatesStreamHandler &streamHandler) noexcept;
+            std::unique_ptr<SubscribeToValidateConfigurationUpdatesOperation>
+                NewPtrSubscribeToValidateConfigurationUpdates(
+                    std::shared_ptr<SubscribeToValidateConfigurationUpdatesStreamHandler> streamHandler) noexcept;
+
             GetConfigurationOperation NewGetConfiguration() noexcept;
-            SubscribeToTopicOperation NewSubscribeToTopic(SubscribeToTopicStreamHandler &) noexcept;
+            std::unique_ptr<GetConfigurationOperation> NewPtrGetConfiguration() noexcept;
+
+            SubscribeToTopicOperation NewSubscribeToTopic(SubscribeToTopicStreamHandler &streamHandler) noexcept;
+            std::unique_ptr<SubscribeToTopicOperation> NewPtrSubscribeToTopic(
+                std::shared_ptr<SubscribeToTopicStreamHandler> streamHandler) noexcept;
+
             GetComponentDetailsOperation NewGetComponentDetails() noexcept;
+            std::unique_ptr<GetComponentDetailsOperation> NewPtrGetComponentDetails() noexcept;
+
             PublishToTopicOperation NewPublishToTopic() noexcept;
+            std::unique_ptr<PublishToTopicOperation> NewPtrPublishToTopic() noexcept;
+
             ListComponentsOperation NewListComponents() noexcept;
+            std::unique_ptr<ListComponentsOperation> NewPtrListComponents() noexcept;
+
             CreateDebugPasswordOperation NewCreateDebugPassword() noexcept;
+            std::unique_ptr<CreateDebugPasswordOperation> NewPtrCreateDebugPassword() noexcept;
+
             GetThingShadowOperation NewGetThingShadow() noexcept;
+            std::unique_ptr<GetThingShadowOperation> NewPtrGetThingShadow() noexcept;
+
             SendConfigurationValidityReportOperation NewSendConfigurationValidityReport() noexcept;
+            std::unique_ptr<SendConfigurationValidityReportOperation> NewPtrSendConfigurationValidityReport() noexcept;
+
             UpdateThingShadowOperation NewUpdateThingShadow() noexcept;
+            std::unique_ptr<UpdateThingShadowOperation> NewPtrUpdateThingShadow() noexcept;
+
             UpdateConfigurationOperation NewUpdateConfiguration() noexcept;
+            std::unique_ptr<UpdateConfigurationOperation> NewPtrUpdateConfiguration() noexcept;
+
             ValidateAuthorizationTokenOperation NewValidateAuthorizationToken() noexcept;
+            std::unique_ptr<ValidateAuthorizationTokenOperation> NewPtrValidateAuthorizationToken() noexcept;
+
             RestartComponentOperation NewRestartComponent() noexcept;
+            std::unique_ptr<RestartComponentOperation> NewPtrRestartComponent() noexcept;
+
             GetLocalDeploymentStatusOperation NewGetLocalDeploymentStatus() noexcept;
+            std::unique_ptr<GetLocalDeploymentStatusOperation> NewPtrGetLocalDeploymentStatus() noexcept;
+
             GetSecretValueOperation NewGetSecretValue() noexcept;
+            std::unique_ptr<GetSecretValueOperation> NewPtrGetSecretValue() noexcept;
+
             UpdateStateOperation NewUpdateState() noexcept;
+            std::unique_ptr<UpdateStateOperation> NewPtrUpdateState() noexcept;
+
             ListNamedShadowsForThingOperation NewListNamedShadowsForThing() noexcept;
+            std::unique_ptr<ListNamedShadowsForThingOperation> NewPtrListNamedShadowsForThing() noexcept;
+
             SubscribeToComponentUpdatesOperation NewSubscribeToComponentUpdates(
-                SubscribeToComponentUpdatesStreamHandler &) noexcept;
+                SubscribeToComponentUpdatesStreamHandler &streamHandler) noexcept;
+            std::unique_ptr<SubscribeToComponentUpdatesOperation> NewPtrSubscribeToComponentUpdates(
+                std::shared_ptr<SubscribeToComponentUpdatesStreamHandler> streamHandler) noexcept;
+
             ListLocalDeploymentsOperation NewListLocalDeployments() noexcept;
+            std::unique_ptr<ListLocalDeploymentsOperation> NewPtrListLocalDeployments() noexcept;
+
             StopComponentOperation NewStopComponent() noexcept;
+            std::unique_ptr<StopComponentOperation> NewPtrStopComponent() noexcept;
+
             PauseComponentOperation NewPauseComponent() noexcept;
+            std::unique_ptr<PauseComponentOperation> NewPtrPauseComponent() noexcept;
+
             CreateLocalDeploymentOperation NewCreateLocalDeployment() noexcept;
+            std::unique_ptr<CreateLocalDeploymentOperation> NewPtrCreateLocalDeployment() noexcept;
+
             ~GreengrassCoreIpcClient() noexcept;
 
           private:

--- a/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcModel.h
+++ b/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcModel.h
@@ -11,6 +11,8 @@
 #include <aws/crt/DateTime.h>
 #include <aws/greengrass/Exports.h>
 
+#include <memory>
+
 using namespace Aws::Eventstreamrpc;
 
 namespace Aws
@@ -34,7 +36,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SystemResourceLimits *) noexcept;
-            /* This needs to be defined so that `SystemResourceLimits` can be used as a key in maps. */
+            /* This needs to be defined so that `SystemResourceLimits` can be used as a
+             * key in maps. */
             bool operator<(const SystemResourceLimits &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -64,7 +67,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ValidateConfigurationUpdateEvent *) noexcept;
-            /* This needs to be defined so that `ValidateConfigurationUpdateEvent` can be used as a key in maps. */
+            /* This needs to be defined so that `ValidateConfigurationUpdateEvent` can be
+             * used as a key in maps. */
             bool operator<(const ValidateConfigurationUpdateEvent &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -91,7 +95,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(MQTTMessage *) noexcept;
-            /* This needs to be defined so that `MQTTMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `MQTTMessage` can be used as a key in
+             * maps. */
             bool operator<(const MQTTMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -118,7 +123,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ConfigurationUpdateEvent *) noexcept;
-            /* This needs to be defined so that `ConfigurationUpdateEvent` can be used as a key in maps. */
+            /* This needs to be defined so that `ConfigurationUpdateEvent` can be used as
+             * a key in maps. */
             bool operator<(const ConfigurationUpdateEvent &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -143,7 +149,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PostComponentUpdateEvent *) noexcept;
-            /* This needs to be defined so that `PostComponentUpdateEvent` can be used as a key in maps. */
+            /* This needs to be defined so that `PostComponentUpdateEvent` can be used as
+             * a key in maps. */
             bool operator<(const PostComponentUpdateEvent &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -169,7 +176,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PreComponentUpdateEvent *) noexcept;
-            /* This needs to be defined so that `PreComponentUpdateEvent` can be used as a key in maps. */
+            /* This needs to be defined so that `PreComponentUpdateEvent` can be used as a
+             * key in maps. */
             bool operator<(const PreComponentUpdateEvent &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -200,7 +208,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(BinaryMessage *) noexcept;
-            /* This needs to be defined so that `BinaryMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `BinaryMessage` can be used as a key in
+             * maps. */
             bool operator<(const BinaryMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -224,7 +233,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(JsonMessage *) noexcept;
-            /* This needs to be defined so that `JsonMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `JsonMessage` can be used as a key in
+             * maps. */
             bool operator<(const JsonMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -278,7 +288,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(RunWithInfo *) noexcept;
-            /* This needs to be defined so that `RunWithInfo` can be used as a key in maps. */
+            /* This needs to be defined so that `RunWithInfo` can be used as a key in
+             * maps. */
             bool operator<(const RunWithInfo &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -329,7 +340,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ValidateConfigurationUpdateEvents *) noexcept;
-            /* This needs to be defined so that `ValidateConfigurationUpdateEvents` can be used as a key in maps. */
+            /* This needs to be defined so that `ValidateConfigurationUpdateEvents` can be
+             * used as a key in maps. */
             bool operator<(const ValidateConfigurationUpdateEvents &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -388,7 +400,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscriptionResponseMessage *) noexcept;
-            /* This needs to be defined so that `SubscriptionResponseMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscriptionResponseMessage` can be used
+             * as a key in maps. */
             bool operator<(const SubscriptionResponseMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -433,7 +446,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(IoTCoreMessage *) noexcept;
-            /* This needs to be defined so that `IoTCoreMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `IoTCoreMessage` can be used as a key in
+             * maps. */
             bool operator<(const IoTCoreMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -476,7 +490,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ConfigurationUpdateEvents *) noexcept;
-            /* This needs to be defined so that `ConfigurationUpdateEvents` can be used as a key in maps. */
+            /* This needs to be defined so that `ConfigurationUpdateEvents` can be used as
+             * a key in maps. */
             bool operator<(const ConfigurationUpdateEvents &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -535,7 +550,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ComponentUpdatePolicyEvents *) noexcept;
-            /* This needs to be defined so that `ComponentUpdatePolicyEvents` can be used as a key in maps. */
+            /* This needs to be defined so that `ComponentUpdatePolicyEvents` can be used
+             * as a key in maps. */
             bool operator<(const ComponentUpdatePolicyEvents &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -569,7 +585,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ConfigurationValidityReport *) noexcept;
-            /* This needs to be defined so that `ConfigurationValidityReport` can be used as a key in maps. */
+            /* This needs to be defined so that `ConfigurationValidityReport` can be used
+             * as a key in maps. */
             bool operator<(const ConfigurationValidityReport &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -632,7 +649,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PublishMessage *) noexcept;
-            /* This needs to be defined so that `PublishMessage` can be used as a key in maps. */
+            /* This needs to be defined so that `PublishMessage` can be used as a key in
+             * maps. */
             bool operator<(const PublishMessage &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -699,7 +717,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SecretValue *) noexcept;
-            /* This needs to be defined so that `SecretValue` can be used as a key in maps. */
+            /* This needs to be defined so that `SecretValue` can be used as a key in
+             * maps. */
             bool operator<(const SecretValue &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -731,7 +750,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(LocalDeployment *) noexcept;
-            /* This needs to be defined so that `LocalDeployment` can be used as a key in maps. */
+            /* This needs to be defined so that `LocalDeployment` can be used as a key in
+             * maps. */
             bool operator<(const LocalDeployment &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -765,7 +785,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ComponentDetails *) noexcept;
-            /* This needs to be defined so that `ComponentDetails` can be used as a key in maps. */
+            /* This needs to be defined so that `ComponentDetails` can be used as a key in
+             * maps. */
             bool operator<(const ComponentDetails &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -792,7 +813,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(InvalidTokenError *) noexcept;
-            /* This needs to be defined so that `InvalidTokenError` can be used as a key in maps. */
+            /* This needs to be defined so that `InvalidTokenError` can be used as a key
+             * in maps. */
             bool operator<(const InvalidTokenError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -816,7 +838,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ValidateAuthorizationTokenResponse *) noexcept;
-            /* This needs to be defined so that `ValidateAuthorizationTokenResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `ValidateAuthorizationTokenResponse` can
+             * be used as a key in maps. */
             bool operator<(const ValidateAuthorizationTokenResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -840,7 +863,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ValidateAuthorizationTokenRequest *) noexcept;
-            /* This needs to be defined so that `ValidateAuthorizationTokenRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `ValidateAuthorizationTokenRequest` can be
+             * used as a key in maps. */
             bool operator<(const ValidateAuthorizationTokenRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -864,7 +888,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateThingShadowResponse *) noexcept;
-            /* This needs to be defined so that `UpdateThingShadowResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateThingShadowResponse` can be used as
+             * a key in maps. */
             bool operator<(const UpdateThingShadowResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -892,7 +917,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateThingShadowRequest *) noexcept;
-            /* This needs to be defined so that `UpdateThingShadowRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateThingShadowRequest` can be used as
+             * a key in maps. */
             bool operator<(const UpdateThingShadowRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -916,7 +942,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateStateResponse *) noexcept;
-            /* This needs to be defined so that `UpdateStateResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateStateResponse` can be used as a key
+             * in maps. */
             bool operator<(const UpdateStateResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -939,7 +966,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateStateRequest *) noexcept;
-            /* This needs to be defined so that `UpdateStateRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateStateRequest` can be used as a key
+             * in maps. */
             bool operator<(const UpdateStateRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -963,7 +991,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(FailedUpdateConditionCheckError *) noexcept;
-            /* This needs to be defined so that `FailedUpdateConditionCheckError` can be used as a key in maps. */
+            /* This needs to be defined so that `FailedUpdateConditionCheckError` can be
+             * used as a key in maps. */
             bool operator<(const FailedUpdateConditionCheckError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -987,7 +1016,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ConflictError *) noexcept;
-            /* This needs to be defined so that `ConflictError` can be used as a key in maps. */
+            /* This needs to be defined so that `ConflictError` can be used as a key in
+             * maps. */
             bool operator<(const ConflictError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1009,7 +1039,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateConfigurationResponse *) noexcept;
-            /* This needs to be defined so that `UpdateConfigurationResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateConfigurationResponse` can be used
+             * as a key in maps. */
             bool operator<(const UpdateConfigurationResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1036,7 +1067,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UpdateConfigurationRequest *) noexcept;
-            /* This needs to be defined so that `UpdateConfigurationRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `UpdateConfigurationRequest` can be used
+             * as a key in maps. */
             bool operator<(const UpdateConfigurationRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1063,8 +1095,9 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToValidateConfigurationUpdatesResponse *) noexcept;
-            /* This needs to be defined so that `SubscribeToValidateConfigurationUpdatesResponse` can be used as a key
-             * in maps. */
+            /* This needs to be defined so that
+             * `SubscribeToValidateConfigurationUpdatesResponse` can be used as a key in
+             * maps. */
             bool operator<(const SubscribeToValidateConfigurationUpdatesResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1088,7 +1121,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToValidateConfigurationUpdatesRequest *) noexcept;
-            /* This needs to be defined so that `SubscribeToValidateConfigurationUpdatesRequest` can be used as a key in
+            /* This needs to be defined so that
+             * `SubscribeToValidateConfigurationUpdatesRequest` can be used as a key in
              * maps. */
             bool operator<(const SubscribeToValidateConfigurationUpdatesRequest &) const noexcept;
             static const char *MODEL_NAME;
@@ -1112,7 +1146,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToTopicResponse *) noexcept;
-            /* This needs to be defined so that `SubscribeToTopicResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToTopicResponse` can be used as
+             * a key in maps. */
             bool operator<(const SubscribeToTopicResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1136,7 +1171,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToTopicRequest *) noexcept;
-            /* This needs to be defined so that `SubscribeToTopicRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToTopicRequest` can be used as a
+             * key in maps. */
             bool operator<(const SubscribeToTopicRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1158,7 +1194,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToIoTCoreResponse *) noexcept;
-            /* This needs to be defined so that `SubscribeToIoTCoreResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToIoTCoreResponse` can be used
+             * as a key in maps. */
             bool operator<(const SubscribeToIoTCoreResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1183,7 +1220,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToIoTCoreRequest *) noexcept;
-            /* This needs to be defined so that `SubscribeToIoTCoreRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToIoTCoreRequest` can be used as
+             * a key in maps. */
             bool operator<(const SubscribeToIoTCoreRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1208,8 +1246,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToConfigurationUpdateResponse *) noexcept;
-            /* This needs to be defined so that `SubscribeToConfigurationUpdateResponse` can be used as a key in maps.
-             */
+            /* This needs to be defined so that `SubscribeToConfigurationUpdateResponse`
+             * can be used as a key in maps. */
             bool operator<(const SubscribeToConfigurationUpdateResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1236,7 +1274,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToConfigurationUpdateRequest *) noexcept;
-            /* This needs to be defined so that `SubscribeToConfigurationUpdateRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToConfigurationUpdateRequest`
+             * can be used as a key in maps. */
             bool operator<(const SubscribeToConfigurationUpdateRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1259,7 +1298,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToComponentUpdatesResponse *) noexcept;
-            /* This needs to be defined so that `SubscribeToComponentUpdatesResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToComponentUpdatesResponse` can
+             * be used as a key in maps. */
             bool operator<(const SubscribeToComponentUpdatesResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1280,7 +1320,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SubscribeToComponentUpdatesRequest *) noexcept;
-            /* This needs to be defined so that `SubscribeToComponentUpdatesRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `SubscribeToComponentUpdatesRequest` can
+             * be used as a key in maps. */
             bool operator<(const SubscribeToComponentUpdatesRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1305,7 +1346,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(StopComponentResponse *) noexcept;
-            /* This needs to be defined so that `StopComponentResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `StopComponentResponse` can be used as a
+             * key in maps. */
             bool operator<(const StopComponentResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1330,7 +1372,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(StopComponentRequest *) noexcept;
-            /* This needs to be defined so that `StopComponentRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `StopComponentRequest` can be used as a
+             * key in maps. */
             bool operator<(const StopComponentRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1354,8 +1397,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SendConfigurationValidityReportResponse *) noexcept;
-            /* This needs to be defined so that `SendConfigurationValidityReportResponse` can be used as a key in maps.
-             */
+            /* This needs to be defined so that `SendConfigurationValidityReportResponse`
+             * can be used as a key in maps. */
             bool operator<(const SendConfigurationValidityReportResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1386,8 +1429,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(SendConfigurationValidityReportRequest *) noexcept;
-            /* This needs to be defined so that `SendConfigurationValidityReportRequest` can be used as a key in maps.
-             */
+            /* This needs to be defined so that `SendConfigurationValidityReportRequest`
+             * can be used as a key in maps. */
             bool operator<(const SendConfigurationValidityReportRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1409,7 +1452,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ResumeComponentResponse *) noexcept;
-            /* This needs to be defined so that `ResumeComponentResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `ResumeComponentResponse` can be used as a
+             * key in maps. */
             bool operator<(const ResumeComponentResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1432,7 +1476,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ResumeComponentRequest *) noexcept;
-            /* This needs to be defined so that `ResumeComponentRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `ResumeComponentRequest` can be used as a
+             * key in maps. */
             bool operator<(const ResumeComponentRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1456,7 +1501,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ComponentNotFoundError *) noexcept;
-            /* This needs to be defined so that `ComponentNotFoundError` can be used as a key in maps. */
+            /* This needs to be defined so that `ComponentNotFoundError` can be used as a
+             * key in maps. */
             bool operator<(const ComponentNotFoundError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1482,7 +1528,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(RestartComponentResponse *) noexcept;
-            /* This needs to be defined so that `RestartComponentResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `RestartComponentResponse` can be used as
+             * a key in maps. */
             bool operator<(const RestartComponentResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1507,7 +1554,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(RestartComponentRequest *) noexcept;
-            /* This needs to be defined so that `RestartComponentRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `RestartComponentRequest` can be used as a
+             * key in maps. */
             bool operator<(const RestartComponentRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1529,7 +1577,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PublishToTopicResponse *) noexcept;
-            /* This needs to be defined so that `PublishToTopicResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `PublishToTopicResponse` can be used as a
+             * key in maps. */
             bool operator<(const PublishToTopicResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1554,7 +1603,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PublishToTopicRequest *) noexcept;
-            /* This needs to be defined so that `PublishToTopicRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `PublishToTopicRequest` can be used as a
+             * key in maps. */
             bool operator<(const PublishToTopicRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1577,7 +1627,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PublishToIoTCoreResponse *) noexcept;
-            /* This needs to be defined so that `PublishToIoTCoreResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `PublishToIoTCoreResponse` can be used as
+             * a key in maps. */
             bool operator<(const PublishToIoTCoreResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1604,7 +1655,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PublishToIoTCoreRequest *) noexcept;
-            /* This needs to be defined so that `PublishToIoTCoreRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `PublishToIoTCoreRequest` can be used as a
+             * key in maps. */
             bool operator<(const PublishToIoTCoreRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1628,7 +1680,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PauseComponentResponse *) noexcept;
-            /* This needs to be defined so that `PauseComponentResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `PauseComponentResponse` can be used as a
+             * key in maps. */
             bool operator<(const PauseComponentResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1651,7 +1704,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(PauseComponentRequest *) noexcept;
-            /* This needs to be defined so that `PauseComponentRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `PauseComponentRequest` can be used as a
+             * key in maps. */
             bool operator<(const PauseComponentRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1679,7 +1733,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListNamedShadowsForThingResponse *) noexcept;
-            /* This needs to be defined so that `ListNamedShadowsForThingResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `ListNamedShadowsForThingResponse` can be
+             * used as a key in maps. */
             bool operator<(const ListNamedShadowsForThingResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1709,7 +1764,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListNamedShadowsForThingRequest *) noexcept;
-            /* This needs to be defined so that `ListNamedShadowsForThingRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `ListNamedShadowsForThingRequest` can be
+             * used as a key in maps. */
             bool operator<(const ListNamedShadowsForThingRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1741,7 +1797,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListLocalDeploymentsResponse *) noexcept;
-            /* This needs to be defined so that `ListLocalDeploymentsResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `ListLocalDeploymentsResponse` can be used
+             * as a key in maps. */
             bool operator<(const ListLocalDeploymentsResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1763,7 +1820,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListLocalDeploymentsRequest *) noexcept;
-            /* This needs to be defined so that `ListLocalDeploymentsRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `ListLocalDeploymentsRequest` can be used
+             * as a key in maps. */
             bool operator<(const ListLocalDeploymentsRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1789,7 +1847,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListComponentsResponse *) noexcept;
-            /* This needs to be defined so that `ListComponentsResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `ListComponentsResponse` can be used as a
+             * key in maps. */
             bool operator<(const ListComponentsResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1811,7 +1870,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ListComponentsRequest *) noexcept;
-            /* This needs to be defined so that `ListComponentsRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `ListComponentsRequest` can be used as a
+             * key in maps. */
             bool operator<(const ListComponentsRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1834,7 +1894,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetThingShadowResponse *) noexcept;
-            /* This needs to be defined so that `GetThingShadowResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `GetThingShadowResponse` can be used as a
+             * key in maps. */
             bool operator<(const GetThingShadowResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1860,7 +1921,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetThingShadowRequest *) noexcept;
-            /* This needs to be defined so that `GetThingShadowRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `GetThingShadowRequest` can be used as a
+             * key in maps. */
             bool operator<(const GetThingShadowRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1894,7 +1956,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetSecretValueResponse *) noexcept;
-            /* This needs to be defined so that `GetSecretValueResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `GetSecretValueResponse` can be used as a
+             * key in maps. */
             bool operator<(const GetSecretValueResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1925,7 +1988,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetSecretValueRequest *) noexcept;
-            /* This needs to be defined so that `GetSecretValueRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `GetSecretValueRequest` can be used as a
+             * key in maps. */
             bool operator<(const GetSecretValueRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1951,7 +2015,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetLocalDeploymentStatusResponse *) noexcept;
-            /* This needs to be defined so that `GetLocalDeploymentStatusResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `GetLocalDeploymentStatusResponse` can be
+             * used as a key in maps. */
             bool operator<(const GetLocalDeploymentStatusResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -1975,7 +2040,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetLocalDeploymentStatusRequest *) noexcept;
-            /* This needs to be defined so that `GetLocalDeploymentStatusRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `GetLocalDeploymentStatusRequest` can be
+             * used as a key in maps. */
             bool operator<(const GetLocalDeploymentStatusRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2001,7 +2067,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetConfigurationResponse *) noexcept;
-            /* This needs to be defined so that `GetConfigurationResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `GetConfigurationResponse` can be used as
+             * a key in maps. */
             bool operator<(const GetConfigurationResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2028,7 +2095,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetConfigurationRequest *) noexcept;
-            /* This needs to be defined so that `GetConfigurationRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `GetConfigurationRequest` can be used as a
+             * key in maps. */
             bool operator<(const GetConfigurationRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2056,7 +2124,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetComponentDetailsResponse *) noexcept;
-            /* This needs to be defined so that `GetComponentDetailsResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `GetComponentDetailsResponse` can be used
+             * as a key in maps. */
             bool operator<(const GetComponentDetailsResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2080,7 +2149,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(GetComponentDetailsRequest *) noexcept;
-            /* This needs to be defined so that `GetComponentDetailsRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `GetComponentDetailsRequest` can be used
+             * as a key in maps. */
             bool operator<(const GetComponentDetailsRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2104,7 +2174,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(DeleteThingShadowResponse *) noexcept;
-            /* This needs to be defined so that `DeleteThingShadowResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `DeleteThingShadowResponse` can be used as
+             * a key in maps. */
             bool operator<(const DeleteThingShadowResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2130,7 +2201,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(DeleteThingShadowRequest *) noexcept;
-            /* This needs to be defined so that `DeleteThingShadowRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `DeleteThingShadowRequest` can be used as
+             * a key in maps. */
             bool operator<(const DeleteThingShadowRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2159,7 +2231,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ResourceNotFoundError *) noexcept;
-            /* This needs to be defined so that `ResourceNotFoundError` can be used as a key in maps. */
+            /* This needs to be defined so that `ResourceNotFoundError` can be used as a
+             * key in maps. */
             bool operator<(const ResourceNotFoundError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2183,7 +2256,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(DeferComponentUpdateResponse *) noexcept;
-            /* This needs to be defined so that `DeferComponentUpdateResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `DeferComponentUpdateResponse` can be used
+             * as a key in maps. */
             bool operator<(const DeferComponentUpdateResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2210,7 +2284,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(DeferComponentUpdateRequest *) noexcept;
-            /* This needs to be defined so that `DeferComponentUpdateRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `DeferComponentUpdateRequest` can be used
+             * as a key in maps. */
             bool operator<(const DeferComponentUpdateRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2236,7 +2311,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(InvalidArgumentsError *) noexcept;
-            /* This needs to be defined so that `InvalidArgumentsError` can be used as a key in maps. */
+            /* This needs to be defined so that `InvalidArgumentsError` can be used as a
+             * key in maps. */
             bool operator<(const InvalidArgumentsError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2260,7 +2336,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(InvalidArtifactsDirectoryPathError *) noexcept;
-            /* This needs to be defined so that `InvalidArtifactsDirectoryPathError` can be used as a key in maps. */
+            /* This needs to be defined so that `InvalidArtifactsDirectoryPathError` can
+             * be used as a key in maps. */
             bool operator<(const InvalidArtifactsDirectoryPathError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2284,7 +2361,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(InvalidRecipeDirectoryPathError *) noexcept;
-            /* This needs to be defined so that `InvalidRecipeDirectoryPathError` can be used as a key in maps. */
+            /* This needs to be defined so that `InvalidRecipeDirectoryPathError` can be
+             * used as a key in maps. */
             bool operator<(const InvalidRecipeDirectoryPathError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2308,7 +2386,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(CreateLocalDeploymentResponse *) noexcept;
-            /* This needs to be defined so that `CreateLocalDeploymentResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `CreateLocalDeploymentResponse` can be
+             * used as a key in maps. */
             bool operator<(const CreateLocalDeploymentResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2382,7 +2461,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(CreateLocalDeploymentRequest *) noexcept;
-            /* This needs to be defined so that `CreateLocalDeploymentRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `CreateLocalDeploymentRequest` can be used
+             * as a key in maps. */
             bool operator<(const CreateLocalDeploymentRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2412,7 +2492,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(ServiceError *) noexcept;
-            /* This needs to be defined so that `ServiceError` can be used as a key in maps. */
+            /* This needs to be defined so that `ServiceError` can be used as a key in
+             * maps. */
             bool operator<(const ServiceError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2436,7 +2517,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(UnauthorizedError *) noexcept;
-            /* This needs to be defined so that `UnauthorizedError` can be used as a key in maps. */
+            /* This needs to be defined so that `UnauthorizedError` can be used as a key
+             * in maps. */
             bool operator<(const UnauthorizedError &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2477,7 +2559,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(CreateDebugPasswordResponse *) noexcept;
-            /* This needs to be defined so that `CreateDebugPasswordResponse` can be used as a key in maps. */
+            /* This needs to be defined so that `CreateDebugPasswordResponse` can be used
+             * as a key in maps. */
             bool operator<(const CreateDebugPasswordResponse &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2503,7 +2586,8 @@ namespace Aws
                 Aws::Crt::StringView,
                 Aws::Crt::Allocator *) noexcept;
             static void s_customDeleter(CreateDebugPasswordRequest *) noexcept;
-            /* This needs to be defined so that `CreateDebugPasswordRequest` can be used as a key in maps. */
+            /* This needs to be defined so that `CreateDebugPasswordRequest` can be used
+             * as a key in maps. */
             bool operator<(const CreateDebugPasswordRequest &) const noexcept;
             static const char *MODEL_NAME;
 
@@ -2519,8 +2603,10 @@ namespace Aws
             virtual void OnStreamEvent(IoTCoreMessage *response) { (void)response; }
 
             /**
-             * A callback that is invoked when an error occurs while parsing a message from the stream.
-             * @param rpcError The RPC error containing the status and possibly a CRT error.
+             * A callback that is invoked when an error occurs while parsing a message
+             * from the stream.
+             * @param rpcError The RPC error containing the status and possibly a CRT
+             * error.
              */
             virtual bool OnStreamError(RpcError rpcError)
             {
@@ -2539,7 +2625,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving an error of type `UnauthorizedError`.
+             * A callback that is invoked upon receiving an error of type
+             * `UnauthorizedError`.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(UnauthorizedError *operationError)
@@ -2549,7 +2636,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving ANY error response from the server.
+             * A callback that is invoked upon receiving ANY error response from the
+             * server.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(OperationError *operationError)
@@ -2564,7 +2652,8 @@ namespace Aws
              */
             void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
             /**
-             * Invoked when a message is received on this continuation but results in an error.
+             * Invoked when a message is received on this continuation but results in an
+             * error.
              *
              * This callback can return true so that the stream is closed afterwards.
              */
@@ -2616,18 +2705,18 @@ namespace Aws
                 SubscribeToIoTCoreStreamHandler *streamHandler,
                 const SubscribeToIoTCoreOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
-
             SubscribeToIoTCoreOperation(
                 ClientConnection &connection,
                 std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler,
                 const SubscribeToIoTCoreOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
-
             /**
              * Used to activate a stream for the `SubscribeToIoTCoreOperation`
              * @param request The request used for the `SubscribeToIoTCoreOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SubscribeToIoTCoreRequest &request,
@@ -2692,8 +2781,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `ResumeComponentOperation`
              * @param request The request used for the `ResumeComponentOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const ResumeComponentRequest &request,
@@ -2755,8 +2846,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `PublishToIoTCoreOperation`
              * @param request The request used for the `PublishToIoTCoreOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const PublishToIoTCoreRequest &request,
@@ -2776,8 +2869,10 @@ namespace Aws
             virtual void OnStreamEvent(ConfigurationUpdateEvents *response) { (void)response; }
 
             /**
-             * A callback that is invoked when an error occurs while parsing a message from the stream.
-             * @param rpcError The RPC error containing the status and possibly a CRT error.
+             * A callback that is invoked when an error occurs while parsing a message
+             * from the stream.
+             * @param rpcError The RPC error containing the status and possibly a CRT
+             * error.
              */
             virtual bool OnStreamError(RpcError rpcError)
             {
@@ -2796,7 +2891,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving an error of type `ResourceNotFoundError`.
+             * A callback that is invoked upon receiving an error of type
+             * `ResourceNotFoundError`.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(ResourceNotFoundError *operationError)
@@ -2806,7 +2902,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving ANY error response from the server.
+             * A callback that is invoked upon receiving ANY error response from the
+             * server.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(OperationError *operationError)
@@ -2821,7 +2918,8 @@ namespace Aws
              */
             void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
             /**
-             * Invoked when a message is received on this continuation but results in an error.
+             * Invoked when a message is received on this continuation but results in an
+             * error.
              *
              * This callback can return true so that the stream is closed afterwards.
              */
@@ -2876,11 +2974,19 @@ namespace Aws
                 SubscribeToConfigurationUpdateStreamHandler *streamHandler,
                 const SubscribeToConfigurationUpdateOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+            SubscribeToConfigurationUpdateOperation(
+                ClientConnection &connection,
+                std::shared_ptr<SubscribeToConfigurationUpdateStreamHandler> streamHandler,
+                const SubscribeToConfigurationUpdateOperationContext &operationContext,
+                Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
              * Used to activate a stream for the `SubscribeToConfigurationUpdateOperation`
-             * @param request The request used for the `SubscribeToConfigurationUpdateOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param request The request used for the
+             * `SubscribeToConfigurationUpdateOperation`
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SubscribeToConfigurationUpdateRequest &request,
@@ -2892,6 +2998,9 @@ namespace Aws
 
           protected:
             Aws::Crt::String GetModelName() const noexcept override;
+
+          private:
+            std::shared_ptr<SubscribeToConfigurationUpdateStreamHandler> pinnedHandler;
         };
 
         class DeleteThingShadowOperationContext : public OperationModelContext
@@ -2942,8 +3051,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `DeleteThingShadowOperation`
              * @param request The request used for the `DeleteThingShadowOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const DeleteThingShadowRequest &request,
@@ -3007,8 +3118,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `DeferComponentUpdateOperation`
              * @param request The request used for the `DeferComponentUpdateOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const DeferComponentUpdateRequest &request,
@@ -3028,8 +3141,10 @@ namespace Aws
             virtual void OnStreamEvent(ValidateConfigurationUpdateEvents *response) { (void)response; }
 
             /**
-             * A callback that is invoked when an error occurs while parsing a message from the stream.
-             * @param rpcError The RPC error containing the status and possibly a CRT error.
+             * A callback that is invoked when an error occurs while parsing a message
+             * from the stream.
+             * @param rpcError The RPC error containing the status and possibly a CRT
+             * error.
              */
             virtual bool OnStreamError(RpcError rpcError)
             {
@@ -3048,7 +3163,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving ANY error response from the server.
+             * A callback that is invoked upon receiving ANY error response from the
+             * server.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(OperationError *operationError)
@@ -3063,7 +3179,8 @@ namespace Aws
              */
             void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
             /**
-             * Invoked when a message is received on this continuation but results in an error.
+             * Invoked when a message is received on this continuation but results in an
+             * error.
              *
              * This callback can return true so that the stream is closed afterwards.
              */
@@ -3120,11 +3237,20 @@ namespace Aws
                 SubscribeToValidateConfigurationUpdatesStreamHandler *streamHandler,
                 const SubscribeToValidateConfigurationUpdatesOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+            SubscribeToValidateConfigurationUpdatesOperation(
+                ClientConnection &connection,
+                std::shared_ptr<SubscribeToValidateConfigurationUpdatesStreamHandler> streamHandler,
+                const SubscribeToValidateConfigurationUpdatesOperationContext &operationContext,
+                Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
-             * Used to activate a stream for the `SubscribeToValidateConfigurationUpdatesOperation`
-             * @param request The request used for the `SubscribeToValidateConfigurationUpdatesOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * Used to activate a stream for the
+             * `SubscribeToValidateConfigurationUpdatesOperation`
+             * @param request The request used for the
+             * `SubscribeToValidateConfigurationUpdatesOperation`
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SubscribeToValidateConfigurationUpdatesRequest &request,
@@ -3136,6 +3262,9 @@ namespace Aws
 
           protected:
             Aws::Crt::String GetModelName() const noexcept override;
+
+          private:
+            std::shared_ptr<SubscribeToValidateConfigurationUpdatesStreamHandler> pinnedHandler;
         };
 
         class GetConfigurationOperationContext : public OperationModelContext
@@ -3186,8 +3315,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `GetConfigurationOperation`
              * @param request The request used for the `GetConfigurationOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const GetConfigurationRequest &request,
@@ -3207,8 +3338,10 @@ namespace Aws
             virtual void OnStreamEvent(SubscriptionResponseMessage *response) { (void)response; }
 
             /**
-             * A callback that is invoked when an error occurs while parsing a message from the stream.
-             * @param rpcError The RPC error containing the status and possibly a CRT error.
+             * A callback that is invoked when an error occurs while parsing a message
+             * from the stream.
+             * @param rpcError The RPC error containing the status and possibly a CRT
+             * error.
              */
             virtual bool OnStreamError(RpcError rpcError)
             {
@@ -3217,7 +3350,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving an error of type `InvalidArgumentsError`.
+             * A callback that is invoked upon receiving an error of type
+             * `InvalidArgumentsError`.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(InvalidArgumentsError *operationError)
@@ -3237,7 +3371,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving an error of type `UnauthorizedError`.
+             * A callback that is invoked upon receiving an error of type
+             * `UnauthorizedError`.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(UnauthorizedError *operationError)
@@ -3247,7 +3382,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving ANY error response from the server.
+             * A callback that is invoked upon receiving ANY error response from the
+             * server.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(OperationError *operationError)
@@ -3262,7 +3398,8 @@ namespace Aws
              */
             void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
             /**
-             * Invoked when a message is received on this continuation but results in an error.
+             * Invoked when a message is received on this continuation but results in an
+             * error.
              *
              * This callback can return true so that the stream is closed afterwards.
              */
@@ -3314,11 +3451,18 @@ namespace Aws
                 SubscribeToTopicStreamHandler *streamHandler,
                 const SubscribeToTopicOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+            SubscribeToTopicOperation(
+                ClientConnection &connection,
+                std::shared_ptr<SubscribeToTopicStreamHandler> streamHandler,
+                const SubscribeToTopicOperationContext &operationContext,
+                Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
              * Used to activate a stream for the `SubscribeToTopicOperation`
              * @param request The request used for the `SubscribeToTopicOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SubscribeToTopicRequest &request,
@@ -3330,6 +3474,9 @@ namespace Aws
 
           protected:
             Aws::Crt::String GetModelName() const noexcept override;
+
+          private:
+            std::shared_ptr<SubscribeToTopicStreamHandler> pinnedHandler;
         };
 
         class GetComponentDetailsOperationContext : public OperationModelContext
@@ -3380,8 +3527,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `GetComponentDetailsOperation`
              * @param request The request used for the `GetComponentDetailsOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const GetComponentDetailsRequest &request,
@@ -3443,8 +3592,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `PublishToTopicOperation`
              * @param request The request used for the `PublishToTopicOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const PublishToTopicRequest &request,
@@ -3506,8 +3657,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `ListComponentsOperation`
              * @param request The request used for the `ListComponentsOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const ListComponentsRequest &request,
@@ -3569,8 +3722,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `CreateDebugPasswordOperation`
              * @param request The request used for the `CreateDebugPasswordOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const CreateDebugPasswordRequest &request,
@@ -3632,8 +3787,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `GetThingShadowOperation`
              * @param request The request used for the `GetThingShadowOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const GetThingShadowRequest &request,
@@ -3696,10 +3853,14 @@ namespace Aws
                 const SendConfigurationValidityReportOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
-             * Used to activate a stream for the `SendConfigurationValidityReportOperation`
-             * @param request The request used for the `SendConfigurationValidityReportOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * Used to activate a stream for the
+             * `SendConfigurationValidityReportOperation`
+             * @param request The request used for the
+             * `SendConfigurationValidityReportOperation`
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SendConfigurationValidityReportRequest &request,
@@ -3761,8 +3922,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `UpdateThingShadowOperation`
              * @param request The request used for the `UpdateThingShadowOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const UpdateThingShadowRequest &request,
@@ -3824,8 +3987,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `UpdateConfigurationOperation`
              * @param request The request used for the `UpdateConfigurationOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const UpdateConfigurationRequest &request,
@@ -3889,9 +4054,12 @@ namespace Aws
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
              * Used to activate a stream for the `ValidateAuthorizationTokenOperation`
-             * @param request The request used for the `ValidateAuthorizationTokenOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param request The request used for the
+             * `ValidateAuthorizationTokenOperation`
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const ValidateAuthorizationTokenRequest &request,
@@ -3953,8 +4121,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `RestartComponentOperation`
              * @param request The request used for the `RestartComponentOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const RestartComponentRequest &request,
@@ -4019,8 +4189,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `GetLocalDeploymentStatusOperation`
              * @param request The request used for the `GetLocalDeploymentStatusOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const GetLocalDeploymentStatusRequest &request,
@@ -4082,8 +4254,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `GetSecretValueOperation`
              * @param request The request used for the `GetSecretValueOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const GetSecretValueRequest &request,
@@ -4145,8 +4319,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `UpdateStateOperation`
              * @param request The request used for the `UpdateStateOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const UpdateStateRequest &request,
@@ -4211,8 +4387,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `ListNamedShadowsForThingOperation`
              * @param request The request used for the `ListNamedShadowsForThingOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const ListNamedShadowsForThingRequest &request,
@@ -4232,8 +4410,10 @@ namespace Aws
             virtual void OnStreamEvent(ComponentUpdatePolicyEvents *response) { (void)response; }
 
             /**
-             * A callback that is invoked when an error occurs while parsing a message from the stream.
-             * @param rpcError The RPC error containing the status and possibly a CRT error.
+             * A callback that is invoked when an error occurs while parsing a message
+             * from the stream.
+             * @param rpcError The RPC error containing the status and possibly a CRT
+             * error.
              */
             virtual bool OnStreamError(RpcError rpcError)
             {
@@ -4252,7 +4432,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving an error of type `ResourceNotFoundError`.
+             * A callback that is invoked upon receiving an error of type
+             * `ResourceNotFoundError`.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(ResourceNotFoundError *operationError)
@@ -4262,7 +4443,8 @@ namespace Aws
             }
 
             /**
-             * A callback that is invoked upon receiving ANY error response from the server.
+             * A callback that is invoked upon receiving ANY error response from the
+             * server.
              * @param operationError The error message being received.
              */
             virtual bool OnStreamError(OperationError *operationError)
@@ -4277,7 +4459,8 @@ namespace Aws
              */
             void OnStreamEvent(Aws::Crt::ScopedResource<AbstractShapeBase> response) override;
             /**
-             * Invoked when a message is received on this continuation but results in an error.
+             * Invoked when a message is received on this continuation but results in an
+             * error.
              *
              * This callback can return true so that the stream is closed afterwards.
              */
@@ -4332,11 +4515,19 @@ namespace Aws
                 SubscribeToComponentUpdatesStreamHandler *streamHandler,
                 const SubscribeToComponentUpdatesOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+            SubscribeToComponentUpdatesOperation(
+                ClientConnection &connection,
+                std::shared_ptr<SubscribeToComponentUpdatesStreamHandler> streamHandler,
+                const SubscribeToComponentUpdatesOperationContext &operationContext,
+                Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
             /**
              * Used to activate a stream for the `SubscribeToComponentUpdatesOperation`
-             * @param request The request used for the `SubscribeToComponentUpdatesOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param request The request used for the
+             * `SubscribeToComponentUpdatesOperation`
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const SubscribeToComponentUpdatesRequest &request,
@@ -4348,6 +4539,9 @@ namespace Aws
 
           protected:
             Aws::Crt::String GetModelName() const noexcept override;
+
+          private:
+            std::shared_ptr<SubscribeToComponentUpdatesStreamHandler> pinnedHandler;
         };
 
         class ListLocalDeploymentsOperationContext : public OperationModelContext
@@ -4400,8 +4594,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `ListLocalDeploymentsOperation`
              * @param request The request used for the `ListLocalDeploymentsOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const ListLocalDeploymentsRequest &request,
@@ -4463,8 +4659,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `StopComponentOperation`
              * @param request The request used for the `StopComponentOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const StopComponentRequest &request,
@@ -4526,8 +4724,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `PauseComponentOperation`
              * @param request The request used for the `PauseComponentOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const PauseComponentRequest &request,
@@ -4591,8 +4791,10 @@ namespace Aws
             /**
              * Used to activate a stream for the `CreateLocalDeploymentOperation`
              * @param request The request used for the `CreateLocalDeploymentOperation`
-             * @param onMessageFlushCallback An optional callback that is invoked when the request is flushed.
-             * @return An `RpcError` that can be used to check whether the stream was activated.
+             * @param onMessageFlushCallback An optional callback that is invoked when the
+             * request is flushed.
+             * @return An `RpcError` that can be used to check whether the stream was
+             * activated.
              */
             std::future<RpcError> Activate(
                 const CreateLocalDeploymentRequest &request,

--- a/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcModel.h
+++ b/greengrass_ipc/include/aws/greengrass/GreengrassCoreIpcModel.h
@@ -2616,6 +2616,13 @@ namespace Aws
                 SubscribeToIoTCoreStreamHandler *streamHandler,
                 const SubscribeToIoTCoreOperationContext &operationContext,
                 Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+
+            SubscribeToIoTCoreOperation(
+                ClientConnection &connection,
+                std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler,
+                const SubscribeToIoTCoreOperationContext &operationContext,
+                Aws::Crt::Allocator *allocator = Aws::Crt::g_allocator) noexcept;
+
             /**
              * Used to activate a stream for the `SubscribeToIoTCoreOperation`
              * @param request The request used for the `SubscribeToIoTCoreOperation`
@@ -2632,6 +2639,9 @@ namespace Aws
 
           protected:
             Aws::Crt::String GetModelName() const noexcept override;
+
+          private:
+            std::shared_ptr<SubscribeToIoTCoreStreamHandler> pinnedHandler;
         };
 
         class ResumeComponentOperationContext : public OperationModelContext

--- a/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
@@ -1,3 +1,4 @@
+#include <aws/crt/Types.h>
 #include <aws/crt/io/Bootstrap.h>
 #include <aws/greengrass/GreengrassCoreIpcClient.h>
 
@@ -73,11 +74,31 @@ namespace Aws
             return ResumeComponentOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_resumeComponentOperationContext, m_allocator);
         }
+
+        std::unique_ptr<ResumeComponentOperation> GreengrassCoreIpcClient::NewPtrResumeComponent() noexcept
+        {
+            return std::unique_ptr<ResumeComponentOperation>(Aws::Crt::New<ResumeComponentOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_resumeComponentOperationContext,
+                m_allocator));
+        }
+
         PublishToIoTCoreOperation GreengrassCoreIpcClient::NewPublishToIoTCore() noexcept
         {
             return PublishToIoTCoreOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_publishToIoTCoreOperationContext, m_allocator);
         }
+
+        std::unique_ptr<PublishToIoTCoreOperation> GreengrassCoreIpcClient::NewPtrPublishToIoTCore() noexcept
+        {
+            return std::unique_ptr<PublishToIoTCoreOperation>(Aws::Crt::New<PublishToIoTCoreOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_publishToIoTCoreOperationContext,
+                m_allocator));
+        }
+
         SubscribeToConfigurationUpdateOperation GreengrassCoreIpcClient::NewSubscribeToConfigurationUpdate(
             SubscribeToConfigurationUpdateStreamHandler &streamHandler) noexcept
         {
@@ -87,16 +108,50 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_subscribeToConfigurationUpdateOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SubscribeToConfigurationUpdateOperation> GreengrassCoreIpcClient::
+            NewPtrSubscribeToConfigurationUpdate(
+                std::shared_ptr<SubscribeToConfigurationUpdateStreamHandler> streamHandler) noexcept
+        {
+            return std::unique_ptr<SubscribeToConfigurationUpdateOperation>(
+                Aws::Crt::New<SubscribeToConfigurationUpdateOperation>(
+                    m_allocator,
+                    m_connection,
+                    std::move(streamHandler),
+                    m_greengrassCoreIpcServiceModel.m_subscribeToConfigurationUpdateOperationContext,
+                    m_allocator));
+        }
+
         DeleteThingShadowOperation GreengrassCoreIpcClient::NewDeleteThingShadow() noexcept
         {
             return DeleteThingShadowOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_deleteThingShadowOperationContext, m_allocator);
         }
+
+        std::unique_ptr<DeleteThingShadowOperation> GreengrassCoreIpcClient::NewPtrDeleteThingShadow() noexcept
+        {
+            return std::unique_ptr<DeleteThingShadowOperation>(Aws::Crt::New<DeleteThingShadowOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_deleteThingShadowOperationContext,
+                m_allocator));
+        }
+
         DeferComponentUpdateOperation GreengrassCoreIpcClient::NewDeferComponentUpdate() noexcept
         {
             return DeferComponentUpdateOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_deferComponentUpdateOperationContext, m_allocator);
         }
+
+        std::unique_ptr<DeferComponentUpdateOperation> GreengrassCoreIpcClient::NewPtrDeferComponentUpdate() noexcept
+        {
+            return std::unique_ptr<DeferComponentUpdateOperation>(Aws::Crt::New<DeferComponentUpdateOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_deferComponentUpdateOperationContext,
+                m_allocator));
+        }
+
         SubscribeToValidateConfigurationUpdatesOperation GreengrassCoreIpcClient::
             NewSubscribeToValidateConfigurationUpdates(
                 SubscribeToValidateConfigurationUpdatesStreamHandler &streamHandler) noexcept
@@ -107,11 +162,35 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_subscribeToValidateConfigurationUpdatesOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SubscribeToValidateConfigurationUpdatesOperation> GreengrassCoreIpcClient::
+            NewPtrSubscribeToValidateConfigurationUpdates(
+                std::shared_ptr<SubscribeToValidateConfigurationUpdatesStreamHandler> streamHandler) noexcept
+        {
+            return std::unique_ptr<SubscribeToValidateConfigurationUpdatesOperation>(
+                Aws::Crt::New<SubscribeToValidateConfigurationUpdatesOperation>(
+                    m_allocator,
+                    m_connection,
+                    std::move(streamHandler),
+                    m_greengrassCoreIpcServiceModel.m_subscribeToValidateConfigurationUpdatesOperationContext,
+                    m_allocator));
+        }
+
         GetConfigurationOperation GreengrassCoreIpcClient::NewGetConfiguration() noexcept
         {
             return GetConfigurationOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_getConfigurationOperationContext, m_allocator);
         }
+
+        std::unique_ptr<GetConfigurationOperation> GreengrassCoreIpcClient::NewPtrGetConfiguration() noexcept
+        {
+            return std::unique_ptr<GetConfigurationOperation>(Aws::Crt::New<GetConfigurationOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_getConfigurationOperationContext,
+                m_allocator));
+        }
+
         SubscribeToTopicOperation GreengrassCoreIpcClient::NewSubscribeToTopic(
             SubscribeToTopicStreamHandler &streamHandler) noexcept
         {
@@ -121,31 +200,93 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_subscribeToTopicOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SubscribeToTopicOperation> GreengrassCoreIpcClient::NewPtrSubscribeToTopic(
+            std::shared_ptr<SubscribeToTopicStreamHandler> streamHandler) noexcept
+        {
+            return std::unique_ptr<SubscribeToTopicOperation>(Aws::Crt::New<SubscribeToTopicOperation>(
+                m_allocator,
+                m_connection,
+                std::move(streamHandler),
+                m_greengrassCoreIpcServiceModel.m_subscribeToTopicOperationContext,
+                m_allocator));
+        }
+
         GetComponentDetailsOperation GreengrassCoreIpcClient::NewGetComponentDetails() noexcept
         {
             return GetComponentDetailsOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_getComponentDetailsOperationContext, m_allocator);
         }
+
+        std::unique_ptr<GetComponentDetailsOperation> GreengrassCoreIpcClient::NewPtrGetComponentDetails() noexcept
+        {
+            return std::unique_ptr<GetComponentDetailsOperation>(Aws::Crt::New<GetComponentDetailsOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_getComponentDetailsOperationContext,
+                m_allocator));
+        }
+
         PublishToTopicOperation GreengrassCoreIpcClient::NewPublishToTopic() noexcept
         {
             return PublishToTopicOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_publishToTopicOperationContext, m_allocator);
         }
+
+        std::unique_ptr<PublishToTopicOperation> GreengrassCoreIpcClient::NewPtrPublishToTopic() noexcept
+        {
+            return std::unique_ptr<PublishToTopicOperation>(Aws::Crt::New<PublishToTopicOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_publishToTopicOperationContext,
+                m_allocator));
+        }
+
         ListComponentsOperation GreengrassCoreIpcClient::NewListComponents() noexcept
         {
             return ListComponentsOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_listComponentsOperationContext, m_allocator);
         }
+
+        std::unique_ptr<ListComponentsOperation> GreengrassCoreIpcClient::NewPtrListComponents() noexcept
+        {
+            return std::unique_ptr<ListComponentsOperation>(Aws::Crt::New<ListComponentsOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_listComponentsOperationContext,
+                m_allocator));
+        }
+
         CreateDebugPasswordOperation GreengrassCoreIpcClient::NewCreateDebugPassword() noexcept
         {
             return CreateDebugPasswordOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_createDebugPasswordOperationContext, m_allocator);
         }
+
+        std::unique_ptr<CreateDebugPasswordOperation> GreengrassCoreIpcClient::NewPtrCreateDebugPassword() noexcept
+        {
+            return std::unique_ptr<CreateDebugPasswordOperation>(Aws::Crt::New<CreateDebugPasswordOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_createDebugPasswordOperationContext,
+                m_allocator));
+        }
+
         GetThingShadowOperation GreengrassCoreIpcClient::NewGetThingShadow() noexcept
         {
             return GetThingShadowOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_getThingShadowOperationContext, m_allocator);
         }
+
+        std::unique_ptr<GetThingShadowOperation> GreengrassCoreIpcClient::NewPtrGetThingShadow() noexcept
+        {
+            return std::unique_ptr<GetThingShadowOperation>(Aws::Crt::New<GetThingShadowOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_getThingShadowOperationContext,
+                m_allocator));
+        }
+
         SendConfigurationValidityReportOperation GreengrassCoreIpcClient::NewSendConfigurationValidityReport() noexcept
         {
             return SendConfigurationValidityReportOperation(
@@ -153,16 +294,48 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_sendConfigurationValidityReportOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SendConfigurationValidityReportOperation> GreengrassCoreIpcClient::
+            NewPtrSendConfigurationValidityReport() noexcept
+        {
+            return std::unique_ptr<SendConfigurationValidityReportOperation>(
+                Aws::Crt::New<SendConfigurationValidityReportOperation>(
+                    m_allocator,
+                    m_connection,
+                    m_greengrassCoreIpcServiceModel.m_sendConfigurationValidityReportOperationContext,
+                    m_allocator));
+        }
+
         UpdateThingShadowOperation GreengrassCoreIpcClient::NewUpdateThingShadow() noexcept
         {
             return UpdateThingShadowOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_updateThingShadowOperationContext, m_allocator);
         }
+
+        std::unique_ptr<UpdateThingShadowOperation> GreengrassCoreIpcClient::NewPtrUpdateThingShadow() noexcept
+        {
+            return std::unique_ptr<UpdateThingShadowOperation>(Aws::Crt::New<UpdateThingShadowOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_updateThingShadowOperationContext,
+                m_allocator));
+        }
+
         UpdateConfigurationOperation GreengrassCoreIpcClient::NewUpdateConfiguration() noexcept
         {
             return UpdateConfigurationOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_updateConfigurationOperationContext, m_allocator);
         }
+
+        std::unique_ptr<UpdateConfigurationOperation> GreengrassCoreIpcClient::NewPtrUpdateConfiguration() noexcept
+        {
+            return std::unique_ptr<UpdateConfigurationOperation>(Aws::Crt::New<UpdateConfigurationOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_updateConfigurationOperationContext,
+                m_allocator));
+        }
+
         ValidateAuthorizationTokenOperation GreengrassCoreIpcClient::NewValidateAuthorizationToken() noexcept
         {
             return ValidateAuthorizationTokenOperation(
@@ -170,31 +343,92 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_validateAuthorizationTokenOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<ValidateAuthorizationTokenOperation> GreengrassCoreIpcClient::
+            NewPtrValidateAuthorizationToken() noexcept
+        {
+            return std::unique_ptr<ValidateAuthorizationTokenOperation>(
+                Aws::Crt::New<ValidateAuthorizationTokenOperation>(
+                    m_allocator,
+                    m_connection,
+                    m_greengrassCoreIpcServiceModel.m_validateAuthorizationTokenOperationContext,
+                    m_allocator));
+        }
+
         RestartComponentOperation GreengrassCoreIpcClient::NewRestartComponent() noexcept
         {
             return RestartComponentOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_restartComponentOperationContext, m_allocator);
         }
+
+        std::unique_ptr<RestartComponentOperation> GreengrassCoreIpcClient::NewPtrRestartComponent() noexcept
+        {
+            return std::unique_ptr<RestartComponentOperation>(Aws::Crt::New<RestartComponentOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_restartComponentOperationContext,
+                m_allocator));
+        }
+
         GetLocalDeploymentStatusOperation GreengrassCoreIpcClient::NewGetLocalDeploymentStatus() noexcept
         {
             return GetLocalDeploymentStatusOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_getLocalDeploymentStatusOperationContext, m_allocator);
         }
+
+        std::unique_ptr<GetLocalDeploymentStatusOperation> GreengrassCoreIpcClient::
+            NewPtrGetLocalDeploymentStatus() noexcept
+        {
+            return std::unique_ptr<GetLocalDeploymentStatusOperation>(Aws::Crt::New<GetLocalDeploymentStatusOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_getLocalDeploymentStatusOperationContext,
+                m_allocator));
+        }
+
         GetSecretValueOperation GreengrassCoreIpcClient::NewGetSecretValue() noexcept
         {
             return GetSecretValueOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_getSecretValueOperationContext, m_allocator);
         }
+
+        std::unique_ptr<GetSecretValueOperation> GreengrassCoreIpcClient::NewPtrGetSecretValue() noexcept
+        {
+            return std::unique_ptr<GetSecretValueOperation>(Aws::Crt::New<GetSecretValueOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_getSecretValueOperationContext,
+                m_allocator));
+        }
+
         UpdateStateOperation GreengrassCoreIpcClient::NewUpdateState() noexcept
         {
             return UpdateStateOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_updateStateOperationContext, m_allocator);
         }
+
+        std::unique_ptr<UpdateStateOperation> GreengrassCoreIpcClient::NewPtrUpdateState() noexcept
+        {
+            return std::unique_ptr<UpdateStateOperation>(Aws::Crt::New<UpdateStateOperation>(
+                m_allocator, m_connection, m_greengrassCoreIpcServiceModel.m_updateStateOperationContext, m_allocator));
+        }
+
         ListNamedShadowsForThingOperation GreengrassCoreIpcClient::NewListNamedShadowsForThing() noexcept
         {
             return ListNamedShadowsForThingOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_listNamedShadowsForThingOperationContext, m_allocator);
         }
+
+        std::unique_ptr<ListNamedShadowsForThingOperation> GreengrassCoreIpcClient::
+            NewPtrListNamedShadowsForThing() noexcept
+        {
+            return std::unique_ptr<ListNamedShadowsForThingOperation>(Aws::Crt::New<ListNamedShadowsForThingOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_listNamedShadowsForThingOperationContext,
+                m_allocator));
+        }
+
         SubscribeToComponentUpdatesOperation GreengrassCoreIpcClient::NewSubscribeToComponentUpdates(
             SubscribeToComponentUpdatesStreamHandler &streamHandler) noexcept
         {
@@ -204,25 +438,78 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_subscribeToComponentUpdatesOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SubscribeToComponentUpdatesOperation> GreengrassCoreIpcClient::
+            NewPtrSubscribeToComponentUpdates(
+                std::shared_ptr<SubscribeToComponentUpdatesStreamHandler> streamHandler) noexcept
+        {
+            return std::unique_ptr<SubscribeToComponentUpdatesOperation>(
+                Aws::Crt::New<SubscribeToComponentUpdatesOperation>(
+                    m_allocator,
+                    m_connection,
+                    std::move(streamHandler),
+                    m_greengrassCoreIpcServiceModel.m_subscribeToComponentUpdatesOperationContext,
+                    m_allocator));
+        }
+
         ListLocalDeploymentsOperation GreengrassCoreIpcClient::NewListLocalDeployments() noexcept
         {
             return ListLocalDeploymentsOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_listLocalDeploymentsOperationContext, m_allocator);
         }
+
+        std::unique_ptr<ListLocalDeploymentsOperation> GreengrassCoreIpcClient::NewPtrListLocalDeployments() noexcept
+        {
+            return std::unique_ptr<ListLocalDeploymentsOperation>(Aws::Crt::New<ListLocalDeploymentsOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_listLocalDeploymentsOperationContext,
+                m_allocator));
+        }
+
         StopComponentOperation GreengrassCoreIpcClient::NewStopComponent() noexcept
         {
             return StopComponentOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_stopComponentOperationContext, m_allocator);
         }
+
+        std::unique_ptr<StopComponentOperation> GreengrassCoreIpcClient::NewPtrStopComponent() noexcept
+        {
+            return std::unique_ptr<StopComponentOperation>(Aws::Crt::New<StopComponentOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_stopComponentOperationContext,
+                m_allocator));
+        }
+
         PauseComponentOperation GreengrassCoreIpcClient::NewPauseComponent() noexcept
         {
             return PauseComponentOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_pauseComponentOperationContext, m_allocator);
         }
+
+        std::unique_ptr<PauseComponentOperation> GreengrassCoreIpcClient::NewPtrPauseComponent() noexcept
+        {
+            return std::unique_ptr<PauseComponentOperation>(Aws::Crt::New<PauseComponentOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_pauseComponentOperationContext,
+                m_allocator));
+        }
+
         CreateLocalDeploymentOperation GreengrassCoreIpcClient::NewCreateLocalDeployment() noexcept
         {
             return CreateLocalDeploymentOperation(
                 m_connection, m_greengrassCoreIpcServiceModel.m_createLocalDeploymentOperationContext, m_allocator);
+        }
+
+        std::unique_ptr<CreateLocalDeploymentOperation> GreengrassCoreIpcClient::NewPtrCreateLocalDeployment() noexcept
+        {
+            return std::unique_ptr<CreateLocalDeploymentOperation>(Aws::Crt::New<CreateLocalDeploymentOperation>(
+                m_allocator,
+                m_connection,
+                m_greengrassCoreIpcServiceModel.m_createLocalDeploymentOperationContext,
+                m_allocator));
         }
 
     } // namespace Greengrass

--- a/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
@@ -63,7 +63,7 @@ namespace Aws
             return std::unique_ptr<SubscribeToIoTCoreOperation>(Aws::Crt::New<SubscribeToIoTCoreOperation>(
                 m_allocator,
                 m_connection,
-                streamHandler,
+                std::move(streamHandler),
                 m_greengrassCoreIpcServiceModel.m_subscribeToIoTCoreOperationContext,
                 m_allocator));
         }

--- a/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcClient.cpp
@@ -56,6 +56,18 @@ namespace Aws
                 m_greengrassCoreIpcServiceModel.m_subscribeToIoTCoreOperationContext,
                 m_allocator);
         }
+
+        std::unique_ptr<SubscribeToIoTCoreOperation> GreengrassCoreIpcClient::NewPtrSubscribeToIoTCore(
+            std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler) noexcept
+        {
+            return std::unique_ptr<SubscribeToIoTCoreOperation>(Aws::Crt::New<SubscribeToIoTCoreOperation>(
+                m_allocator,
+                m_connection,
+                streamHandler,
+                m_greengrassCoreIpcServiceModel.m_subscribeToIoTCoreOperationContext,
+                m_allocator));
+        }
+
         ResumeComponentOperation GreengrassCoreIpcClient::NewResumeComponent() noexcept
         {
             return ResumeComponentOperation(

--- a/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
@@ -5134,6 +5134,16 @@ namespace Aws
         {
         }
 
+        SubscribeToIoTCoreOperation::SubscribeToIoTCoreOperation(
+            ClientConnection &connection,
+            std::shared_ptr<SubscribeToIoTCoreStreamHandler> streamHandler,
+            const SubscribeToIoTCoreOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator) noexcept
+            : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+              pinnedHandler(streamHandler)
+        {
+        }
+
         std::future<RpcError> SubscribeToIoTCoreOperation::Activate(
             const SubscribeToIoTCoreRequest &request,
             OnMessageFlushCallback onMessageFlushCallback) noexcept

--- a/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
@@ -5383,6 +5383,16 @@ namespace Aws
         {
         }
 
+        SubscribeToConfigurationUpdateOperation::SubscribeToConfigurationUpdateOperation(
+            ClientConnection &connection,
+            std::shared_ptr<SubscribeToConfigurationUpdateStreamHandler> streamHandler,
+            const SubscribeToConfigurationUpdateOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator) noexcept
+            : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+              pinnedHandler(std::move(streamHandler))
+        {
+        }
+
         std::future<RpcError> SubscribeToConfigurationUpdateOperation::Activate(
             const SubscribeToConfigurationUpdateRequest &request,
             OnMessageFlushCallback onMessageFlushCallback) noexcept
@@ -5619,6 +5629,16 @@ namespace Aws
         {
         }
 
+        SubscribeToValidateConfigurationUpdatesOperation::SubscribeToValidateConfigurationUpdatesOperation(
+            ClientConnection &connection,
+            std::shared_ptr<SubscribeToValidateConfigurationUpdatesStreamHandler> streamHandler,
+            const SubscribeToValidateConfigurationUpdatesOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator) noexcept
+            : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+              pinnedHandler(std::move(streamHandler))
+        {
+        }
+
         std::future<RpcError> SubscribeToValidateConfigurationUpdatesOperation::Activate(
             const SubscribeToValidateConfigurationUpdatesRequest &request,
             OnMessageFlushCallback onMessageFlushCallback) noexcept
@@ -5790,6 +5810,16 @@ namespace Aws
             const SubscribeToTopicOperationContext &operationContext,
             Aws::Crt::Allocator *allocator) noexcept
             : ClientOperation(connection, streamHandler, operationContext, allocator)
+        {
+        }
+
+        SubscribeToTopicOperation::SubscribeToTopicOperation(
+            ClientConnection &connection,
+            std::shared_ptr<SubscribeToTopicStreamHandler> streamHandler,
+            const SubscribeToTopicOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator) noexcept
+            : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+              pinnedHandler(std::move(streamHandler))
         {
         }
 
@@ -6859,6 +6889,16 @@ namespace Aws
             const SubscribeToComponentUpdatesOperationContext &operationContext,
             Aws::Crt::Allocator *allocator) noexcept
             : ClientOperation(connection, streamHandler, operationContext, allocator)
+        {
+        }
+
+        SubscribeToComponentUpdatesOperation::SubscribeToComponentUpdatesOperation(
+            ClientConnection &connection,
+            std::shared_ptr<SubscribeToComponentUpdatesStreamHandler> streamHandler,
+            const SubscribeToComponentUpdatesOperationContext &operationContext,
+            Aws::Crt::Allocator *allocator) noexcept
+            : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
+              pinnedHandler(std::move(streamHandler))
         {
         }
 

--- a/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
+++ b/greengrass_ipc/source/GreengrassCoreIpcModel.cpp
@@ -5140,7 +5140,7 @@ namespace Aws
             const SubscribeToIoTCoreOperationContext &operationContext,
             Aws::Crt::Allocator *allocator) noexcept
             : ClientOperation(connection, streamHandler.get(), operationContext, allocator),
-              pinnedHandler(streamHandler)
+              pinnedHandler(std::move(streamHandler))
         {
         }
 


### PR DESCRIPTION
New approach to GG IPC operation management.

* Make ClientContinuationHandler's destructor virtual so that it can actually be used as a pointed-to value
* ClientOperation uses public inheritance so that we can use the virtual destructor
* Most importantly, a new set of per-operation APIs that return a pointer to the operation, not the operation's value itself
* The new pointer-returning APIs that use a stream handler take the stream handler by shared ptr to guarantee the handler lives sufficiently long 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
