### PR TITLE
Windows variants ticket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022 # latest
     steps:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
@@ -86,7 +86,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
   windows-vs14:
-    runs-on: windows-latest
+    runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:
       matrix:
         arch: [Win32, x64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:
       matrix:
-        arch: [x86, x64]
+        arch: [Win32, x64]
     steps:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
 
-  windows-vs16:
+  windows:
     runs-on: windows-latest
     steps:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
@@ -83,26 +83,20 @@ jobs:
           md D:\a\work
           cd D:\a\work
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }}
 
   windows-vs14:
     runs-on: windows-latest
     strategy:
       matrix:
-        arch: [x86, x64]
+        arch: [Win32, x64]
     steps:
-      - uses: ilammy/msvc-dev-cmd@v1
-        with:
-          toolset: 14.0
-          arch: ${{ matrix.arch }}
-          uwp: false
-          spectre: true
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |
           md D:\a\work
           cd D:\a\work
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --spec=downstream
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-Tv140 --cmake-extra=-A${{ matrix.arch }}
 
   windows-no-cpu-extensions:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
     strategy:
       matrix:
-        arch: [Win32, x64]
+        arch: [x86, x64]
     steps:
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
         run: |

--- a/eventstream_rpc/source/EventStreamClient.cpp
+++ b/eventstream_rpc/source/EventStreamClient.cpp
@@ -1302,7 +1302,7 @@ namespace Aws
             const Crt::Optional<Crt::ByteBuf> &payload,
             uint32_t messageFlags)
         {
-            bool streamAlreadyTerminated = messageFlags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM;
+            bool streamAlreadyTerminated = (messageFlags & AWS_EVENT_STREAM_RPC_MESSAGE_FLAG_TERMINATE_STREAM) != 0;
 
             Crt::StringView payloadStringView;
             if (payload.has_value())

--- a/eventstream_rpc/tests/EventStreamClientTest.cpp
+++ b/eventstream_rpc/tests/EventStreamClientTest.cpp
@@ -12,11 +12,6 @@
 #include <queue>
 #include <sstream>
 
-#ifdef WIN32
-#    undef SetPort
-#    undef GetMessage
-#endif
-
 using namespace Aws::Crt;
 using namespace Aws::Eventstreamrpc;
 using namespace Awstest;

--- a/eventstream_rpc/tests/EventStreamClientTest.cpp
+++ b/eventstream_rpc/tests/EventStreamClientTest.cpp
@@ -12,6 +12,11 @@
 #include <queue>
 #include <sstream>
 
+#ifdef WIN32
+#    undef SetPort
+#    undef GetMessage
+#endif
+
 using namespace Aws::Crt;
 using namespace Aws::Eventstreamrpc;
 using namespace Awstest;

--- a/samples/mqtt/basic_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/basic_pub_sub/CMakeLists.txt
@@ -19,5 +19,6 @@ else ()
 endif ()
 
 find_package(aws-crt-cpp REQUIRED)
+find_package(aws-c-iot REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-crt-cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-crt-cpp AWS::aws-c-iot)

--- a/samples/mqtt/basic_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/basic_pub_sub/CMakeLists.txt
@@ -20,4 +20,4 @@ endif ()
 
 find_package(aws-crt-cpp REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} AWS::aws-crt-cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-crt-cpp)

--- a/samples/mqtt/basic_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/basic_pub_sub/CMakeLists.txt
@@ -19,6 +19,5 @@ else ()
 endif ()
 
 find_package(aws-crt-cpp REQUIRED)
-find_package(aws-c-iot REQUIRED)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE AWS::aws-crt-cpp AWS::aws-c-iot)
+target_link_libraries(${PROJECT_NAME} AWS::aws-crt-cpp)


### PR DESCRIPTION
Issue: 
Previously, "windows-vs14 (x86)" was just doing an x64 build with the latest Visual Studio

Description of changes:
Now, the 14.0 toolset and Win32 (aka x86) architecture is actually used

Visual Studio 2015 isn't actually available on Github's [Windows image](https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#visual-studio-enterprise-2019) but we can pass -T v140 and compile with the "toolset" from Visual Studio 2015.

Fixes needed to pass CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
