### PR TITLE
Updated Shadow sample to allow clearing properties by passing null

### DIFF
--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -72,9 +72,22 @@ static void s_changeShadowValue(
 
     ShadowState state;
     JsonObject desired;
-    desired.WithString(shadowProperty, value);
     JsonObject reported;
-    reported.WithString(shadowProperty, value);
+
+    if (value == "null") {
+        JsonObject nullObject;
+        nullObject.AsNull();
+        desired.WithObject(shadowProperty, nullObject);
+        reported.WithObject(shadowProperty, nullObject);
+    }
+    else if (value == "clear_shadow") {
+        desired.AsNull();
+        reported.AsNull();
+    }
+    else {
+        desired.WithString(shadowProperty, value);
+        reported.WithString(shadowProperty, value);
+    }
     state.Desired = desired;
     state.Reported = reported;
 
@@ -288,7 +301,6 @@ int main(int argc, char *argv[])
                 if (event->State && event->State->View().ValueExists(shadowProperty))
                 {
                     JsonView objectView = event->State->View().GetJsonObject(shadowProperty);
-
                     if (objectView.IsNull())
                     {
                         fprintf(
@@ -324,10 +336,15 @@ int main(int argc, char *argv[])
         auto onUpdateShadowAccepted = [&](UpdateShadowResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
-                fprintf(
-                    stdout,
-                    "Finished updating reported shadow value to %s.\n",
-                    response->State->Reported->View().GetString(shadowProperty).c_str());
+                if (response->State->Reported) {
+                    fprintf(
+                        stdout,
+                        "Finished updating reported shadow value to %s.\n",
+                        response->State->Reported->View().GetString(shadowProperty).c_str());
+                }
+                else {
+                    fprintf(stdout, "Finished clearing shadow properties\n");
+                }
                 fprintf(stdout, "Enter desired value:\n");
             }
             else

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -74,17 +74,20 @@ static void s_changeShadowValue(
     JsonObject desired;
     JsonObject reported;
 
-    if (value == "null") {
+    if (value == "null")
+    {
         JsonObject nullObject;
         nullObject.AsNull();
         desired.WithObject(shadowProperty, nullObject);
         reported.WithObject(shadowProperty, nullObject);
     }
-    else if (value == "clear_shadow") {
+    else if (value == "clear_shadow")
+    {
         desired.AsNull();
         reported.AsNull();
     }
-    else {
+    else
+    {
         desired.WithString(shadowProperty, value);
         reported.WithString(shadowProperty, value);
     }
@@ -336,13 +339,15 @@ int main(int argc, char *argv[])
         auto onUpdateShadowAccepted = [&](UpdateShadowResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
-                if (response->State->Reported) {
+                if (response->State->Reported)
+                {
                     fprintf(
                         stdout,
                         "Finished updating reported shadow value to %s.\n",
                         response->State->Reported->View().GetString(shadowProperty).c_str());
                 }
-                else {
+                else
+                {
                     fprintf(stdout, "Finished clearing shadow properties\n");
                 }
                 fprintf(stdout, "Enter desired value:\n");


### PR DESCRIPTION
*Description of changes:*

Modifies the Shadow sample to show how to clear properties, either individually or by clearing the entire state. Now if you enter `null` it will clear the `shadow_property` property in the Shadow document, and if you enter `clear_shadow` it will clear all the fields in `desired` and `reported`.

Also adjusted code for printing the reported shadow updated so it does not get a segmentation fault when `null` is returned.

__________

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
