### PR TITLE
Minor modifications to the sample README file

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -56,7 +56,6 @@ and receive.
 {
   "Version": "2012-10-17",
   "Statement": [
-
     {
       "Effect": "Allow",
       "Action": [
@@ -85,7 +84,6 @@ and receive.
         "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
       ]
     }
-
   ]
 }
 </pre>
@@ -94,7 +92,7 @@ and receive.
 To run the basic MQTT Pub-Sub use the following command:
 
 ``` sh
-./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA1>
+./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
 --topic <topic name>
 ```
@@ -107,7 +105,7 @@ To run this sample using websockets, see below:
 To run using Websockets, use the following command:
 
 ``` sh
-./basic-pub-sub --endpoint <endpoint> --topic <topic name> --ca_file <path to root CA1>
+./basic-pub-sub --endpoint <endpoint> --topic <topic name> --ca_file <path to root CA>
 --use_websocket --signing_region <signing_region>
 ```
 
@@ -166,7 +164,7 @@ To run this sample using [SoftHSM2](https://www.opendnssec.org/softhsm/) as the 
 
 5)  Now you can run the sample:
     ```sh
-    ./pkcs11-pub-sub --endpoint <xxxx-ats.iot.xxxx.amazonaws.com> --ca_file <AmazonRootCA1.pem> --cert <certificate.pem.crt> --pkcs11_lib <libsofthsm2.so> --pin <user-pin> --token_label <token-label> --key_label <key-label>
+    ./pkcs11-pub-sub --endpoint <xxxx-ats.iot.xxxx.amazonaws.com> --ca_file <AmazonRootCA.pem> --cert <certificate.pem.crt> --pkcs11_lib <libsofthsm2.so> --pin <user-pin> --token_label <token-label> --key_label <key-label>
     ```
 
 
@@ -181,7 +179,7 @@ source: `samples/mqtt/raw_pub_sub/main.cpp`
 To run the Raw MQTT Pub-Sub sample use the following command:
 
 ``` sh
-./raw-pub-sub --endpoint <endpoint> --ca_file <path to root CA1>
+./raw-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
 --topic <topic name> --user_name <user name to send on connect> --password <password to send on connect>
 ```
@@ -221,7 +219,6 @@ and receive.
 {
   "Version": "2012-10-17",
   "Statement": [
-
     {
       "Effect": "Allow",
       "Action": [
@@ -263,7 +260,6 @@ and receive.
       "Action": "iot:Connect",
       "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
     }
-
   ]
 }
 </pre>
@@ -272,7 +268,7 @@ and receive.
 To run the Shadow sample use the following command:
 
 ``` sh
-./shadow-sync --endpoint <endpoint> --ca_file <path to root CA1>
+./shadow-sync --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
 --thing_name <thing name> --shadow_property <shadow property name>
 ```
@@ -357,7 +353,7 @@ See the [Basic job policy example](https://docs.aws.amazon.com/iot/latest/develo
 To run the job sample use the following command:
 
 ``` sh
-./describe-job-execution --endpoint <endpoint> --ca_file <path to root CA1>
+./describe-job-execution --endpoint <endpoint> --ca_file <path to root CA>
 --cert <path to the certificate> --key <path to the private key>
 --thing_name <thing name> --job_id <the job id>
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -24,6 +24,12 @@ cmake -DCMAKE_PREFIX_PATH="<absolute path sdk-cpp-workspace dir>" -DCMAKE_BUILD_
 cmake --build . --config "<Release|RelWithDebInfo|Debug>"
 ```
 
+To view the commands for a given sample, run the compiled program and pass `--help`.
+
+```
+./basic-pub-sub --help
+```
+
 #### Note
 
 * `-DCMAKE_PREFIX_PATH` needs to be set to the path aws-iot-device-sdk-cpp-v2 installed. Since [Installation](../README.md#Installation) takes sdk-cpp-workspace as an example, here takes that as an example too.
@@ -172,6 +178,16 @@ This is a starting point for using custom
 
 source: `samples/mqtt/raw_pub_sub/main.cpp`
 
+To run the Raw MQTT Pub-Sub sample use the following command:
+
+``` sh
+./raw-pub-sub --endpoint <endpoint> --ca_file <path to root CA1>
+--cert <path to the certificate> --key <path to the private key>
+--topic <topic name> --user_name <user name to send on connect> --password <password to send on connect>
+```
+
+This will allow you to run the program. To disconnect and exit the program, enter `exit`.
+
 ## Shadow
 
 This sample uses the AWS IoT
@@ -253,6 +269,16 @@ and receive.
 </pre>
 </details>
 
+To run the Shadow sample use the following command:
+
+``` sh
+./shadow-sync --endpoint <endpoint> --ca_file <path to root CA1>
+--cert <path to the certificate> --key <path to the private key>
+--thing_name <thing name> --shadow_property <shadow property name>
+```
+
+This will allow you to run the program and set the shadow property. To disconnect and exit the program, enter `quit`.
+
 ## Jobs
 
 This sample uses the AWS IoT
@@ -276,53 +302,67 @@ and receive.
 {
   "Version": "2012-10-17",
   "Statement": [
-
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Publish"
-      ],
-      "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/start-next",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/update"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Receive"
-      ],
-      "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/notify-next",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/start-next/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/start-next/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/update/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*/update/rejected"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iot:Subscribe"
-      ],
-      "Resource": [
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/notify-next",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/start-next/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/start-next/rejected",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/update/accepted",
-        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*/update/rejected"
-      ]
-    },
     {
       "Effect": "Allow",
       "Action": "iot:Connect",
-      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/<b>thingname</b>",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:client/test-*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Publish",
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/dc/pubtopic",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/events/job/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/events/jobExecution/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Subscribe",
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/test/dc/subtopic",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/events/jobExecution/*",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topicfilter/$aws/things/<b>thingname</b>/jobs/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iot:Receive",
+      "Resource": [
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/test/dc/subtopic",
+        "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>/jobs/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iot:DescribeJobExecution",
+        "iot:GetPendingJobExecutions",
+        "iot:StartNextPendingJobExecution",
+        "iot:UpdateJobExecution"
+      ],
+      "Resource": "arn:aws:iot:<b>region</b>:<b>account</b>:topic/$aws/things/<b>thingname</b>"
     }
-
   ]
 }
 </pre>
+
+See the [Basic job policy example](https://docs.aws.amazon.com/iot/latest/developerguide/basic-jobs-example.html) page for another policy example.
 </details>
+
+To run the job sample use the following command:
+
+``` sh
+./describe-job-execution --endpoint <endpoint> --ca_file <path to root CA1>
+--cert <path to the certificate> --key <path to the private key>
+--thing_name <thing name> --job_id <the job id>
+```
+
+Note that if you get a `Service Error 4 occurred` error, you may have incorrectly input the job id. The job id needs to exactly match the job id in the AWS console.
 
 ## Fleet provisioning
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -35,11 +35,7 @@ cmake --build . --config "<Release|RelWithDebInfo|Debug>"
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
 for AWS IoT to send and receive messages through an MQTT connection.
-On startup, the device connects to the server and subscribes to a topic.
-
-The terminal prompts the user for input. Type something and press enter to publish a message to the topic.
-Since the sample is subscribed to the same topic, it will also receive the message back from the server.
-Type `quit` and press enter to end the sample.
+On startup, the device connects to the server, subscribes to a topic, and begins publishing messages to that topic. The device should receive those same messages back from the message broker, since it is subscribed to that same topic. Status updates are continually printed to the console.
 
 Source: `samples/mqtt/basic_pub_sub/main.cpp`
 
@@ -92,7 +88,7 @@ and receive.
 To run the basic MQTT Pub-Sub use the following command:
 
 ``` sh
-./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA>
+./basic-pub-sub --endpoint <endpoint> --ca_file <path to root CA1>
 --cert <path to the certificate> --key <path to the private key>
 --topic <topic name>
 ```

--- a/samples/README.md
+++ b/samples/README.md
@@ -93,6 +93,23 @@ To run the basic MQTT Pub-Sub use the following command:
 --topic <topic name>
 ```
 
+To run this sample using websockets, see below:
+
+<details>
+<summary>(Websockets)</summary>
+
+To run using Websockets, use the following command:
+
+``` sh
+./basic-pub-sub --endpoint <endpoint> --topic <topic name> --ca_file <path to root CA1>
+--use_websocket --signing_region <signing_region>
+```
+
+Note that using Websockets will attempt to fetch the AWS credentials from your enviornment variables or local files.
+See the [authorizing direct AWS](https://docs.aws.amazon.com/iot/latest/developerguide/authorizing-direct-aws.html) page for documentation on how to get the AWS credentials, which then you can set to the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS`, and `AWS_SESSION_TOKEN` environment variables.
+
+</details>
+
 ## PKCS#11 MQTT Pub-Sub
 
 This sample is similar to the [Basic Pub-Sub](#basic-mqtt-pub-sub),


### PR DESCRIPTION
*Description of changes:*

This PR makes a few minor changes to the README in the `samples` folder. The changes are:
* Removes text mentioning the interactive mode in the pub-sub sample
* Changes `path to root CA` to `path to root CA1` to clarify which CA file is expected in the pub-sub sample
* Adds a section for running the pub-sub example using websockets
  * I'm not totally sure if the linked AWS document is the one that should be pointed to - there may be a better file to point to.
* Added a command example to the Raw MQTT Pub-Sub sample. Also added a sentence mentioning the use of `exit` to quit the sample.
* Added a command example to the Shadow sample. Also added a sentence mentioning the use of `quit` to quit the sample.
* Changed the policy for the Jobs sample to the policy found at [this page on the AWS documentation](https://docs.aws.amazon.com/iot/latest/developerguide/basic-jobs-example.html)
  * The current policy shown on the Jobs sample did not work and would give an error code of `5138` when used.
* Added a command example to the Jobs sample. Also added a note about `Service Error 4 occurred` and how it might indicate that the job ID may be incorrectly inputted
  * Not totally sure if this is necessary to mention, but it was a little confusing to me initially.

~~Currently I am marking this PR as a draft so I can check the other samples.~~

There's a few samples I skipped for now (*PKCS#11, Fleet provisioning, Secure Tunnel, Greengrass*) that I will try to come back to in the future.

______

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*