### PR TITLE
Refactor of command line argument parsing to single file

### DIFF
--- a/samples/greengrass/basic_discovery/CMakeLists.txt
+++ b/samples/greengrass/basic_discovery/CMakeLists.txt
@@ -4,6 +4,8 @@ project(basic-discovery CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -42,17 +42,14 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("basic-discovery");
     cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.AddCommonProxyCommands();
+    cmdUtils.AddCommonTopicMessageCommands();
     cmdUtils.RemoveCommand("endpoint");
     cmdUtils.RegisterCommand(
         "region", "<str>", "The region for your Greengrass groups (optional, default='us-east-1').");
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
-    cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic')");
     cmdUtils.RegisterCommand(
         "mode", "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
-    cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
-    cmdUtils.RegisterCommand(
-        "proxy_host", "<str>", "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
-    cmdUtils.RegisterCommand("proxy_port", "<int>", "Proxy port to use for discovery call. (optional, default='0')");
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
 

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -19,7 +19,7 @@
 using namespace Aws::Crt;
 using namespace Aws::Discovery;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -53,7 +53,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterCommand(
         "proxy_host", "<str>", "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<int>", "Proxy port to use for discovery call. (optional, default='0')");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -50,8 +50,7 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("mode", "<both|publish|subscribe>", "Default both (optional)");
     cmdUtils.RegisterCommand("message", "<message to publish>", "Message to publish. Default 'Hello World' (optional)");
     cmdUtils.RegisterCommand(
-        "proxy_host",
-        "<proxy host name>",
+        "proxy_host", "<proxy host name>",
         "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Proxy port to use for discovery call. (optional)");
     cmdUtils.SendArguments(argv, argv + argc);
@@ -149,138 +148,111 @@ int main(int argc, char *argv[])
     std::promise<void> connectionFinishedPromise;
     std::promise<void> shutdownCompletedPromise;
 
-    discoveryClient->Discover(
-        thingName,
-        [&](DiscoverResponse *response, int error, int httpResponseCode)
+    discoveryClient->Discover(thingName, [&](DiscoverResponse *response, int error, int httpResponseCode) {
+        if (!error && response->GGGroups)
         {
-            if (!error && response->GGGroups)
+            auto groupToUse = std::move(response->GGGroups->at(0));
+
+            auto connectivityInfo = groupToUse.Cores->at(0).Connectivity->at(0);
+
+            fprintf(
+                stdout, "Connecting to group %s with thing arn %s, using endpoint %s:%d\n",
+                groupToUse.GGGroupId->c_str(), groupToUse.Cores->at(0).ThingArn->c_str(),
+                connectivityInfo.HostAddress->c_str(), (int)connectivityInfo.Port.value());
+
+            connection = mqttClient.NewConnection(
+                Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
+                    .WithCertificateAuthority(ByteCursorFromCString(groupToUse.CAs->at(0).c_str()))
+                    .WithPortOverride(connectivityInfo.Port.value())
+                    .WithEndpoint(connectivityInfo.HostAddress.value())
+                    .Build());
+
+            if (!connection)
             {
-                auto groupToUse = std::move(response->GGGroups->at(0));
+                fprintf(stderr, "Connection setup failed with error %s", ErrorDebugString(mqttClient.LastError()));
+                exit(-1);
+            }
 
-                auto connectivityInfo = groupToUse.Cores->at(0).Connectivity->at(0);
-
-                fprintf(
-                    stdout,
-                    "Connecting to group %s with thing arn %s, using endpoint %s:%d\n",
-                    groupToUse.GGGroupId->c_str(),
-                    groupToUse.Cores->at(0).ThingArn->c_str(),
-                    connectivityInfo.HostAddress->c_str(),
-                    (int)connectivityInfo.Port.value());
-
-                connection = mqttClient.NewConnection(
-                    Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
-                        .WithCertificateAuthority(ByteCursorFromCString(groupToUse.CAs->at(0).c_str()))
-                        .WithPortOverride(connectivityInfo.Port.value())
-                        .WithEndpoint(connectivityInfo.HostAddress.value())
-                        .Build());
-
-                if (!connection)
+            connection->OnConnectionCompleted = [&, connectivityInfo, groupToUse](
+                                                    Mqtt::MqttConnection &conn, int errorCode,
+                                                    Mqtt::ReturnCode /*returnCode*/, bool /*sessionPresent*/) {
+                if (!errorCode)
                 {
-                    fprintf(stderr, "Connection setup failed with error %s", ErrorDebugString(mqttClient.LastError()));
-                    exit(-1);
-                }
+                    fprintf(
+                        stdout, "Connected to group %s, using connection to %s:%d\n", groupToUse.GGGroupId->c_str(),
+                        connectivityInfo.HostAddress->c_str(), (int)connectivityInfo.Port.value());
 
-                connection->OnConnectionCompleted = [&, connectivityInfo, groupToUse](
-                                                        Mqtt::MqttConnection &conn,
-                                                        int errorCode,
-                                                        Mqtt::ReturnCode /*returnCode*/,
-                                                        bool /*sessionPresent*/)
-                {
-                    if (!errorCode)
+                    if (mode == "both" || mode == "subscribe")
                     {
-                        fprintf(
-                            stdout,
-                            "Connected to group %s, using connection to %s:%d\n",
-                            groupToUse.GGGroupId->c_str(),
-                            connectivityInfo.HostAddress->c_str(),
-                            (int)connectivityInfo.Port.value());
+                        auto onMessage = [&](Mqtt::MqttConnection & /*connection*/, const String &receivedOnTopic,
+                                             const ByteBuf &payload, bool /*dup*/, Mqtt::QOS /*qos*/, bool /*retain*/) {
+                            fprintf(stdout, "Publish received on topic %s\n", receivedOnTopic.c_str());
+                            fprintf(stdout, "Message: \n");
+                            fwrite(payload.buffer, 1, payload.len, stdout);
+                            fprintf(stdout, "\n");
+                        };
 
-                        if (mode == "both" || mode == "subscribe")
-                        {
-                            auto onMessage = [&](Mqtt::MqttConnection & /*connection*/,
-                                                 const String &receivedOnTopic,
-                                                 const ByteBuf &payload,
-                                                 bool /*dup*/,
-                                                 Mqtt::QOS /*qos*/,
-                                                 bool /*retain*/)
+                        auto onSubAck = [&](Mqtt::MqttConnection & /*connection*/, uint16_t /*packetId*/,
+                                            const String &topic, Mqtt::QOS /*qos*/, int errorCode) {
+                            if (!errorCode)
                             {
-                                fprintf(stdout, "Publish received on topic %s\n", receivedOnTopic.c_str());
-                                fprintf(stdout, "Message: \n");
-                                fwrite(payload.buffer, 1, payload.len, stdout);
-                                fprintf(stdout, "\n");
-                            };
-
-                            auto onSubAck = [&](Mqtt::MqttConnection & /*connection*/,
-                                                uint16_t /*packetId*/,
-                                                const String &topic,
-                                                Mqtt::QOS /*qos*/,
-                                                int errorCode)
+                                fprintf(stdout, "Successfully subscribed to %s\n", topic.c_str());
+                                connectionFinishedPromise.set_value();
+                            }
+                            else
                             {
-                                if (!errorCode)
-                                {
-                                    fprintf(stdout, "Successfully subscribed to %s\n", topic.c_str());
-                                    connectionFinishedPromise.set_value();
-                                }
-                                else
-                                {
-                                    fprintf(
-                                        stderr,
-                                        "Failed to subscribe to %s with error %s. Exiting\n",
-                                        topic.c_str(),
-                                        aws_error_debug_str(errorCode));
-                                    exit(-1);
-                                }
-                            };
+                                fprintf(
+                                    stderr, "Failed to subscribe to %s with error %s. Exiting\n", topic.c_str(),
+                                    aws_error_debug_str(errorCode));
+                                exit(-1);
+                            }
+                        };
 
-                            conn.Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_MOST_ONCE, onMessage, onSubAck);
-                        }
-                        else
-                        {
-                            connectionFinishedPromise.set_value();
-                        }
+                        conn.Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_MOST_ONCE, onMessage, onSubAck);
                     }
                     else
                     {
-                        fprintf(
-                            stderr,
-                            "Error connecting to group %s, using connection to %s:%d\n",
-                            groupToUse.GGGroupId->c_str(),
-                            connectivityInfo.HostAddress->c_str(),
-                            (int)connectivityInfo.Port.value());
-                        fprintf(stderr, "Error: %s\n", aws_error_debug_str(errorCode));
-                        exit(-1);
+                        connectionFinishedPromise.set_value();
                     }
-                };
-
-                connection->OnConnectionInterrupted = [](Mqtt::MqttConnection &, int errorCode)
-                { fprintf(stderr, "Connection interrupted with error %s\n", aws_error_debug_str(errorCode)); };
-
-                connection->OnConnectionResumed =
-                    [](Mqtt::MqttConnection & /*connection*/, Mqtt::ReturnCode /*connectCode*/, bool /*sessionPresent*/)
-                { fprintf(stdout, "Connection resumed\n"); };
-
-                connection->OnDisconnect = [&](Mqtt::MqttConnection & /*connection*/)
+                }
+                else
                 {
-                    fprintf(stdout, "Connection disconnected. Shutting Down.....\n");
-                    shutdownCompletedPromise.set_value();
-                };
-
-                if (!connection->Connect(thingName.c_str(), false))
-                {
-                    fprintf(stderr, "Connect failed with error %s\n", aws_error_debug_str(aws_last_error()));
+                    fprintf(
+                        stderr, "Error connecting to group %s, using connection to %s:%d\n",
+                        groupToUse.GGGroupId->c_str(), connectivityInfo.HostAddress->c_str(),
+                        (int)connectivityInfo.Port.value());
+                    fprintf(stderr, "Error: %s\n", aws_error_debug_str(errorCode));
                     exit(-1);
                 }
-            }
-            else
+            };
+
+            connection->OnConnectionInterrupted = [](Mqtt::MqttConnection &, int errorCode) {
+                fprintf(stderr, "Connection interrupted with error %s\n", aws_error_debug_str(errorCode));
+            };
+
+            connection->OnConnectionResumed = [](Mqtt::MqttConnection & /*connection*/,
+                                                 Mqtt::ReturnCode /*connectCode*/,
+                                                 bool /*sessionPresent*/) { fprintf(stdout, "Connection resumed\n"); };
+
+            connection->OnDisconnect = [&](Mqtt::MqttConnection & /*connection*/) {
+                fprintf(stdout, "Connection disconnected. Shutting Down.....\n");
+                shutdownCompletedPromise.set_value();
+            };
+
+            if (!connection->Connect(thingName.c_str(), false))
             {
-                fprintf(
-                    stderr,
-                    "Discover failed with error: %s, and http response code %d\n",
-                    aws_error_debug_str(error),
-                    httpResponseCode);
+                fprintf(stderr, "Connect failed with error %s\n", aws_error_debug_str(aws_last_error()));
                 exit(-1);
             }
-        });
+        }
+        else
+        {
+            fprintf(
+                stderr, "Discover failed with error: %s, and http response code %d\n", aws_error_debug_str(error),
+                httpResponseCode);
+            exit(-1);
+        }
+    });
 
     {
         connectionFinishedPromise.get_future().wait();
@@ -314,8 +286,7 @@ int main(int argc, char *argv[])
             ByteBuf payload = ByteBufNewCopy(DefaultAllocator(), (const uint8_t *)input.data(), input.length());
             ByteBuf *payloadPtr = &payload;
 
-            auto onPublishComplete = [payloadPtr](Mqtt::MqttConnection &, uint16_t packetId, int errorCode)
-            {
+            auto onPublishComplete = [payloadPtr](Mqtt::MqttConnection &, uint16_t packetId, int errorCode) {
                 aws_byte_buf_clean_up(payloadPtr);
 
                 if (packetId)

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -53,8 +53,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "proxy_host", "<str>", "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<int>", "Proxy port to use for discovery call. (optional, default='0')");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -19,7 +19,7 @@
 using namespace Aws::Crt;
 using namespace Aws::Discovery;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -47,12 +47,11 @@ int main(int argc, char *argv[])
         "region", "<str>", "The region for your Greengrass groups (optional, default='us-east-1').");
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
     cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic')");
-    cmdUtils.RegisterCommand("mode", "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
+    cmdUtils.RegisterCommand(
+        "mode", "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
     cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
     cmdUtils.RegisterCommand(
-        "proxy_host",
-        "<str>",
-        "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
+        "proxy_host", "<str>", "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<int>", "Proxy port to use for discovery call. (optional, default='0')");
     cmdUtils.SendArguments(argv, argv + argc);
 

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -50,7 +50,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("mode", "<both|publish|subscribe>", "Default both (optional)");
     cmdUtils.RegisterCommand("message", "<message to publish>", "Message to publish. Default 'Hello World' (optional)");
     cmdUtils.RegisterCommand(
-        "proxy_host", "<proxy host name>",
+        "proxy_host",
+        "<proxy host name>",
         "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Proxy port to use for discovery call. (optional)");
     cmdUtils.SendArguments(argv, argv + argc);
@@ -156,9 +157,12 @@ int main(int argc, char *argv[])
             auto connectivityInfo = groupToUse.Cores->at(0).Connectivity->at(0);
 
             fprintf(
-                stdout, "Connecting to group %s with thing arn %s, using endpoint %s:%d\n",
-                groupToUse.GGGroupId->c_str(), groupToUse.Cores->at(0).ThingArn->c_str(),
-                connectivityInfo.HostAddress->c_str(), (int)connectivityInfo.Port.value());
+                stdout,
+                "Connecting to group %s with thing arn %s, using endpoint %s:%d\n",
+                groupToUse.GGGroupId->c_str(),
+                groupToUse.Cores->at(0).ThingArn->c_str(),
+                connectivityInfo.HostAddress->c_str(),
+                (int)connectivityInfo.Port.value());
 
             connection = mqttClient.NewConnection(
                 Aws::Iot::MqttClientConnectionConfigBuilder(certificatePath.c_str(), keyPath.c_str())
@@ -174,26 +178,38 @@ int main(int argc, char *argv[])
             }
 
             connection->OnConnectionCompleted = [&, connectivityInfo, groupToUse](
-                                                    Mqtt::MqttConnection &conn, int errorCode,
-                                                    Mqtt::ReturnCode /*returnCode*/, bool /*sessionPresent*/) {
+                                                    Mqtt::MqttConnection &conn,
+                                                    int errorCode,
+                                                    Mqtt::ReturnCode /*returnCode*/,
+                                                    bool /*sessionPresent*/) {
                 if (!errorCode)
                 {
                     fprintf(
-                        stdout, "Connected to group %s, using connection to %s:%d\n", groupToUse.GGGroupId->c_str(),
-                        connectivityInfo.HostAddress->c_str(), (int)connectivityInfo.Port.value());
+                        stdout,
+                        "Connected to group %s, using connection to %s:%d\n",
+                        groupToUse.GGGroupId->c_str(),
+                        connectivityInfo.HostAddress->c_str(),
+                        (int)connectivityInfo.Port.value());
 
                     if (mode == "both" || mode == "subscribe")
                     {
-                        auto onMessage = [&](Mqtt::MqttConnection & /*connection*/, const String &receivedOnTopic,
-                                             const ByteBuf &payload, bool /*dup*/, Mqtt::QOS /*qos*/, bool /*retain*/) {
+                        auto onMessage = [&](Mqtt::MqttConnection & /*connection*/,
+                                             const String &receivedOnTopic,
+                                             const ByteBuf &payload,
+                                             bool /*dup*/,
+                                             Mqtt::QOS /*qos*/,
+                                             bool /*retain*/) {
                             fprintf(stdout, "Publish received on topic %s\n", receivedOnTopic.c_str());
                             fprintf(stdout, "Message: \n");
                             fwrite(payload.buffer, 1, payload.len, stdout);
                             fprintf(stdout, "\n");
                         };
 
-                        auto onSubAck = [&](Mqtt::MqttConnection & /*connection*/, uint16_t /*packetId*/,
-                                            const String &topic, Mqtt::QOS /*qos*/, int errorCode) {
+                        auto onSubAck = [&](Mqtt::MqttConnection & /*connection*/,
+                                            uint16_t /*packetId*/,
+                                            const String &topic,
+                                            Mqtt::QOS /*qos*/,
+                                            int errorCode) {
                             if (!errorCode)
                             {
                                 fprintf(stdout, "Successfully subscribed to %s\n", topic.c_str());
@@ -202,7 +218,9 @@ int main(int argc, char *argv[])
                             else
                             {
                                 fprintf(
-                                    stderr, "Failed to subscribe to %s with error %s. Exiting\n", topic.c_str(),
+                                    stderr,
+                                    "Failed to subscribe to %s with error %s. Exiting\n",
+                                    topic.c_str(),
                                     aws_error_debug_str(errorCode));
                                 exit(-1);
                             }
@@ -218,8 +236,10 @@ int main(int argc, char *argv[])
                 else
                 {
                     fprintf(
-                        stderr, "Error connecting to group %s, using connection to %s:%d\n",
-                        groupToUse.GGGroupId->c_str(), connectivityInfo.HostAddress->c_str(),
+                        stderr,
+                        "Error connecting to group %s, using connection to %s:%d\n",
+                        groupToUse.GGGroupId->c_str(),
+                        connectivityInfo.HostAddress->c_str(),
                         (int)connectivityInfo.Port.value());
                     fprintf(stderr, "Error: %s\n", aws_error_debug_str(errorCode));
                     exit(-1);
@@ -248,7 +268,9 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(
-                stderr, "Discover failed with error: %s, and http response code %d\n", aws_error_debug_str(error),
+                stderr,
+                "Discover failed with error: %s, and http response code %d\n",
+                aws_error_debug_str(error),
                 httpResponseCode);
             exit(-1);
         }

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -44,16 +44,16 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RemoveCommand("endpoint");
     cmdUtils.RegisterCommand(
-        "region", "<region>", "The region for your green grass groups, default us-east-1 (optional)");
-    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing");
-    cmdUtils.RegisterCommand("topic", "<topic>", "Targeted topic. Default is test/topic (optional)");
-    cmdUtils.RegisterCommand("mode", "<both|publish|subscribe>", "Default both (optional)");
-    cmdUtils.RegisterCommand("message", "<message to publish>", "Message to publish. Default 'Hello World' (optional)");
+        "region", "<str>", "The region for your Greengrass groups (optional, default='us-east-1').");
+    cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
+    cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic')");
+    cmdUtils.RegisterCommand("mode", "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
+    cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
     cmdUtils.RegisterCommand(
         "proxy_host",
-        "<proxy host name>",
+        "<str>",
         "Proxy host to use for discovery call. Default is to not use a proxy. (optional)");
-    cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Proxy port to use for discovery call. (optional)");
+    cmdUtils.RegisterCommand("proxy_port", "<int>", "Proxy port to use for discovery call. (optional, default='0')");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/greengrass/ipc/CMakeLists.txt
+++ b/samples/greengrass/ipc/CMakeLists.txt
@@ -4,6 +4,8 @@ project(greengrass-ipc CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -30,8 +30,7 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("greengrass-ipc");
     cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic').");
-    cmdUtils.RegisterCommand(
-        "message", "<str>", "Message to publish (optional, default='Hello World').");
+    cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterProgramName("greengrass-ipc");
     cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic').");
     cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -29,8 +29,7 @@ int main(int argc, char *argv[])
     /*********************** Parse Arguments ***************************/
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("greengrass-ipc");
-    cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic').");
-    cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
+    cmdUtils.AddCommonTopicMessageCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
 

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -15,7 +15,7 @@ using namespace Aws::Greengrass;
 /* Used to check that the publish has been received so that the demo can exit successfully. */
 static std::atomic_bool s_publishReceived(false);
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -7,34 +7,13 @@
 
 #include <aws/greengrass/GreengrassCoreIpcClient.h>
 
+#include "../../utils/CommandLineUtils.h"
+
 using namespace Aws::Crt;
 using namespace Aws::Greengrass;
 
-static void s_printHelp()
-{
-    fprintf(stdout, "Usage:\n");
-    fprintf(stdout, "greengrass-ipc --topic <optional: topic> --message <optional: message to publish>\n\n");
-    fprintf(stdout, "topic: targeted topic. Default is test/topic\n");
-    fprintf(stdout, "message: message to publish. default 'Hello World'\n");
-}
-
 /* Used to check that the publish has been received so that the demo can exit successfully. */
 static std::atomic_bool s_publishReceived(false);
-
-bool s_cmdOptionExists(char **begin, char **end, const String &option)
-{
-    return std::find(begin, end, option) != end;
-}
-
-char *s_getCmdOption(char **begin, char **end, const String &option)
-{
-    char **itr = std::find(begin, end, option);
-    if (itr != end && ++itr != end)
-    {
-        return *itr;
-    }
-    return 0;
-}
 
 int main(int argc, char *argv[])
 {
@@ -48,21 +27,20 @@ int main(int argc, char *argv[])
     String message("Hello World");
 
     /*********************** Parse Arguments ***************************/
-    if (s_cmdOptionExists(argv, argv + argc, "--help"))
-    {
-        s_printHelp();
-        return 0;
-    }
+    Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.RegisterProgramName("greengrass-ipc");
+    cmdUtils.RegisterCommand("topic", "<topic>", "Targeted topic. Default is test/topic. (optional)");
+    cmdUtils.RegisterCommand(
+        "message", "<message to publish>", "Message to publish. Default 'Hello World'. (optional)");
+    cmdUtils.SendArguments(argv, argv + argc);
 
-    if (s_cmdOptionExists(argv, argv + argc, "--topic"))
+    if (cmdUtils.HasCommand("help"))
     {
-        topic = s_getCmdOption(argv, argv + argc, "--topic");
+        cmdUtils.PrintHelp();
+        exit(-1);
     }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--message"))
-    {
-        message = s_getCmdOption(argv, argv + argc, "--message");
-    }
+    topic = cmdUtils.GetCommandOrDefault("topic", topic);
+    message = cmdUtils.GetCommandOrDefault("message", message);
 
     Io::EventLoopGroup eventLoopGroup(1);
     if (!eventLoopGroup)

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -82,7 +82,8 @@ int main(int argc, char *argv[])
         bool OnErrorCallback(RpcError status) override
         {
             fprintf(
-                stdout, "Processing messages from the Greengrass Core resulted in error: %s\n",
+                stdout,
+                "Processing messages from the Greengrass Core resulted in error: %s\n",
                 status.StatusToString().c_str());
             return true;
         }
@@ -167,7 +168,8 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(
-                stderr, "Attempting to receive the response from the server failed with error code %s\n",
+                stderr,
+                "Attempting to receive the response from the server failed with error code %s\n",
                 subscribeResult.GetRpcError().StatusToString().c_str());
         }
     }
@@ -185,7 +187,9 @@ int main(int argc, char *argv[])
     if (!requestStatus)
     {
         fprintf(
-            stderr, "Failed to publish to %s topic with error %s\n", topic.c_str(),
+            stderr,
+            "Failed to publish to %s topic with error %s\n",
+            topic.c_str(),
             requestStatus.StatusToString().c_str());
         exit(-1);
     }
@@ -224,7 +228,8 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(
-                stderr, "Attempting to receive the response from the server failed with error code %s\n",
+                stderr,
+                "Attempting to receive the response from the server failed with error code %s\n",
                 publishResult.GetRpcError().StatusToString().c_str());
         }
     }

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -29,9 +29,9 @@ int main(int argc, char *argv[])
     /*********************** Parse Arguments ***************************/
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("greengrass-ipc");
-    cmdUtils.RegisterCommand("topic", "<topic>", "Targeted topic. Default is test/topic. (optional)");
+    cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic').");
     cmdUtils.RegisterCommand(
-        "message", "<message to publish>", "Message to publish. Default 'Hello World'. (optional)");
+        "message", "<str>", "Message to publish (optional, default='Hello World').");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -15,7 +15,7 @@ using namespace Aws::Greengrass;
 /* Used to check that the publish has been received so that the demo can exit successfully. */
 static std::atomic_bool s_publishReceived(false);
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -31,7 +31,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterProgramName("greengrass-ipc");
     cmdUtils.RegisterCommand("topic", "<str>", "Targeted topic (optional, default='test/topic').");
     cmdUtils.RegisterCommand("message", "<str>", "Message to publish (optional, default='Hello World').");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -82,8 +82,7 @@ int main(int argc, char *argv[])
         bool OnErrorCallback(RpcError status) override
         {
             fprintf(
-                stdout,
-                "Processing messages from the Greengrass Core resulted in error: %s\n",
+                stdout, "Processing messages from the Greengrass Core resulted in error: %s\n",
                 status.StatusToString().c_str());
             return true;
         }
@@ -168,8 +167,7 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(
-                stderr,
-                "Attempting to receive the response from the server failed with error code %s\n",
+                stderr, "Attempting to receive the response from the server failed with error code %s\n",
                 subscribeResult.GetRpcError().StatusToString().c_str());
         }
     }
@@ -187,9 +185,7 @@ int main(int argc, char *argv[])
     if (!requestStatus)
     {
         fprintf(
-            stderr,
-            "Failed to publish to %s topic with error %s\n",
-            topic.c_str(),
+            stderr, "Failed to publish to %s topic with error %s\n", topic.c_str(),
             requestStatus.StatusToString().c_str());
         exit(-1);
     }
@@ -228,8 +224,7 @@ int main(int argc, char *argv[])
         else
         {
             fprintf(
-                stderr,
-                "Attempting to receive the response from the server failed with error code %s\n",
+                stderr, "Attempting to receive the response from the server failed with error code %s\n",
                 publishResult.GetRpcError().StatusToString().c_str());
         }
     }

--- a/samples/identity/fleet_provisioning/CMakeLists.txt
+++ b/samples/identity/fleet_provisioning/CMakeLists.txt
@@ -4,6 +4,8 @@ project(fleet-provisioning CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -133,8 +133,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -177,8 +176,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -194,8 +192,7 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -231,8 +228,7 @@ int main(int argc, char *argv[])
         std::promise<void> registerAcceptedCompletedPromise;
         std::promise<void> registerRejectedCompletedPromise;
 
-        auto onCsrPublishSubAck = [&](int ioErr)
-        {
+        auto onCsrPublishSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error publishing to CreateCertificateFromCsr: %s\n", ErrorDebugString(ioErr));
@@ -242,8 +238,7 @@ int main(int argc, char *argv[])
             csrPublishCompletedPromise.set_value();
         };
 
-        auto onCsrAcceptedSubAck = [&](int ioErr)
-        {
+        auto onCsrAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -254,8 +249,7 @@ int main(int argc, char *argv[])
             csrAcceptedCompletedPromise.set_value();
         };
 
-        auto onCsrRejectedSubAck = [&](int ioErr)
-        {
+        auto onCsrRejectedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -265,8 +259,7 @@ int main(int argc, char *argv[])
             csrRejectedCompletedPromise.set_value();
         };
 
-        auto onCsrAccepted = [&](CreateCertificateFromCsrResponse *response, int ioErr)
-        {
+        auto onCsrAccepted = [&](CreateCertificateFromCsrResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -280,16 +273,12 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onCsrRejected = [&](ErrorResponse *error, int ioErr)
-        {
+        auto onCsrRejected = [&](ErrorResponse *error, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout,
-                    "CreateCertificateFromCsr failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode,
-                    error->ErrorMessage->c_str(),
-                    error->ErrorCode->c_str());
+                    stdout, "CreateCertificateFromCsr failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
                 exit(-1);
             }
             else
@@ -299,8 +288,7 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onKeysPublishSubAck = [&](int ioErr)
-        {
+        auto onKeysPublishSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error publishing to CreateKeysAndCertificate: %s\n", ErrorDebugString(ioErr));
@@ -310,8 +298,7 @@ int main(int argc, char *argv[])
             keysPublishCompletedPromise.set_value();
         };
 
-        auto onKeysAcceptedSubAck = [&](int ioErr)
-        {
+        auto onKeysAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -322,8 +309,7 @@ int main(int argc, char *argv[])
             keysAcceptedCompletedPromise.set_value();
         };
 
-        auto onKeysRejectedSubAck = [&](int ioErr)
-        {
+        auto onKeysRejectedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -333,8 +319,7 @@ int main(int argc, char *argv[])
             keysRejectedCompletedPromise.set_value();
         };
 
-        auto onKeysAccepted = [&](CreateKeysAndCertificateResponse *response, int ioErr)
-        {
+        auto onKeysAccepted = [&](CreateKeysAndCertificateResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
@@ -348,16 +333,12 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onKeysRejected = [&](ErrorResponse *error, int ioErr)
-        {
+        auto onKeysRejected = [&](ErrorResponse *error, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout,
-                    "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode,
-                    error->ErrorMessage->c_str(),
-                    error->ErrorCode->c_str());
+                    stdout, "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
                 exit(-1);
             }
             else
@@ -367,8 +348,7 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onRegisterAcceptedSubAck = [&](int ioErr)
-        {
+        auto onRegisterAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error subscribing to RegisterThing accepted: %s\n", ErrorDebugString(ioErr));
@@ -378,8 +358,7 @@ int main(int argc, char *argv[])
             registerAcceptedCompletedPromise.set_value();
         };
 
-        auto onRegisterRejectedSubAck = [&](int ioErr)
-        {
+        auto onRegisterRejectedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error subscribing to RegisterThing rejected: %s\n", ErrorDebugString(ioErr));
@@ -388,8 +367,7 @@ int main(int argc, char *argv[])
             registerRejectedCompletedPromise.set_value();
         };
 
-        auto onRegisterAccepted = [&](RegisterThingResponse *response, int ioErr)
-        {
+        auto onRegisterAccepted = [&](RegisterThingResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(stdout, "RegisterThingResponse ThingName: %s.\n", response->ThingName->c_str());
@@ -401,16 +379,12 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onRegisterRejected = [&](ErrorResponse *error, int ioErr)
-        {
+        auto onRegisterRejected = [&](ErrorResponse *error, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout,
-                    "RegisterThing failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode,
-                    error->ErrorMessage->c_str(),
-                    error->ErrorCode->c_str());
+                    stdout, "RegisterThing failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
             }
             else
             {
@@ -419,8 +393,7 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onRegisterPublishSubAck = [&](int ioErr)
-        {
+        auto onRegisterPublishSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error publishing to RegisterThing: %s\n", ErrorDebugString(ioErr));

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -82,8 +82,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("template_name", "<str>", "The name of your provisioning template");
     cmdUtils.RegisterCommand("template_parameters", "<json>", "Template parameters json");
     cmdUtils.RegisterCommand("csr", "<path>", "Path to CSR in PEM format (optional)");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -133,7 +133,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -277,8 +278,11 @@ int main(int argc, char *argv[])
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout, "CreateCertificateFromCsr failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
+                    stdout,
+                    "CreateCertificateFromCsr failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode,
+                    error->ErrorMessage->c_str(),
+                    error->ErrorCode->c_str());
                 exit(-1);
             }
             else
@@ -337,8 +341,11 @@ int main(int argc, char *argv[])
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout, "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
+                    stdout,
+                    "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode,
+                    error->ErrorMessage->c_str(),
+                    error->ErrorCode->c_str());
                 exit(-1);
             }
             else
@@ -383,8 +390,11 @@ int main(int argc, char *argv[])
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout, "RegisterThing failed with statusCode %d, errorMessage %s and errorCode %s.",
-                    *error->StatusCode, error->ErrorMessage->c_str(), error->ErrorCode->c_str());
+                    stdout,
+                    "RegisterThing failed with statusCode %d, errorMessage %s and errorCode %s.",
+                    *error->StatusCode,
+                    error->ErrorMessage->c_str(),
+                    error->ErrorCode->c_str());
             }
             else
             {

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -53,7 +53,7 @@ static std::string getFileData(std::string const &fileName)
     return str;
 }
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -82,7 +82,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterCommand("template_name", "<str>", "The name of your provisioning template");
     cmdUtils.RegisterCommand("template_parameters", "<json>", "Template parameters json");
     cmdUtils.RegisterCommand("csr", "<path>", "Path to CSR in PEM format (optional)");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -53,7 +53,7 @@ static std::string getFileData(std::string const &fileName)
     return str;
 }
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -79,9 +79,9 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("fleet-provisioning");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("template_name", "<template name>", "The name of your provisioning template");
-    cmdUtils.RegisterCommand("template_parameters", "<template parameters>", "Template parameters json");
-    cmdUtils.RegisterCommand("csr", "<path to csr>", "Path to CSR in PEM format (optional)");
+    cmdUtils.RegisterCommand("template_name", "<str>", "The name of your provisioning template");
+    cmdUtils.RegisterCommand("template_parameters", "<json>", "Template parameters json");
+    cmdUtils.RegisterCommand("csr", "<path>", "Path to CSR in PEM format (optional)");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
     caFile = cmdUtils.GetCommandOrDefault("ca_file", caFile);
     if (cmdUtils.HasCommand("csr"))
     {
-        csrFile = getFileData(cmdUtils.GetCommand("csr").c_str());
+        csrFile = getFileData(cmdUtils.GetCommand("csr").c_str()).c_str();
     }
 
     /********************** Now Setup an Mqtt Client ******************/

--- a/samples/jobs/describe_job_execution/CMakeLists.txt
+++ b/samples/jobs/describe_job_execution/CMakeLists.txt
@@ -4,6 +4,8 @@ project(describe-job-execution CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -93,8 +93,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -138,8 +137,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -155,8 +153,7 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -187,13 +184,11 @@ int main(int argc, char *argv[])
         // This isn't absolutely necessary but since we're doing a publish almost immediately afterwards,
         // to be cautious make sure the subscribe has finished before doing the publish.
         std::promise<void> subAckedPromise;
-        auto subAckHandler = [&](int)
-        {
+        auto subAckHandler = [&](int) {
             /* if error code returns it will be recorded by the other callback */
             subAckedPromise.set_value();
         };
-        auto subscriptionHandler = [&](DescribeJobExecutionResponse *response, int ioErr)
-        {
+        auto subscriptionHandler = [&](DescribeJobExecutionResponse *response, int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
@@ -211,8 +206,7 @@ int main(int argc, char *argv[])
         subAckedPromise.get_future().wait();
 
         subAckedPromise = std::promise<void>();
-        auto failureHandler = [&](RejectedError *rejectedError, int ioErr)
-        {
+        auto failureHandler = [&](RejectedError *rejectedError, int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
@@ -238,8 +232,7 @@ int main(int argc, char *argv[])
         describeJobExecutionRequest.ClientToken = uuid.ToString();
         std::promise<void> publishDescribeJobExeCompletedPromise;
 
-        auto publishHandler = [&](int ioErr)
-        {
+        auto publishHandler = [&](int ioErr) {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -93,7 +93,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -24,7 +24,7 @@
 using namespace Aws::Crt;
 using namespace Aws::Iotjobs;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -46,7 +46,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("job_id", "<str>", "The job id you want to describe.");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -46,8 +46,8 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("job_id", "<str>", "The job id you want to describe.");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -44,8 +44,8 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("describe-job-execution");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing.");
-    cmdUtils.RegisterCommand("job_id", "<job id>", "The job id you want to describe.");
+    cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
+    cmdUtils.RegisterCommand("job_id", "<str>", "The job id you want to describe.");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -19,43 +19,10 @@
 #include <iostream>
 #include <mutex>
 
+#include "../../utils/CommandLineUtils.h"
+
 using namespace Aws::Crt;
 using namespace Aws::Iotjobs;
-
-static void s_printHelp()
-{
-    fprintf(stdout, "Usage:\n");
-    fprintf(
-        stdout,
-        "describe-job-execution --endpoint <endpoint> --cert <path to cert>"
-        " --key <path to key> --ca_file <optional: path to custom ca>"
-        " --thing_name <thing name> --job_id <job id>\n\n");
-    fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
-    fprintf(stdout, "cert: path to your client certificate in PEM format\n");
-    fprintf(stdout, "key: path to your key in PEM format\n");
-    fprintf(
-        stdout,
-        "ca_file: Optional, if the mqtt server uses a certificate that's not already"
-        " in your trust store, set this.\n");
-    fprintf(stdout, "\tIt's the path to a CA file in PEM format\n");
-    fprintf(stdout, "thing_name: the name of your IOT thing\n");
-    fprintf(stdout, "job_id: the job id you want to describe.\n");
-}
-
-bool s_cmdOptionExists(char **begin, char **end, const String &option)
-{
-    return std::find(begin, end, option) != end;
-}
-
-char *s_getCmdOption(char **begin, char **end, const String &option)
-{
-    char **itr = std::find(begin, end, option);
-    if (itr != end && ++itr != end)
-    {
-        return *itr;
-    }
-    return 0;
-}
 
 int main(int argc, char *argv[])
 {
@@ -74,24 +41,24 @@ int main(int argc, char *argv[])
     String jobId;
 
     /*********************** Parse Arguments ***************************/
-    if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--cert") &&
-          s_cmdOptionExists(argv, argv + argc, "--key") && s_cmdOptionExists(argv, argv + argc, "--thing_name") &&
-          s_cmdOptionExists(argv, argv + argc, "--job_id")))
-    {
-        s_printHelp();
-        return 0;
-    }
+    Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.RegisterProgramName("describe-job-execution");
+    cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing.");
+    cmdUtils.RegisterCommand("job_id", "<job id>", "The job id you want to describe.");
+    cmdUtils.SendArguments(argv, argv + argc);
 
-    endpoint = s_getCmdOption(argv, argv + argc, "--endpoint");
-    certificatePath = s_getCmdOption(argv, argv + argc, "--cert");
-    keyPath = s_getCmdOption(argv, argv + argc, "--key");
-    thingName = s_getCmdOption(argv, argv + argc, "--thing_name");
-    jobId = s_getCmdOption(argv, argv + argc, "--job_id");
-
-    if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
+    if (cmdUtils.HasCommand("help"))
     {
-        caFile = s_getCmdOption(argv, argv + argc, "--ca_file");
+        cmdUtils.PrintHelp();
+        exit(-1);
     }
+    endpoint = cmdUtils.GetCommandRequired("endpoint");
+    certificatePath = cmdUtils.GetCommandRequired("cert");
+    keyPath = cmdUtils.GetCommandRequired("key");
+    thingName = cmdUtils.GetCommandRequired("thing_name");
+    jobId = cmdUtils.GetCommandRequired("job_id");
+    caFile = cmdUtils.GetCommandOrDefault("ca_file", caFile);
 
     /********************** Now Setup an Mqtt Client ******************/
     /*
@@ -171,7 +138,8 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
+    {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -187,7 +155,8 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
+    {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -218,11 +187,13 @@ int main(int argc, char *argv[])
         // This isn't absolutely necessary but since we're doing a publish almost immediately afterwards,
         // to be cautious make sure the subscribe has finished before doing the publish.
         std::promise<void> subAckedPromise;
-        auto subAckHandler = [&](int) {
+        auto subAckHandler = [&](int)
+        {
             /* if error code returns it will be recorded by the other callback */
             subAckedPromise.set_value();
         };
-        auto subscriptionHandler = [&](DescribeJobExecutionResponse *response, int ioErr) {
+        auto subscriptionHandler = [&](DescribeJobExecutionResponse *response, int ioErr)
+        {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
@@ -240,7 +211,8 @@ int main(int argc, char *argv[])
         subAckedPromise.get_future().wait();
 
         subAckedPromise = std::promise<void>();
-        auto failureHandler = [&](RejectedError *rejectedError, int ioErr) {
+        auto failureHandler = [&](RejectedError *rejectedError, int ioErr)
+        {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);
@@ -266,7 +238,8 @@ int main(int argc, char *argv[])
         describeJobExecutionRequest.ClientToken = uuid.ToString();
         std::promise<void> publishDescribeJobExeCompletedPromise;
 
-        auto publishHandler = [&](int ioErr) {
+        auto publishHandler = [&](int ioErr)
+        {
             if (ioErr)
             {
                 fprintf(stderr, "Error %d occurred\n", ioErr);

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -24,7 +24,7 @@
 using namespace Aws::Crt;
 using namespace Aws::Iotjobs;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/mqtt/basic_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/basic_pub_sub/CMakeLists.txt
@@ -4,6 +4,8 @@ project(basic-pub-sub CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -62,13 +62,11 @@ int main(int argc, char *argv[])
         "cert", "Path to your client certificate in PEM format. If this is not set you must specify use_websocket");
     cmdUtils.RegisterCommand("topic", "<topic>", "Topic to publish, subscribe to. (optional)");
     cmdUtils.RegisterCommand(
-        "client_id",
-        "<client id>"
-        "Client id to use (optional)");
+        "client_id", "<client id>"
+                     "Client id to use (optional)");
     cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
     cmdUtils.RegisterCommand(
-        "signing_region",
-        "<region>",
+        "signing_region", "<region>",
         "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
     cmdUtils.RegisterCommand("proxy_host", "<proxy host>", "Host name of the http proxy to use (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Port of the http proxy to use (optional)");
@@ -80,16 +78,13 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "x509_thing", "<thing name>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_cert",
-        "<path to cert>",
+        "x509_cert", "<path to cert>",
         "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_key",
-        "<path to key>",
+        "x509_key", "<path to key>",
         "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_rootca",
-        "<path to root ca>",
+        "x509_rootca", "<path to root ca>",
         "Path to the root certificate used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand("message", "<message>", "The message to send in the payload (optional)");
     cmdUtils.RegisterCommand("count", "<count>", "The number of messages to send (optional)");
@@ -224,8 +219,7 @@ int main(int argc, char *argv[])
             if (!tlsCtxOptions)
             {
                 fprintf(
-                    stderr,
-                    "Unable to initialize tls context options, error: %s!\n",
+                    stderr, "Unable to initialize tls context options, error: %s!\n",
                     ErrorDebugString(tlsCtxOptions.LastError()));
                 return -1;
             }
@@ -239,8 +233,7 @@ int main(int argc, char *argv[])
             if (!x509TlsCtx)
             {
                 fprintf(
-                    stderr,
-                    "Unable to create tls context, error: %s!\n",
+                    stderr, "Unable to create tls context, error: %s!\n",
                     ErrorDebugString(x509TlsCtx.GetInitializationError()));
                 return -1;
             }
@@ -251,8 +244,7 @@ int main(int argc, char *argv[])
             if (!x509Config.TlsOptions)
             {
                 fprintf(
-                    stderr,
-                    "Unable to create tls options from tls context, error: %s!\n",
+                    stderr, "Unable to create tls options from tls context, error: %s!\n",
                     ErrorDebugString(x509Config.TlsOptions.LastError()));
                 return -1;
             }
@@ -308,8 +300,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -347,8 +338,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -369,16 +359,16 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto onInterrupted = [&](Mqtt::MqttConnection &, int error)
-    { fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error)); };
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
+        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
+    };
 
     auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
 
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection &)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -409,13 +399,8 @@ int main(int argc, char *argv[])
         /*
          * This is invoked upon the receipt of a Publish on a subscribed topic.
          */
-        auto onMessage = [&](Mqtt::MqttConnection &,
-                             const String &topic,
-                             const ByteBuf &byteBuf,
-                             bool /*dup*/,
-                             Mqtt::QOS /*qos*/,
-                             bool /*retain*/)
-        {
+        auto onMessage = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf, bool /*dup*/,
+                             Mqtt::QOS /*qos*/, bool /*retain*/) {
             {
                 std::lock_guard<std::mutex> lock(receiveMutex);
                 ++receivedCount;
@@ -432,9 +417,8 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::promise<void> subscribeFinishedPromise;
-        auto onSubAck =
-            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode)
-        {
+        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS,
+                            int errorCode) {
             if (errorCode)
             {
                 fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.AddCommonProxyCommands();
     cmdUtils.AddCommonTopicMessageCommands();
-    cmdUtils.AddCommonx509Commands();
+    cmdUtils.AddCommonX509Commands();
     cmdUtils.AddCommonWebsocketCommands();
     cmdUtils.UpdateCommandHelp(
         "key", "Path to your key in PEM format. If this is not set you must specify use_websocket");

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -20,7 +20,7 @@
 
 using namespace Aws::Crt;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 
     /************************ Setup the Lib ****************************/
@@ -92,7 +92,8 @@ int main(const int argc, const char *argv[])
         "message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -92,8 +92,8 @@ int main(int argc, char *argv[])
         "message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -20,7 +20,7 @@
 
 using namespace Aws::Crt;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
 
     /************************ Setup the Lib ****************************/

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -62,11 +62,13 @@ int main(int argc, char *argv[])
         "cert", "Path to your client certificate in PEM format. If this is not set you must specify use_websocket");
     cmdUtils.RegisterCommand("topic", "<topic>", "Topic to publish, subscribe to. (optional)");
     cmdUtils.RegisterCommand(
-        "client_id", "<client id>"
-                     "Client id to use (optional)");
+        "client_id",
+        "<client id>"
+        "Client id to use (optional)");
     cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
     cmdUtils.RegisterCommand(
-        "signing_region", "<region>",
+        "signing_region",
+        "<region>",
         "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
     cmdUtils.RegisterCommand("proxy_host", "<proxy host>", "Host name of the http proxy to use (optional)");
     cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Port of the http proxy to use (optional)");
@@ -78,13 +80,16 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "x509_thing", "<thing name>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_cert", "<path to cert>",
+        "x509_cert",
+        "<path to cert>",
         "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_key", "<path to key>",
+        "x509_key",
+        "<path to key>",
         "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_rootca", "<path to root ca>",
+        "x509_rootca",
+        "<path to root ca>",
         "Path to the root certificate used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand("message", "<message>", "The message to send in the payload (optional)");
     cmdUtils.RegisterCommand("count", "<count>", "The number of messages to send (optional)");
@@ -219,7 +224,8 @@ int main(int argc, char *argv[])
             if (!tlsCtxOptions)
             {
                 fprintf(
-                    stderr, "Unable to initialize tls context options, error: %s!\n",
+                    stderr,
+                    "Unable to initialize tls context options, error: %s!\n",
                     ErrorDebugString(tlsCtxOptions.LastError()));
                 return -1;
             }
@@ -233,7 +239,8 @@ int main(int argc, char *argv[])
             if (!x509TlsCtx)
             {
                 fprintf(
-                    stderr, "Unable to create tls context, error: %s!\n",
+                    stderr,
+                    "Unable to create tls context, error: %s!\n",
                     ErrorDebugString(x509TlsCtx.GetInitializationError()));
                 return -1;
             }
@@ -244,7 +251,8 @@ int main(int argc, char *argv[])
             if (!x509Config.TlsOptions)
             {
                 fprintf(
-                    stderr, "Unable to create tls options from tls context, error: %s!\n",
+                    stderr,
+                    "Unable to create tls options from tls context, error: %s!\n",
                     ErrorDebugString(x509Config.TlsOptions.LastError()));
                 return -1;
             }
@@ -300,7 +308,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -399,8 +408,12 @@ int main(int argc, char *argv[])
         /*
          * This is invoked upon the receipt of a Publish on a subscribed topic.
          */
-        auto onMessage = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf, bool /*dup*/,
-                             Mqtt::QOS /*qos*/, bool /*retain*/) {
+        auto onMessage = [&](Mqtt::MqttConnection &,
+                             const String &topic,
+                             const ByteBuf &byteBuf,
+                             bool /*dup*/,
+                             Mqtt::QOS /*qos*/,
+                             bool /*retain*/) {
             {
                 std::lock_guard<std::mutex> lock(receiveMutex);
                 ++receivedCount;
@@ -417,27 +430,27 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::promise<void> subscribeFinishedPromise;
-        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS,
-                            int errorCode) {
-            if (errorCode)
-            {
-                fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
-                exit(-1);
-            }
-            else
-            {
-                if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
+        auto onSubAck =
+            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
+                if (errorCode)
                 {
-                    fprintf(stderr, "Subscribe rejected by the broker.");
+                    fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
                     exit(-1);
                 }
                 else
                 {
-                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                    if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
+                    {
+                        fprintf(stderr, "Subscribe rejected by the broker.");
+                        exit(-1);
+                    }
+                    else
+                    {
+                        fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
+                    }
                 }
-            }
-            subscribeFinishedPromise.set_value();
-        };
+                subscribeFinishedPromise.set_value();
+            };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onMessage, onSubAck);
         subscribeFinishedPromise.get_future().wait();

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -75,8 +75,7 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
     cmdUtils.RegisterCommand(
         "x509_role_alias", "<str>", "Role alias to use with the x509 credentials provider (required for x509)");
-    cmdUtils.RegisterCommand(
-        "x509_endpoint", "<str>", "Endpoint to fetch x509 credentials from (required for x509)");
+    cmdUtils.RegisterCommand("x509_endpoint", "<str>", "Endpoint to fetch x509 credentials from (required for x509)");
     cmdUtils.RegisterCommand(
         "x509_thing", "<str>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
     cmdUtils.RegisterCommand(
@@ -88,10 +87,9 @@ int main(int argc, char *argv[])
         "<path>",
         "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_rootca",
-        "<path>",
-        "Path to the root certificate used in fetching x509 credentials (required for x509)");
-    cmdUtils.RegisterCommand("message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
+        "x509_rootca", "<path>", "Path to the root certificate used in fetching x509 credentials (required for x509)");
+    cmdUtils.RegisterCommand(
+        "message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
     cmdUtils.SendArguments(argv, argv + argc);

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -56,40 +56,18 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("basic_pub_sub");
     cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.AddCommonProxyCommands();
+    cmdUtils.AddCommonTopicMessageCommands();
+    cmdUtils.AddCommonx509Commands();
+    cmdUtils.AddCommonWebsocketCommands();
     cmdUtils.UpdateCommandHelp(
         "key", "Path to your key in PEM format. If this is not set you must specify use_websocket");
     cmdUtils.UpdateCommandHelp(
         "cert", "Path to your client certificate in PEM format. If this is not set you must specify use_websocket");
-    cmdUtils.RegisterCommand("topic", "<str>", "Topic to publish, subscribe to. (optional, default='test/topic')");
     cmdUtils.RegisterCommand(
         "client_id",
         "<str>"
         "Client id to use (optional, default='test-*')");
-    cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
-    cmdUtils.RegisterCommand(
-        "signing_region",
-        "<str>",
-        "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
-    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the http proxy to use (optional)");
-    cmdUtils.RegisterCommand("proxy_port", "<int>", "Port of the http proxy to use (optional, default='8080')");
-    cmdUtils.RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
-    cmdUtils.RegisterCommand(
-        "x509_role_alias", "<str>", "Role alias to use with the x509 credentials provider (required for x509)");
-    cmdUtils.RegisterCommand("x509_endpoint", "<str>", "Endpoint to fetch x509 credentials from (required for x509)");
-    cmdUtils.RegisterCommand(
-        "x509_thing", "<str>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
-    cmdUtils.RegisterCommand(
-        "x509_cert",
-        "<path>",
-        "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
-    cmdUtils.RegisterCommand(
-        "x509_key",
-        "<path>",
-        "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
-    cmdUtils.RegisterCommand(
-        "x509_rootca", "<path>", "Path to the root certificate used in fetching x509 credentials (required for x509)");
-    cmdUtils.RegisterCommand(
-        "message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
     const char **const_argv = (const char **)argv;
@@ -163,7 +141,7 @@ int main(int argc, char *argv[])
             "x509_cert", "X509 credentials sourcing requires an IoT certificate to be specified.");
         x509KeyPath = cmdUtils.GetCommandRequired(
             "x509_key", "X509 credentials sourcing requires an IoT thing private key to be specified.");
-        x509RootCAFile = cmdUtils.GetCommandOrDefault("x509_rootca", x509RootCAFile);
+        x509RootCAFile = cmdUtils.GetCommandOrDefault("x509_ca_file", x509RootCAFile);
     }
 
     messagePayload = cmdUtils.GetCommandOrDefault("message", messagePayload);

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -16,70 +16,9 @@
 #include <iostream>
 #include <mutex>
 
+#include "../../utils/CommandLineUtils.h"
+
 using namespace Aws::Crt;
-
-static void s_printHelp()
-{
-    fprintf(stdout, "Usage:\n");
-    fprintf(
-        stdout,
-        "basic-pub-sub --endpoint <endpoint> --cert <path to cert>"
-        " --key <path to key> --topic <topic> --message <message> --count <count>"
-        " --client_id <client id> --ca_file <optional: path to custom ca>"
-        " --use_websocket --signing_region <region> --proxy_host <host> --proxy_port <port>"
-        " --x509 --x509_role_alias <role_alias> --x509_endpoint <endpoint> --x509_thing <thing_name>"
-        " --x509_cert <path to cert> --x509_key <path to key> --x509_rootca <path to root ca>\n\n");
-    fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
-    fprintf(
-        stdout,
-        "cert: path to your client certificate in PEM format. If this is not set you must specify use_websocket\n");
-    fprintf(stdout, "key: path to your key in PEM format. If this is not set you must specify use_websocket\n");
-    fprintf(stdout, "topic: topic to publish, subscribe to. (optional)\n");
-    fprintf(stdout, "message: override payload of published messages. (optional, defaults to \"Hello world!\"))\n");
-    fprintf(stdout, "count: number of messages to publish. (optional, defaults to 10)\n");
-    fprintf(stdout, "client_id: client id to use (optional)\n");
-    fprintf(
-        stdout,
-        "ca_file: Optional, if the mqtt server uses a certificate that's not already"
-        " in your trust store, set this.\n");
-    fprintf(stdout, "\tIt's the path to a CA file in PEM format\n");
-    fprintf(stdout, "use_websocket: if specified, uses a websocket over https (optional)\n");
-    fprintf(
-        stdout,
-        "signing_region: used for websocket signer it should only be specific if websockets are used. (required for "
-        "websockets)\n");
-    fprintf(stdout, "proxy_host: host name of the http proxy to use (optional).\n");
-    fprintf(stdout, "proxy_port: port of the http proxy to use (optional).\n");
-
-    fprintf(stdout, "  x509: Use the x509 credentials provider while using websockets (optional)\n");
-    fprintf(stdout, "  x509_role_alias: Role alias to use with the x509 credentials provider (required for x509)\n");
-    fprintf(stdout, "  x509_endpoint: Endpoint to fetch x509 credentials from (required for x509)\n");
-    fprintf(stdout, "  x509_thing: Thing name to fetch x509 credentials on behalf of (required for x509)\n");
-    fprintf(
-        stdout,
-        "  x509_cert: Path to the IoT thing certificate used in fetching x509 credentials (required for x509)\n");
-    fprintf(
-        stdout,
-        "  x509_key: Path to the IoT thing private key used in fetching x509 credentials (required for x509)\n");
-    fprintf(
-        stdout,
-        "  x509_rootca: Path to the root certificate used in fetching x509 credentials (required for x509)\n\n");
-}
-
-bool s_cmdOptionExists(char **begin, char **end, const String &option)
-{
-    return std::find(begin, end, option) != end;
-}
-
-char *s_getCmdOption(char **begin, char **end, const String &option)
-{
-    char **itr = std::find(begin, end, option);
-    if (itr != end && ++itr != end)
-    {
-        return *itr;
-    }
-    return 0;
-}
 
 int main(int argc, char *argv[])
 {
@@ -114,74 +53,87 @@ int main(int argc, char *argv[])
     String messagePayload("Hello world!");
 
     /*********************** Parse Arguments ***************************/
-    if (!s_cmdOptionExists(argv, argv + argc, "--endpoint"))
+    Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.RegisterProgramName("basic_pub_sub");
+    cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.UpdateCommandHelp(
+        "key", "Path to your key in PEM format. If this is not set you must specify use_websocket");
+    cmdUtils.UpdateCommandHelp(
+        "cert", "Path to your client certificate in PEM format. If this is not set you must specify use_websocket");
+    cmdUtils.RegisterCommand("topic", "<topic>", "Topic to publish, subscribe to. (optional)");
+    cmdUtils.RegisterCommand(
+        "client_id",
+        "<client id>"
+        "Client id to use (optional)");
+    cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
+    cmdUtils.RegisterCommand(
+        "signing_region",
+        "<region>",
+        "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
+    cmdUtils.RegisterCommand("proxy_host", "<proxy host>", "Host name of the http proxy to use (optional)");
+    cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Port of the http proxy to use (optional)");
+    cmdUtils.RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
+    cmdUtils.RegisterCommand(
+        "x509_role_alias", "<role alias>", "Role alias to use with the x509 credentials provider (required for x509)");
+    cmdUtils.RegisterCommand(
+        "x509_endpoint", "<endpoint>", "Endpoint to fetch x509 credentials from (required for x509)");
+    cmdUtils.RegisterCommand(
+        "x509_thing", "<thing name>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
+    cmdUtils.RegisterCommand(
+        "x509_cert",
+        "<path to cert>",
+        "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
+    cmdUtils.RegisterCommand(
+        "x509_key",
+        "<path to key>",
+        "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
+    cmdUtils.RegisterCommand(
+        "x509_rootca",
+        "<path to root ca>",
+        "Path to the root certificate used in fetching x509 credentials (required for x509)");
+    cmdUtils.RegisterCommand("message", "<message>", "The message to send in the payload (optional)");
+    cmdUtils.RegisterCommand("count", "<count>", "The number of messages to send (optional)");
+    cmdUtils.RegisterCommand("help", "", "Prints this message");
+    cmdUtils.SendArguments(argv, argv + argc);
+
+    if (cmdUtils.HasCommand("help"))
     {
-        s_printHelp();
-        return 1;
+        cmdUtils.PrintHelp();
+        exit(-1);
     }
-
-    endpoint = s_getCmdOption(argv, argv + argc, "--endpoint");
-
-    if (s_cmdOptionExists(argv, argv + argc, "--key"))
-    {
-        keyPath = s_getCmdOption(argv, argv + argc, "--key");
-    }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--cert"))
-    {
-        certificatePath = s_getCmdOption(argv, argv + argc, "--cert");
-    }
-
+    endpoint = cmdUtils.GetCommandRequired("endpoint");
+    keyPath = cmdUtils.GetCommandOrDefault("key", keyPath);
+    certificatePath = cmdUtils.GetCommandOrDefault("cert", certificatePath);
     if (keyPath.empty() != certificatePath.empty())
     {
-        fprintf(stdout, "Using mtls (cert and key) requires both the certificate and the private key\n");
-        s_printHelp();
+        cmdUtils.PrintHelp();
+        fprintf(stdout, "Using mtls (cert and key) requires both the certificate and private key\n");
         return 1;
     }
-    if (s_getCmdOption(argv, argv + argc, "--topic"))
+    topic = cmdUtils.GetCommandOrDefault("topic", topic);
+    caFile = cmdUtils.GetCommandOrDefault("ca_file", caFile);
+    clientId = cmdUtils.GetCommandOrDefault("client_id", clientId);
+    if (cmdUtils.HasCommand("use_websocket"))
     {
-        topic = s_getCmdOption(argv, argv + argc, "--topic");
-    }
-    if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
-    {
-        caFile = s_getCmdOption(argv, argv + argc, "--ca_file");
-    }
-    if (s_cmdOptionExists(argv, argv + argc, "--client_id"))
-    {
-        clientId = s_getCmdOption(argv, argv + argc, "--client_id");
-    }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--use_websocket"))
-    {
-        if (!s_cmdOptionExists(argv, argv + argc, "--signing_region"))
-        {
-            fprintf(stdout, "Websockets require a signing region to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
         useWebSocket = true;
-        signingRegion = s_getCmdOption(argv, argv + argc, "--signing_region");
+        signingRegion =
+            cmdUtils.GetCommandRequired("signing_region", "Websockets require a signing region to be specified.");
     }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--proxy_host"))
+    proxyHost = cmdUtils.GetCommandOrDefault("proxy_host", proxyHost);
+    if (cmdUtils.HasCommand("prox_port"))
     {
-        proxyHost = s_getCmdOption(argv, argv + argc, "--proxy_host");
-    }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--proxy_port"))
-    {
-        int port = atoi(s_getCmdOption(argv, argv + argc, "--proxy_port"));
-        if (port > 0 && port <= UINT16_MAX)
+        int port = atoi(cmdUtils.GetCommand("proxy_port").c_str());
+        if (port > 0 && port < UINT16_MAX)
         {
             proxyPort = static_cast<uint16_t>(port);
         }
     }
-
     bool usingMtls = !certificatePath.empty() && !keyPath.empty();
 
     /* one or the other, but not both nor neither */
     if (useWebSocket == usingMtls)
     {
+        cmdUtils.PrintHelp();
         if (useWebSocket && usingMtls)
         {
             fprintf(stdout, "You must use either websockets or mtls for authentication, but not both.\n");
@@ -190,77 +142,35 @@ int main(int argc, char *argv[])
         {
             fprintf(stdout, "You must use either websockets or mtls for authentication.\n");
         }
-
-        s_printHelp();
         return 1;
     }
 
     // x509 credentials provider configuration
-    if (s_cmdOptionExists(argv, argv + argc, "--x509"))
+    if (cmdUtils.HasCommand("x509"))
     {
         if (!useWebSocket)
         {
+            cmdUtils.PrintHelp();
             fprintf(stdout, "X509 credentials sourcing requires websockets to be enabled and configured.\n");
-            s_printHelp();
             return 1;
         }
-
-        if (!s_cmdOptionExists(argv, argv + argc, "--x509_role_alias"))
-        {
-            fprintf(stdout, "X509 credentials sourcing requires an x509 role alias to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
-        x509RoleAlias = s_getCmdOption(argv, argv + argc, "--x509_role_alias");
-
-        if (!s_cmdOptionExists(argv, argv + argc, "--x509_endpoint"))
-        {
-            fprintf(stdout, "X509 credentials sourcing requires an x509 endpoint to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
-        x509Endpoint = s_getCmdOption(argv, argv + argc, "--x509_endpoint");
-
-        if (!s_cmdOptionExists(argv, argv + argc, "--x509_thing"))
-        {
-            fprintf(stdout, "X509 credentials sourcing requires an x509 thing name to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
-        x509ThingName = s_getCmdOption(argv, argv + argc, "--x509_thing");
-
-        if (!s_cmdOptionExists(argv, argv + argc, "--x509_cert"))
-        {
-            fprintf(stdout, "X509 credentials sourcing requires an Iot thing certificate to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
-        x509CertificatePath = s_getCmdOption(argv, argv + argc, "--x509_cert");
-
-        if (!s_cmdOptionExists(argv, argv + argc, "--x509_key"))
-        {
-            fprintf(stdout, "X509 credentials sourcing requires an Iot thing private key to be specified.\n");
-            s_printHelp();
-            return 1;
-        }
-        x509KeyPath = s_getCmdOption(argv, argv + argc, "--x509_key");
-
-        if (s_cmdOptionExists(argv, argv + argc, "--x509_rootca"))
-        {
-            x509RootCAFile = s_getCmdOption(argv, argv + argc, "--x509_rootca");
-        }
-
-        useX509 = true;
+        x509RoleAlias = cmdUtils.GetCommandRequired(
+            "x509_role_alias", "X509 credentials sourcing requires an x509 role alias to be specified.");
+        x509Endpoint = cmdUtils.GetCommandRequired(
+            "x509_endpoint", "X509 credentials sourcing requires an x509 endpoint to be specified.");
+        x509ThingName = cmdUtils.GetCommandRequired(
+            "x509_thing", "X509 credentials sourcing requires an x509 thing name to be specified.");
+        x509CertificatePath = cmdUtils.GetCommandRequired(
+            "x509_cert", "X509 credentials sourcing requires an IoT certificate to be specified.");
+        x509KeyPath = cmdUtils.GetCommandRequired(
+            "x509_key", "X509 credentials sourcing requires an IoT thing private key to be specified.");
+        x509RootCAFile = cmdUtils.GetCommandOrDefault("x509_rootca", x509RootCAFile);
     }
 
-    if (s_cmdOptionExists(argv, argv + argc, "--message"))
+    messagePayload = cmdUtils.GetCommandOrDefault("message", messagePayload);
+    if (cmdUtils.HasCommand("count"))
     {
-        messagePayload = s_getCmdOption(argv, argv + argc, "--message");
-    }
-
-    if (s_cmdOptionExists(argv, argv + argc, "--count"))
-    {
-        int count = atoi(s_getCmdOption(argv, argv + argc, "--count"));
+        int count = atoi(cmdUtils.GetCommand("count").c_str());
         if (count > 0)
         {
             messageCount = count;
@@ -378,7 +288,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        s_printHelp();
+        cmdUtils.PrintHelp();
     }
 
     if (!proxyHost.empty())
@@ -437,7 +347,8 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
+    {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -458,16 +369,16 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
-        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
-    };
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error)
+    { fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error)); };
 
     auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
 
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection &) {
+    auto onDisconnect = [&](Mqtt::MqttConnection &)
+    {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -503,7 +414,8 @@ int main(int argc, char *argv[])
                              const ByteBuf &byteBuf,
                              bool /*dup*/,
                              Mqtt::QOS /*qos*/,
-                             bool /*retain*/) {
+                             bool /*retain*/)
+        {
             {
                 std::lock_guard<std::mutex> lock(receiveMutex);
                 ++receivedCount;
@@ -521,26 +433,27 @@ int main(int argc, char *argv[])
          */
         std::promise<void> subscribeFinishedPromise;
         auto onSubAck =
-            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
-                if (errorCode)
+            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode)
+        {
+            if (errorCode)
+            {
+                fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+                exit(-1);
+            }
+            else
+            {
+                if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
                 {
-                    fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
+                    fprintf(stderr, "Subscribe rejected by the broker.");
                     exit(-1);
                 }
                 else
                 {
-                    if (!packetId || QoS == AWS_MQTT_QOS_FAILURE)
-                    {
-                        fprintf(stderr, "Subscribe rejected by the broker.");
-                        exit(-1);
-                    }
-                    else
-                    {
-                        fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
-                    }
+                    fprintf(stdout, "Subscribe on topic %s on packetId %d Succeeded\n", topic.c_str(), packetId);
                 }
-                subscribeFinishedPromise.set_value();
-            };
+            }
+            subscribeFinishedPromise.set_value();
+        };
 
         connection->Subscribe(topic.c_str(), AWS_MQTT_QOS_AT_LEAST_ONCE, onMessage, onSubAck);
         subscribeFinishedPromise.get_future().wait();

--- a/samples/mqtt/basic_pub_sub/main.cpp
+++ b/samples/mqtt/basic_pub_sub/main.cpp
@@ -60,39 +60,39 @@ int main(int argc, char *argv[])
         "key", "Path to your key in PEM format. If this is not set you must specify use_websocket");
     cmdUtils.UpdateCommandHelp(
         "cert", "Path to your client certificate in PEM format. If this is not set you must specify use_websocket");
-    cmdUtils.RegisterCommand("topic", "<topic>", "Topic to publish, subscribe to. (optional)");
+    cmdUtils.RegisterCommand("topic", "<str>", "Topic to publish, subscribe to. (optional, default='test/topic')");
     cmdUtils.RegisterCommand(
         "client_id",
-        "<client id>"
-        "Client id to use (optional)");
+        "<str>"
+        "Client id to use (optional, default='test-*')");
     cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
     cmdUtils.RegisterCommand(
         "signing_region",
-        "<region>",
+        "<str>",
         "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
-    cmdUtils.RegisterCommand("proxy_host", "<proxy host>", "Host name of the http proxy to use (optional)");
-    cmdUtils.RegisterCommand("proxy_port", "<proxy port>", "Port of the http proxy to use (optional)");
+    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the http proxy to use (optional)");
+    cmdUtils.RegisterCommand("proxy_port", "<int>", "Port of the http proxy to use (optional, default='8080')");
     cmdUtils.RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
     cmdUtils.RegisterCommand(
-        "x509_role_alias", "<role alias>", "Role alias to use with the x509 credentials provider (required for x509)");
+        "x509_role_alias", "<str>", "Role alias to use with the x509 credentials provider (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_endpoint", "<endpoint>", "Endpoint to fetch x509 credentials from (required for x509)");
+        "x509_endpoint", "<str>", "Endpoint to fetch x509 credentials from (required for x509)");
     cmdUtils.RegisterCommand(
-        "x509_thing", "<thing name>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
+        "x509_thing", "<str>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
     cmdUtils.RegisterCommand(
         "x509_cert",
-        "<path to cert>",
+        "<path>",
         "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
         "x509_key",
-        "<path to key>",
+        "<path>",
         "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
     cmdUtils.RegisterCommand(
         "x509_rootca",
-        "<path to root ca>",
+        "<path>",
         "Path to the root certificate used in fetching x509 credentials (required for x509)");
-    cmdUtils.RegisterCommand("message", "<message>", "The message to send in the payload (optional)");
-    cmdUtils.RegisterCommand("count", "<count>", "The number of messages to send (optional)");
+    cmdUtils.RegisterCommand("message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
+    cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
     cmdUtils.SendArguments(argv, argv + argc);
 

--- a/samples/mqtt/pkcs11_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/pkcs11_pub_sub/CMakeLists.txt
@@ -4,6 +4,8 @@ project(pkcs11-pub-sub CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -139,8 +139,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -174,8 +173,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -196,16 +194,16 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto onInterrupted = [&](Mqtt::MqttConnection &, int error)
-    { fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error)); };
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
+        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
+    };
 
     auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
 
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection &)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -241,13 +239,8 @@ int main(int argc, char *argv[])
     /*
      * This is invoked upon the receipt of a Publish on a subscribed topic.
      */
-    auto onMessage = [&](Mqtt::MqttConnection &,
-                         const String &topic,
-                         const ByteBuf &byteBuf,
-                         bool /*dup*/,
-                         Mqtt::QOS /*qos*/,
-                         bool /*retain*/)
-    {
+    auto onMessage = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf, bool /*dup*/,
+                         Mqtt::QOS /*qos*/, bool /*retain*/) {
         {
             std::lock_guard<std::mutex> lock(receiveMutex);
             ++receivedCount;
@@ -264,8 +257,7 @@ int main(int argc, char *argv[])
      * Subscribe for incoming publish messages on topic.
      */
     std::promise<void> subscribeFinishedPromise;
-    auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode)
-    {
+    auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
         if (errorCode)
         {
             fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -139,7 +139,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -239,8 +240,12 @@ int main(int argc, char *argv[])
     /*
      * This is invoked upon the receipt of a Publish on a subscribed topic.
      */
-    auto onMessage = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf, bool /*dup*/,
-                         Mqtt::QOS /*qos*/, bool /*retain*/) {
+    auto onMessage = [&](Mqtt::MqttConnection &,
+                         const String &topic,
+                         const ByteBuf &byteBuf,
+                         bool /*dup*/,
+                         Mqtt::QOS /*qos*/,
+                         bool /*retain*/) {
         {
             std::lock_guard<std::mutex> lock(receiveMutex);
             ++receivedCount;

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -11,7 +11,7 @@
 
 using namespace Aws::Crt;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 
     /************************ Setup the Lib ****************************/
@@ -39,7 +39,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterCommand("count", "<int>", "Number of messages to publish. (optional, default=10).");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -26,16 +26,13 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("pkcs11_pub_sub");
     cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.AddCommonTopicMessageCommands();
     cmdUtils.RemoveCommand("key");
     cmdUtils.RegisterCommand("pkcs11_lib", "<path>", "Path to PKCS#11 library.");
     cmdUtils.RegisterCommand("pin", "<str>", "User PIN for logging into PKCS#11 token.");
     cmdUtils.RegisterCommand("token_label", "<str>", "Label of the PKCS#11 token to use (optional).");
     cmdUtils.RegisterCommand("slot_id", "<int>", "Slot ID containing PKCS#11 token to use (optional).");
     cmdUtils.RegisterCommand("key_label", "<str>", "Label of private key on the PKCS#11 token (optional).");
-    cmdUtils.RegisterCommand(
-        "topic", "<mqtt topic>", "MQTT topic for subscribe and publish (optional, default='/test/topic').");
-    cmdUtils.RegisterCommand(
-        "message", "<mqtt message>", "MQTT message to publish (optional, default='Hello World!').");
     cmdUtils.RegisterCommand("count", "<int>", "Number of messages to publish. (optional, default=10).");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -11,7 +11,7 @@
 
 using namespace Aws::Crt;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
 
     /************************ Setup the Lib ****************************/

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -7,96 +7,9 @@
 #include <aws/crt/io/Pkcs11.h>
 #include <aws/iot/MqttClient.h>
 
+#include "../../utils/CommandLineUtils.h"
+
 using namespace Aws::Crt;
-
-static void s_printHelp()
-{
-    fprintf(stdout, "Usage:\n");
-    fprintf(
-        stdout,
-        "basic-pub-sub"
-        " --endpoint <hostname>"
-        " --cert <path>"
-        " --pkcs11_lib <path>"
-        " --pin <str>"
-        " [--token_label <str>]"
-        " [--slot_id <int>]"
-        " [--key_label <str>]"
-        " [--topic <mqtt topic>]"
-        " [--message <str>]"
-        " [--count <int>]"
-        " [--client_id <str>]"
-        " [--ca_file <path>]"
-        "\n\n");
-    fprintf(stdout, "endpoint       Endpoint of the mqtt server not including a port.\n");
-    fprintf(stdout, "cert           Path to your client certificate in PEM format.\n");
-    fprintf(stdout, "pkcs11_lib     Path to PKCS#11 library.\n");
-    fprintf(stdout, "pin            User PIN for logging into PKCS#11 token.\n");
-    fprintf(stdout, "token_label    Label of the PKCS#11 token to use (optional).\n");
-    fprintf(stdout, "slot_id        Slot ID containing PKCS#11 token to use (optional).\n");
-    fprintf(stdout, "key_label      Label of private key on the PKCS#11 token (optional).\n");
-    fprintf(stdout, "topic          MQTT topic for subscribe and publish (optional, default='/test/topic').\n");
-    fprintf(stdout, "message        MQTT message to publish (optional, default='Hello World!').\n");
-    fprintf(stdout, "count          Number of messages to publish. (optional, default=10).\n");
-    fprintf(stdout, "client_id      Client id to use (optional, default='test-*').\n");
-    fprintf(stdout, "ca_file:       Path to AmazonRootCA1.pem (optional, system trust store used by default).\n");
-    fprintf(stdout, "\n");
-}
-
-class ArgParser
-{
-  public:
-    ArgParser(int argc, char *argv[])
-    {
-        m_argv = argv;
-        m_argvEnd = argv + argc;
-
-        if (Exists("--help"))
-        {
-            s_printHelp();
-            exit(0);
-        }
-    }
-
-    bool Exists(const String &name) const { return std::find(m_argv, m_argvEnd, name) != m_argvEnd; }
-
-    String GetRequired(const String &name) const
-    {
-        const char *val = FindValue(name);
-        if (val == nullptr)
-        {
-            s_printHelp();
-            fprintf(stderr, "Missing required argument: %s\n", name.c_str());
-            exit(-1);
-        }
-        return val;
-    }
-
-    String GetOptional(const String &name, const String &defaultVal)
-    {
-        const char *val = FindValue(name);
-        if (val == nullptr)
-        {
-            return defaultVal;
-        }
-        return val;
-    }
-
-  private:
-    const char *FindValue(const String &name) const
-    {
-        char **itr = std::find(m_argv, m_argvEnd, name);
-        if (itr == m_argvEnd || ++itr == m_argvEnd)
-        {
-            return nullptr;
-        }
-        return *itr;
-    }
-
-  private:
-    char **m_argv;
-    char **m_argvEnd;
-};
 
 int main(int argc, char *argv[])
 {
@@ -110,20 +23,41 @@ int main(int argc, char *argv[])
     // apiHandle.InitializeLogging(LogLevel::Error, stderr);
 
     /*********************** Parse Arguments ***************************/
-    ArgParser args(argc, argv);
+    Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.RegisterProgramName("pkcs11_pub_sub");
+    cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.RemoveCommand("key");
+    cmdUtils.RegisterCommand("pkcs11_lib", "<path>", "Path to PKCS#11 library.");
+    cmdUtils.RegisterCommand("pin", "<str>", "User PIN for logging into PKCS#11 token.");
+    cmdUtils.RegisterCommand("token_label", "<str>", "Label of the PKCS#11 token to use (optional).");
+    cmdUtils.RegisterCommand("slot_id", "<int>", "Slot ID containing PKCS#11 token to use (optional).");
+    cmdUtils.RegisterCommand("key_label", "<str>", "Label of private key on the PKCS#11 token (optional).");
+    cmdUtils.RegisterCommand(
+        "topic", "<mqtt topic>", "MQTT topic for subscribe and publish (optional, default='/test/topic').");
+    cmdUtils.RegisterCommand(
+        "message", "<mqtt message>", "MQTT message to publish (optional, default='Hello World!').");
+    cmdUtils.RegisterCommand("count", "<int>", "Number of messages to publish. (optional, default=10).");
+    cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
+    cmdUtils.RegisterCommand("help", "", "Prints this message");
+    cmdUtils.SendArguments(argv, argv + argc);
 
-    String endpoint = args.GetRequired("--endpoint");
-    String certificatePath = args.GetRequired("--cert");
-    String pkcs11LibPath = args.GetRequired("--pkcs11_lib");
-    String pkcs11UserPin = args.GetRequired("--pin");
-    String pkcs11TokenLabel = args.GetOptional("--token_label", "");
-    String pkcs11SlotIdStr = args.GetOptional("--slot_id", "");
-    String pkcs11KeyLabel = args.GetOptional("--key_label", "");
-    String topic = args.GetOptional("--topic", "test/topic");
-    String messagePayload = args.GetOptional("--message", "Hello world!");
-    int messageCount = std::stoi(args.GetOptional("--count", "10").c_str());
-    String caFile = args.GetOptional("--ca_file", "");
-    String clientId = args.GetOptional("--client_id", String("test-") + Aws::Crt::UUID().ToString());
+    if (cmdUtils.HasCommand("help"))
+    {
+        cmdUtils.PrintHelp();
+        exit(-1);
+    }
+    String endpoint = cmdUtils.GetCommandRequired("endpoint");
+    String certificatePath = cmdUtils.GetCommandRequired("cert");
+    String pkcs11LibPath = cmdUtils.GetCommandRequired("pkcs11_lib");
+    String pkcs11UserPin = cmdUtils.GetCommandRequired("pin");
+    String pkcs11TokenLabel = cmdUtils.GetCommandOrDefault("token_label", "");
+    String pkcs11SlotIdStr = cmdUtils.GetCommandOrDefault("slot_id", "");
+    String pkcs11KeyLabel = cmdUtils.GetCommandOrDefault("key_label", "");
+    String topic = cmdUtils.GetCommandOrDefault("topic", "test/topic");
+    String messagePayload = cmdUtils.GetCommandOrDefault("message", "Hello world!");
+    int messageCount = std::stoi(cmdUtils.GetCommandOrDefault("count", "10").c_str());
+    String caFile = cmdUtils.GetCommandOrDefault("ca_file", "");
+    String clientId = cmdUtils.GetCommandOrDefault("client_id", String("test-") + Aws::Crt::UUID().ToString());
 
     /********************** Now Setup an Mqtt Client ******************/
     /*
@@ -240,7 +174,8 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
+    {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -261,16 +196,16 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
-        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
-    };
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error)
+    { fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error)); };
 
     auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
 
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection &) {
+    auto onDisconnect = [&](Mqtt::MqttConnection &)
+    {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -311,7 +246,8 @@ int main(int argc, char *argv[])
                          const ByteBuf &byteBuf,
                          bool /*dup*/,
                          Mqtt::QOS /*qos*/,
-                         bool /*retain*/) {
+                         bool /*retain*/)
+    {
         {
             std::lock_guard<std::mutex> lock(receiveMutex);
             ++receivedCount;
@@ -328,7 +264,8 @@ int main(int argc, char *argv[])
      * Subscribe for incoming publish messages on topic.
      */
     std::promise<void> subscribeFinishedPromise;
-    auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode) {
+    auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode)
+    {
         if (errorCode)
         {
             fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));

--- a/samples/mqtt/pkcs11_pub_sub/main.cpp
+++ b/samples/mqtt/pkcs11_pub_sub/main.cpp
@@ -39,8 +39,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("count", "<int>", "Number of messages to publish. (optional, default=10).");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/mqtt/raw_pub_sub/CMakeLists.txt
+++ b/samples/mqtt/raw_pub_sub/CMakeLists.txt
@@ -4,6 +4,8 @@ project(raw-pub-sub CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -50,14 +50,14 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("raw_pub_sub");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("topic", "<topic>", "Topic to publish, subscribe to. (optional).");
-    cmdUtils.RegisterCommand("client_id", "<client id>", "Client id to use (optional).");
+    cmdUtils.RegisterCommand("topic", "<str>", "Topic to publish, subscribe to. (optional, default='test/topic').");
+    cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
     cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional).");
-    cmdUtils.RegisterCommand("proxy_host", "<host>", "Host name of the http proxy to use (optional).");
-    cmdUtils.RegisterCommand("proxy_port", "<port>", "port of the http proxy to use (optional).");
-    cmdUtils.RegisterCommand("user_name", "<user name>", "User name to send with mqtt connect.");
-    cmdUtils.RegisterCommand("password", "<password>", "Password to send with mqtt connect.");
-    cmdUtils.RegisterCommand("protocol_name", "<protocol>", "defaults to x-amzn-mqtt-ca (optional).");
+    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the http proxy to use (optional).");
+    cmdUtils.RegisterCommand("proxy_port", "<int>", "port of the http proxy to use (optional, default='8080').");
+    cmdUtils.RegisterCommand("user_name", "<str>", "User name to send with mqtt connect.");
+    cmdUtils.RegisterCommand("password", "<str>", "Password to send with mqtt connect.");
+    cmdUtils.RegisterCommand("protocol_name", "<str>", "The X.509 client certificate auth (optional, default='x-amzn-mqtt-ca').");
     cmdUtils.RegisterCommand(
         "auth_params",
         "<comma delimited list>",

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -19,7 +19,7 @@
 
 using namespace Aws::Crt;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 
     /************************ Setup the Lib ****************************/
@@ -64,7 +64,8 @@ int main(const int argc, const char *argv[])
         "<comma delimited list>",
         "Comma delimited list of auth parameters. For websockets these will be set as headers (optional).");
     cmdUtils.RegisterCommand(Utils::CommandLineOption("help", "", "Prints this message"));
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -59,8 +59,7 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("password", "<password>", "Password to send with mqtt connect.");
     cmdUtils.RegisterCommand("protocol_name", "<protocol>", "defaults to x-amzn-mqtt-ca (optional).");
     cmdUtils.RegisterCommand(
-        "auth_params",
-        "<comma delimited list>",
+        "auth_params", "<comma delimited list>",
         "Comma delimited list of auth parameters. For websockets these will be set as headers (optional).");
     cmdUtils.RegisterCommand(Utils::CommandLineOption("help", "", "Prints this message"));
     cmdUtils.SendArguments(argv, argv + argc);
@@ -166,8 +165,7 @@ int main(int argc, char *argv[])
         {
             /* set authorizer headers on the outgoing websocket upgrade request. */
             connection->WebsocketInterceptor = [&](std::shared_ptr<Http::HttpRequest> req,
-                                                   const Mqtt::OnWebSocketHandshakeInterceptComplete &onComplete)
-            {
+                                                   const Mqtt::OnWebSocketHandshakeInterceptComplete &onComplete) {
                 for (auto &param : authParams)
                 {
                     Http::HttpHeader header;
@@ -231,8 +229,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -253,16 +250,16 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto onInterrupted = [&](Mqtt::MqttConnection &, int error)
-    { fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error)); };
+    auto onInterrupted = [&](Mqtt::MqttConnection &, int error) {
+        fprintf(stdout, "Connection interrupted with error %s\n", ErrorDebugString(error));
+    };
 
     auto onResumed = [&](Mqtt::MqttConnection &, Mqtt::ReturnCode, bool) { fprintf(stdout, "Connection resumed\n"); };
 
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection &)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection &) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -274,18 +271,12 @@ int main(int argc, char *argv[])
     connection->OnConnectionInterrupted = std::move(onInterrupted);
     connection->OnConnectionResumed = std::move(onResumed);
 
-    connection->SetOnMessageHandler(
-        [](Mqtt::MqttConnection &,
-           const String &topic,
-           const ByteBuf &payload,
-           bool /*dup*/,
-           Mqtt::QOS /*qos*/,
-           bool /*retain*/)
-        {
-            fprintf(stdout, "Generic Publish received on topic %s, payload:\n", topic.c_str());
-            fwrite(payload.buffer, 1, payload.len, stdout);
-            fprintf(stdout, "\n");
-        });
+    connection->SetOnMessageHandler([](Mqtt::MqttConnection &, const String &topic, const ByteBuf &payload,
+                                       bool /*dup*/, Mqtt::QOS /*qos*/, bool /*retain*/) {
+        fprintf(stdout, "Generic Publish received on topic %s, payload:\n", topic.c_str());
+        fwrite(payload.buffer, 1, payload.len, stdout);
+        fprintf(stdout, "\n");
+    });
 
     /*
      * Actually perform the connect dance.
@@ -304,13 +295,8 @@ int main(int argc, char *argv[])
         /*
          * This is invoked upon the receipt of a Publish on a subscribed topic.
          */
-        auto onMessage = [&](Mqtt::MqttConnection &,
-                             const String &topic,
-                             const ByteBuf &byteBuf,
-                             bool /*dup*/,
-                             Mqtt::QOS /*qos*/,
-                             bool /*retain*/)
-        {
+        auto onMessage = [&](Mqtt::MqttConnection &, const String &topic, const ByteBuf &byteBuf, bool /*dup*/,
+                             Mqtt::QOS /*qos*/, bool /*retain*/) {
             fprintf(stdout, "Publish received on topic %s\n", topic.c_str());
             fprintf(stdout, "\n Message:\n");
             fwrite(byteBuf.buffer, 1, byteBuf.len, stdout);
@@ -321,9 +307,8 @@ int main(int argc, char *argv[])
          * Subscribe for incoming publish messages on topic.
          */
         std::promise<void> subscribeFinishedPromise;
-        auto onSubAck =
-            [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS, int errorCode)
-        {
+        auto onSubAck = [&](Mqtt::MqttConnection &, uint16_t packetId, const String &topic, Mqtt::QOS QoS,
+                            int errorCode) {
             if (errorCode)
             {
                 fprintf(stderr, "Subscribe failed with error %s\n", aws_error_debug_str(errorCode));
@@ -364,8 +349,7 @@ int main(int argc, char *argv[])
 
             ByteBuf payload = ByteBufFromArray((const uint8_t *)input.data(), input.length());
 
-            auto onPublishComplete = [](Mqtt::MqttConnection &, uint16_t packetId, int errorCode)
-            {
+            auto onPublishComplete = [](Mqtt::MqttConnection &, uint16_t packetId, int errorCode) {
                 if (packetId)
                 {
                     fprintf(stdout, "Operation on packetId %d Succeeded\n", packetId);

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -50,11 +50,12 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("raw_pub_sub");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("topic", "<str>", "Topic to publish, subscribe to. (optional, default='test/topic').");
+    cmdUtils.AddCommonProxyCommands();
+    cmdUtils.AddCommonTopicMessageCommands();
+    cmdUtils.AddCommonWebsocketCommands();
+    cmdUtils.RemoveCommand("message");
+    cmdUtils.RemoveCommand("region");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
-    cmdUtils.RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional).");
-    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the http proxy to use (optional).");
-    cmdUtils.RegisterCommand("proxy_port", "<int>", "port of the http proxy to use (optional, default='8080').");
     cmdUtils.RegisterCommand("user_name", "<str>", "User name to send with mqtt connect.");
     cmdUtils.RegisterCommand("password", "<str>", "Password to send with mqtt connect.");
     cmdUtils.RegisterCommand(

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -57,7 +57,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("proxy_port", "<int>", "port of the http proxy to use (optional, default='8080').");
     cmdUtils.RegisterCommand("user_name", "<str>", "User name to send with mqtt connect.");
     cmdUtils.RegisterCommand("password", "<str>", "Password to send with mqtt connect.");
-    cmdUtils.RegisterCommand("protocol_name", "<str>", "The X.509 client certificate auth (optional, default='x-amzn-mqtt-ca').");
+    cmdUtils.RegisterCommand(
+        "protocol_name", "<str>", "The X.509 client certificate auth (optional, default='x-amzn-mqtt-ca').");
     cmdUtils.RegisterCommand(
         "auth_params",
         "<comma delimited list>",

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -19,7 +19,7 @@
 
 using namespace Aws::Crt;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
 
     /************************ Setup the Lib ****************************/

--- a/samples/mqtt/raw_pub_sub/main.cpp
+++ b/samples/mqtt/raw_pub_sub/main.cpp
@@ -64,8 +64,8 @@ int main(int argc, char *argv[])
         "<comma delimited list>",
         "Comma delimited list of auth parameters. For websockets these will be set as headers (optional).");
     cmdUtils.RegisterCommand(Utils::CommandLineOption("help", "", "Prints this message"));
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/secure_tunneling/secure_tunnel/CMakeLists.txt
+++ b/samples/secure_tunneling/secure_tunnel/CMakeLists.txt
@@ -4,6 +4,8 @@ project(secure-tunnel CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -42,14 +42,12 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "ca_file", "<path to custom ca>", "Path to AmazonRootCA1.pem (optional, system trust store used by default).");
     cmdUtils.RegisterCommand(
-        "access_token_file",
-        "<path to access token>",
+        "access_token_file", "<path to access token>",
         "Path to the tunneling access token file (optional if --access_token used).");
     cmdUtils.RegisterCommand(
         "access_token", "<access token>", "Tunneling access token (optional if --access_token_file used).");
     cmdUtils.RegisterCommand(
-        "local_proxy_mode_source",
-        "<sets to Source Mode>",
+        "local_proxy_mode_source", "<sets to Source Mode>",
         "Use to set local proxy mode to source. Default is destination (optional).");
     cmdUtils.RegisterCommand(
         "proxy_host", "<host name of the proxy server>", "Host name of the proxy server to connect through");
@@ -167,58 +165,54 @@ int main(int argc, char *argv[])
     std::promise<bool> connectionClosedPromise;
 
     /*********************** Callbacks ***************************/
-    auto OnConnectionComplete = [&]()
-    {
+    auto OnConnectionComplete = [&]() {
         switch (localProxyMode)
         {
-            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-                fprintf(stdout, "Connection Complete in Destination Mode\n");
-                break;
-            case AWS_SECURE_TUNNELING_SOURCE_MODE:
-                connectionCompletedPromise.set_value(true);
-                fprintf(stdout, "Connection Complete in Source Mode\n");
-                fprintf(stdout, "Sending Stream Start request\n");
-                secureTunnel->SendStreamStart();
-                break;
+        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+            fprintf(stdout, "Connection Complete in Destination Mode\n");
+            break;
+        case AWS_SECURE_TUNNELING_SOURCE_MODE:
+            connectionCompletedPromise.set_value(true);
+            fprintf(stdout, "Connection Complete in Source Mode\n");
+            fprintf(stdout, "Sending Stream Start request\n");
+            secureTunnel->SendStreamStart();
+            break;
         }
     };
 
-    auto OnConnectionShutdown = [&]()
-    {
+    auto OnConnectionShutdown = [&]() {
         fprintf(stdout, "Connection Shutdown\n");
         connectionClosedPromise.set_value(true);
     };
 
-    auto OnSendDataComplete = [&](int error_code)
-    {
+    auto OnSendDataComplete = [&](int error_code) {
         switch (localProxyMode)
         {
-            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-                if (!error_code)
-                {
-                    fprintf(stdout, "Send Data Complete in Destination Mode\n");
-                }
-                else
-                {
-                    fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
-                }
+        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+            if (!error_code)
+            {
+                fprintf(stdout, "Send Data Complete in Destination Mode\n");
+            }
+            else
+            {
+                fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
+            }
 
-                break;
-            case AWS_SECURE_TUNNELING_SOURCE_MODE:
-                if (!error_code)
-                {
-                    fprintf(stdout, "Send Data Complete in Source Mode\n");
-                }
-                else
-                {
-                    fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
-                }
-                break;
+            break;
+        case AWS_SECURE_TUNNELING_SOURCE_MODE:
+            if (!error_code)
+            {
+                fprintf(stdout, "Send Data Complete in Source Mode\n");
+            }
+            else
+            {
+                fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
+            }
+            break;
         }
     };
 
-    auto OnDataReceive = [&](const struct aws_byte_buf &data)
-    {
+    auto OnDataReceive = [&](const struct aws_byte_buf &data) {
         string receivedData = std::string((char *)data.buffer, data.len);
         string returnMessage = "Echo:" + receivedData;
 
@@ -226,22 +220,22 @@ int main(int argc, char *argv[])
 
         switch (localProxyMode)
         {
-            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-                fprintf(stdout, "Data Receive Complete in Destination\n");
-                fprintf(stdout, "Sending response message:\"%s\"\n", returnMessage.c_str());
-                secureTunnel->SendData(ByteCursorFromCString(returnMessage.c_str()));
-                if (isTest)
+        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+            fprintf(stdout, "Data Receive Complete in Destination\n");
+            fprintf(stdout, "Sending response message:\"%s\"\n", returnMessage.c_str());
+            secureTunnel->SendData(ByteCursorFromCString(returnMessage.c_str()));
+            if (isTest)
+            {
+                expectedMessageCount--;
+                if (expectedMessageCount == 0)
                 {
-                    expectedMessageCount--;
-                    if (expectedMessageCount == 0)
-                    {
-                        exit(0);
-                    }
+                    exit(0);
                 }
-                break;
-            case AWS_SECURE_TUNNELING_SOURCE_MODE:
-                fprintf(stdout, "Data Receive Complete in Source\n");
-                break;
+            }
+            break;
+        case AWS_SECURE_TUNNELING_SOURCE_MODE:
+            fprintf(stdout, "Data Receive Complete in Source\n");
+            break;
         }
     };
 
@@ -289,11 +283,7 @@ int main(int argc, char *argv[])
          * Create a new SecureTunnel using the SecureTunnelBuilder
          */
         secureTunnel = SecureTunnelBuilder(
-                           Aws::Crt::g_allocator,
-                           bootstrap,
-                           SocketOptions(),
-                           accessToken.c_str(),
-                           localProxyMode,
+                           Aws::Crt::g_allocator, bootstrap, SocketOptions(), accessToken.c_str(), localProxyMode,
                            endpoint.c_str())
                            .WithRootCa(caFile.c_str())
                            .WithHttpClientConnectionProxyOptions(proxyOptions)
@@ -313,11 +303,7 @@ int main(int argc, char *argv[])
          * Create a new SecureTunnel using the SecureTunnelBuilder
          */
         secureTunnel = SecureTunnelBuilder(
-                           Aws::Crt::g_allocator,
-                           bootstrap,
-                           SocketOptions(),
-                           accessToken.c_str(),
-                           localProxyMode,
+                           Aws::Crt::g_allocator, bootstrap, SocketOptions(), accessToken.c_str(), localProxyMode,
                            endpoint.c_str())
                            .WithRootCa(caFile.c_str())
                            .WithOnConnectionComplete(OnConnectionComplete)

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -17,7 +17,7 @@ using namespace Aws::Iotsecuretunneling;
 using namespace Aws::Crt::Io;
 using namespace std::chrono_literals;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     ApiHandle apiHandle;
 

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -37,6 +37,7 @@ int main(int argc, char *argv[])
 
     /*********************** Parse Arguments ***************************/
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.AddCommonProxyCommands();
     cmdUtils.RegisterProgramName("secure_tunnel");
     cmdUtils.RegisterCommand("region", "<str>", "The region of your secure tunnel");
     cmdUtils.RegisterCommand(
@@ -46,16 +47,13 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("access_token", "<str>", "Tunneling access token (optional if --access_token_file used).");
     cmdUtils.RegisterCommand(
         "local_proxy_mode_source", "<str>", "Use to set local proxy mode to source (optional, default='destination').");
-    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the proxy server to connect through (optional)");
-    cmdUtils.RegisterCommand(
-        "proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
+    cmdUtils.RegisterCommand("message", "<str>", "Message to send (optional, default='Hello World!').");
+    cmdUtils.RegisterCommand("help", "", "Prints this message");
+    cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional, ignore unless testing).");
     cmdUtils.RegisterCommand(
         "proxy_user_name", "<str>", "User name passed if proxy server requires a user name (optional)");
     cmdUtils.RegisterCommand(
         "proxy_password", "<str>", "Password passed if proxy server requires a password (optional)");
-    cmdUtils.RegisterCommand("message", "<str>", "Message to send (optional, default='Hello World!').");
-    cmdUtils.RegisterCommand("help", "", "Prints this message");
-    cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional, ignore unless testing).");
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
 

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -17,7 +17,7 @@ using namespace Aws::Iotsecuretunneling;
 using namespace Aws::Crt::Io;
 using namespace std::chrono_literals;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     ApiHandle apiHandle;
 
@@ -56,7 +56,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterCommand("message", "<str>", "Message to send (optional, default='Hello World!').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
     cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional, ignore unless testing).");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -42,18 +42,13 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "ca_file", "<path>", "Path to AmazonRootCA1.pem (optional, system trust store used by default).");
     cmdUtils.RegisterCommand(
-        "access_token_file",
-        "<path>",
-        "Path to the tunneling access token file (optional if --access_token used).");
+        "access_token_file", "<path>", "Path to the tunneling access token file (optional if --access_token used).");
+    cmdUtils.RegisterCommand("access_token", "<str>", "Tunneling access token (optional if --access_token_file used).");
     cmdUtils.RegisterCommand(
-        "access_token", "<str>", "Tunneling access token (optional if --access_token_file used).");
+        "local_proxy_mode_source", "<str>", "Use to set local proxy mode to source (optional, default='destination').");
+    cmdUtils.RegisterCommand("proxy_host", "<str>", "Host name of the proxy server to connect through (optional)");
     cmdUtils.RegisterCommand(
-        "local_proxy_mode_source",
-        "<str>",
-        "Use to set local proxy mode to source (optional, default='destination').");
-    cmdUtils.RegisterCommand(
-        "proxy_host", "<str>", "Host name of the proxy server to connect through (optional)");
-    cmdUtils.RegisterCommand("proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
+        "proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
     cmdUtils.RegisterCommand(
         "proxy_user_name", "<str>", "User name passed if proxy server requires a user name (optional)");
     cmdUtils.RegisterCommand(

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -42,12 +42,14 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "ca_file", "<path to custom ca>", "Path to AmazonRootCA1.pem (optional, system trust store used by default).");
     cmdUtils.RegisterCommand(
-        "access_token_file", "<path to access token>",
+        "access_token_file",
+        "<path to access token>",
         "Path to the tunneling access token file (optional if --access_token used).");
     cmdUtils.RegisterCommand(
         "access_token", "<access token>", "Tunneling access token (optional if --access_token_file used).");
     cmdUtils.RegisterCommand(
-        "local_proxy_mode_source", "<sets to Source Mode>",
+        "local_proxy_mode_source",
+        "<sets to Source Mode>",
         "Use to set local proxy mode to source. Default is destination (optional).");
     cmdUtils.RegisterCommand(
         "proxy_host", "<host name of the proxy server>", "Host name of the proxy server to connect through");
@@ -168,15 +170,15 @@ int main(int argc, char *argv[])
     auto OnConnectionComplete = [&]() {
         switch (localProxyMode)
         {
-        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-            fprintf(stdout, "Connection Complete in Destination Mode\n");
-            break;
-        case AWS_SECURE_TUNNELING_SOURCE_MODE:
-            connectionCompletedPromise.set_value(true);
-            fprintf(stdout, "Connection Complete in Source Mode\n");
-            fprintf(stdout, "Sending Stream Start request\n");
-            secureTunnel->SendStreamStart();
-            break;
+            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+                fprintf(stdout, "Connection Complete in Destination Mode\n");
+                break;
+            case AWS_SECURE_TUNNELING_SOURCE_MODE:
+                connectionCompletedPromise.set_value(true);
+                fprintf(stdout, "Connection Complete in Source Mode\n");
+                fprintf(stdout, "Sending Stream Start request\n");
+                secureTunnel->SendStreamStart();
+                break;
         }
     };
 
@@ -188,27 +190,27 @@ int main(int argc, char *argv[])
     auto OnSendDataComplete = [&](int error_code) {
         switch (localProxyMode)
         {
-        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-            if (!error_code)
-            {
-                fprintf(stdout, "Send Data Complete in Destination Mode\n");
-            }
-            else
-            {
-                fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
-            }
+            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+                if (!error_code)
+                {
+                    fprintf(stdout, "Send Data Complete in Destination Mode\n");
+                }
+                else
+                {
+                    fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
+                }
 
-            break;
-        case AWS_SECURE_TUNNELING_SOURCE_MODE:
-            if (!error_code)
-            {
-                fprintf(stdout, "Send Data Complete in Source Mode\n");
-            }
-            else
-            {
-                fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
-            }
-            break;
+                break;
+            case AWS_SECURE_TUNNELING_SOURCE_MODE:
+                if (!error_code)
+                {
+                    fprintf(stdout, "Send Data Complete in Source Mode\n");
+                }
+                else
+                {
+                    fprintf(stderr, "Send Data Failed: %s\n", ErrorDebugString(error_code));
+                }
+                break;
         }
     };
 
@@ -220,22 +222,22 @@ int main(int argc, char *argv[])
 
         switch (localProxyMode)
         {
-        case AWS_SECURE_TUNNELING_DESTINATION_MODE:
-            fprintf(stdout, "Data Receive Complete in Destination\n");
-            fprintf(stdout, "Sending response message:\"%s\"\n", returnMessage.c_str());
-            secureTunnel->SendData(ByteCursorFromCString(returnMessage.c_str()));
-            if (isTest)
-            {
-                expectedMessageCount--;
-                if (expectedMessageCount == 0)
+            case AWS_SECURE_TUNNELING_DESTINATION_MODE:
+                fprintf(stdout, "Data Receive Complete in Destination\n");
+                fprintf(stdout, "Sending response message:\"%s\"\n", returnMessage.c_str());
+                secureTunnel->SendData(ByteCursorFromCString(returnMessage.c_str()));
+                if (isTest)
                 {
-                    exit(0);
+                    expectedMessageCount--;
+                    if (expectedMessageCount == 0)
+                    {
+                        exit(0);
+                    }
                 }
-            }
-            break;
-        case AWS_SECURE_TUNNELING_SOURCE_MODE:
-            fprintf(stdout, "Data Receive Complete in Source\n");
-            break;
+                break;
+            case AWS_SECURE_TUNNELING_SOURCE_MODE:
+                fprintf(stdout, "Data Receive Complete in Source\n");
+                break;
         }
     };
 
@@ -283,7 +285,11 @@ int main(int argc, char *argv[])
          * Create a new SecureTunnel using the SecureTunnelBuilder
          */
         secureTunnel = SecureTunnelBuilder(
-                           Aws::Crt::g_allocator, bootstrap, SocketOptions(), accessToken.c_str(), localProxyMode,
+                           Aws::Crt::g_allocator,
+                           bootstrap,
+                           SocketOptions(),
+                           accessToken.c_str(),
+                           localProxyMode,
                            endpoint.c_str())
                            .WithRootCa(caFile.c_str())
                            .WithHttpClientConnectionProxyOptions(proxyOptions)
@@ -303,7 +309,11 @@ int main(int argc, char *argv[])
          * Create a new SecureTunnel using the SecureTunnelBuilder
          */
         secureTunnel = SecureTunnelBuilder(
-                           Aws::Crt::g_allocator, bootstrap, SocketOptions(), accessToken.c_str(), localProxyMode,
+                           Aws::Crt::g_allocator,
+                           bootstrap,
+                           SocketOptions(),
+                           accessToken.c_str(),
+                           localProxyMode,
                            endpoint.c_str())
                            .WithRootCa(caFile.c_str())
                            .WithOnConnectionComplete(OnConnectionComplete)

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
     /*
      * Generate secure tunneling endpoint using region
      */
-    region = cmdUtils.GetCommandRequired("region");
+    region = cmdUtils.GetCommandRequired("region").c_str();
     endpoint = "data.tunneling.iot." + region + ".amazonaws.com";
 
     if (!(cmdUtils.HasCommand("access_token_file") || cmdUtils.HasCommand("access_token")))
@@ -83,11 +83,11 @@ int main(int argc, char *argv[])
 
     if (cmdUtils.HasCommand("access_token"))
     {
-        accessToken = cmdUtils.GetCommand("access_token");
+        accessToken = cmdUtils.GetCommand("access_token").c_str();
     }
     else
     {
-        accessToken = cmdUtils.GetCommand("access_token_file");
+        accessToken = cmdUtils.GetCommand("access_token_file").c_str();
 
         ifstream accessTokenFile(accessToken.c_str());
         if (accessTokenFile.is_open())
@@ -104,18 +104,19 @@ int main(int argc, char *argv[])
 
     if (cmdUtils.HasCommand("proxy_host") || cmdUtils.HasCommand("proxy_port"))
     {
-        proxyHost = cmdUtils.GetCommandRequired("proxy_host", "--proxy_host must be set to connect through a proxy.");
+        proxyHost =
+            cmdUtils.GetCommandRequired("proxy_host", "--proxy_host must be set to connect through a proxy.").c_str();
         int port = atoi(
             cmdUtils.GetCommandRequired("proxy_port", "--proxy_port must be set to connect through a proxy.").c_str());
         if (port > 0 && port <= UINT16_MAX)
         {
             proxyPort = static_cast<uint16_t>(port);
         }
-        proxyUserName = cmdUtils.GetCommandOrDefault("proxy_user_name", "");
-        proxyPassword = cmdUtils.GetCommandOrDefault("proxy_password", "");
+        proxyUserName = cmdUtils.GetCommandOrDefault("proxy_user_name", "").c_str();
+        proxyPassword = cmdUtils.GetCommandOrDefault("proxy_password", "").c_str();
     }
 
-    caFile = cmdUtils.GetCommandOrDefault("ca_file", "");
+    caFile = cmdUtils.GetCommandOrDefault("ca_file", "").c_str();
 
     /*
      * localProxyMode is set to destination by default unless flag is set to source
@@ -129,7 +130,7 @@ int main(int argc, char *argv[])
         localProxyMode = AWS_SECURE_TUNNELING_DESTINATION_MODE;
     }
 
-    message = cmdUtils.GetCommandOrDefault("message", "Hello World");
+    message = cmdUtils.GetCommandOrDefault("message", "Hello World").c_str();
 
     /*
      * For internal testing

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -56,8 +56,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("message", "<str>", "Message to send (optional, default='Hello World!').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
     cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional, ignore unless testing).");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -12,7 +12,6 @@
 
 #include "../../utils/CommandLineUtils.h"
 
-//using namespace std;
 using namespace Aws::Crt;
 using namespace Aws::Iotsecuretunneling;
 using namespace Aws::Crt::Io;

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -12,26 +12,27 @@
 
 #include "../../utils/CommandLineUtils.h"
 
-using namespace std;
+//using namespace std;
 using namespace Aws::Crt;
 using namespace Aws::Iotsecuretunneling;
 using namespace Aws::Crt::Io;
+using namespace std::chrono_literals;
 
 int main(int argc, char *argv[])
 {
     ApiHandle apiHandle;
 
-    string region;
-    string endpoint;
-    string caFile;
-    string accessToken;
-    string message = "Hello World";
+    String region;
+    String endpoint;
+    String caFile;
+    String accessToken;
+    String message = "Hello World";
     aws_secure_tunneling_local_proxy_mode localProxyMode;
 
-    string proxyHost;
+    String proxyHost;
     uint16_t proxyPort(8080);
-    string proxyUserName;
-    string proxyPassword;
+    String proxyUserName;
+    String proxyPassword;
 
     std::shared_ptr<SecureTunnel> secureTunnel;
 
@@ -71,7 +72,7 @@ int main(int argc, char *argv[])
     /*
      * Generate secure tunneling endpoint using region
      */
-    region = cmdUtils.GetCommandRequired("region").c_str();
+    region = cmdUtils.GetCommandRequired("region");
     endpoint = "data.tunneling.iot." + region + ".amazonaws.com";
 
     if (!(cmdUtils.HasCommand("access_token_file") || cmdUtils.HasCommand("access_token")))
@@ -83,13 +84,13 @@ int main(int argc, char *argv[])
 
     if (cmdUtils.HasCommand("access_token"))
     {
-        accessToken = cmdUtils.GetCommand("access_token").c_str();
+        accessToken = cmdUtils.GetCommand("access_token");
     }
     else
     {
-        accessToken = cmdUtils.GetCommand("access_token_file").c_str();
+        accessToken = cmdUtils.GetCommand("access_token_file");
 
-        ifstream accessTokenFile(accessToken.c_str());
+        std::ifstream accessTokenFile(accessToken.c_str());
         if (accessTokenFile.is_open())
         {
             getline(accessTokenFile, accessToken);
@@ -112,11 +113,11 @@ int main(int argc, char *argv[])
         {
             proxyPort = static_cast<uint16_t>(port);
         }
-        proxyUserName = cmdUtils.GetCommandOrDefault("proxy_user_name", "").c_str();
-        proxyPassword = cmdUtils.GetCommandOrDefault("proxy_password", "").c_str();
+        proxyUserName = cmdUtils.GetCommandOrDefault("proxy_user_name", "");
+        proxyPassword = cmdUtils.GetCommandOrDefault("proxy_password", "");
     }
 
-    caFile = cmdUtils.GetCommandOrDefault("ca_file", "").c_str();
+    caFile = cmdUtils.GetCommandOrDefault("ca_file", "");
 
     /*
      * localProxyMode is set to destination by default unless flag is set to source
@@ -130,7 +131,7 @@ int main(int argc, char *argv[])
         localProxyMode = AWS_SECURE_TUNNELING_DESTINATION_MODE;
     }
 
-    message = cmdUtils.GetCommandOrDefault("message", "Hello World").c_str();
+    message = cmdUtils.GetCommandOrDefault("message", "Hello World");
 
     /*
      * For internal testing
@@ -216,8 +217,8 @@ int main(int argc, char *argv[])
     };
 
     auto OnDataReceive = [&](const struct aws_byte_buf &data) {
-        string receivedData = std::string((char *)data.buffer, data.len);
-        string returnMessage = "Echo:" + receivedData;
+        String receivedData = String((char *)data.buffer, data.len);
+        String returnMessage = "Echo:" + receivedData;
 
         fprintf(stdout, "Received: \"%s\"\n", receivedData.c_str());
 
@@ -349,7 +350,7 @@ int main(int argc, char *argv[])
             if (localProxyMode == AWS_SECURE_TUNNELING_SOURCE_MODE)
             {
                 messageCount++;
-                string toSend = to_string(messageCount) + ": " + message.c_str();
+                String toSend = (std::to_string(messageCount) + ": " + message.c_str()).c_str();
 
                 if (!secureTunnel->SendData(ByteCursorFromCString(toSend.c_str())))
                 {

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -38,29 +38,29 @@ int main(int argc, char *argv[])
     /*********************** Parse Arguments ***************************/
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("secure_tunnel");
-    cmdUtils.RegisterCommand("region", "<aws region of secure tunnel>", "The region of your secure tunnel");
+    cmdUtils.RegisterCommand("region", "<str>", "The region of your secure tunnel");
     cmdUtils.RegisterCommand(
-        "ca_file", "<path to custom ca>", "Path to AmazonRootCA1.pem (optional, system trust store used by default).");
+        "ca_file", "<path>", "Path to AmazonRootCA1.pem (optional, system trust store used by default).");
     cmdUtils.RegisterCommand(
         "access_token_file",
-        "<path to access token>",
+        "<path>",
         "Path to the tunneling access token file (optional if --access_token used).");
     cmdUtils.RegisterCommand(
-        "access_token", "<access token>", "Tunneling access token (optional if --access_token_file used).");
+        "access_token", "<str>", "Tunneling access token (optional if --access_token_file used).");
     cmdUtils.RegisterCommand(
         "local_proxy_mode_source",
-        "<sets to Source Mode>",
-        "Use to set local proxy mode to source. Default is destination (optional).");
+        "<str>",
+        "Use to set local proxy mode to source (optional, default='destination').");
     cmdUtils.RegisterCommand(
-        "proxy_host", "<host name of the proxy server>", "Host name of the proxy server to connect through");
-    cmdUtils.RegisterCommand("proxy_port", "<port of the proxy server>", "Port of the proxy server to connect through");
+        "proxy_host", "<str>", "Host name of the proxy server to connect through (optional)");
+    cmdUtils.RegisterCommand("proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
     cmdUtils.RegisterCommand(
-        "proxy_user_name", "<user name>", "User name passed if proxy server requires a user name (optional)");
+        "proxy_user_name", "<str>", "User name passed if proxy server requires a user name (optional)");
     cmdUtils.RegisterCommand(
-        "proxy_password", "<password>", "Password passed if proxy server requires a password (optional)");
-    cmdUtils.RegisterCommand("message", "<message>", "Message to send. Default: 'Hello World' (optional)");
+        "proxy_password", "<str>", "Password passed if proxy server requires a password (optional)");
+    cmdUtils.RegisterCommand("message", "<str>", "Message to send (optional, default='Hello World!').");
     cmdUtils.RegisterCommand("help", "", "Prints this message");
-    cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional - ignore unless testing).");
+    cmdUtils.RegisterCommand("test", "", "Used to trigger internal testing (optional, ignore unless testing).");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/secure_tunneling/tunnel_notification/CMakeLists.txt
+++ b/samples/secure_tunneling/tunnel_notification/CMakeLists.txt
@@ -4,6 +4,8 @@ project(tunnel-notification CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("tunnel_notification");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing");
+    cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -29,7 +29,7 @@ using namespace Aws::Crt;
 using namespace Aws::Crt::Mqtt;
 using namespace Aws::Iotsecuretunneling;
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -49,7 +49,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.RegisterProgramName("tunnel_notification");
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -186,7 +187,10 @@ int main(int argc, char *argv[])
             std::string region = response->Region->c_str();
 
             fprintf(
-                stdout, "Recv: Token:%s, Mode:%s, Region:%s\n", clientAccessToken.c_str(), clientMode.c_str(),
+                stdout,
+                "Recv: Token:%s, Mode:%s, Region:%s\n",
+                clientAccessToken.c_str(),
+                clientMode.c_str(),
                 region.c_str());
 
             size_t nServices = response->Services->size();

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -49,8 +49,8 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterProgramName("tunnel_notification");
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -29,7 +29,7 @@ using namespace Aws::Crt;
 using namespace Aws::Crt::Mqtt;
 using namespace Aws::Iotsecuretunneling;
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -21,45 +21,13 @@
 #include <mutex>
 #include <thread>
 
+#include "../../utils/CommandLineUtils.h"
+
 using namespace std;
 using namespace Aws::Iot;
 using namespace Aws::Crt;
 using namespace Aws::Crt::Mqtt;
 using namespace Aws::Iotsecuretunneling;
-
-static void s_printHelp()
-{
-    fprintf(stdout, "Usage:\n");
-    fprintf(
-        stdout,
-        "tunnel-notification --endpoint <endpoint> --cert <path to cert>"
-        " --key <path to key> --ca_file <optional: path to custom ca>"
-        " --thing_name <thing name> \n\n");
-    fprintf(stdout, "endpoint: the endpoint of the mqtt server not including a port\n");
-    fprintf(stdout, "cert: path to your client certificate in PEM format\n");
-    fprintf(stdout, "key: path to your key in PEM format\n");
-    fprintf(
-        stdout,
-        "ca_file: Optional, if the mqtt server uses a certificate that's not already"
-        " in your trust store, set this.\n");
-    fprintf(stdout, "\tIt's the path to a CA file in PEM format\n");
-    fprintf(stdout, "thing_name: the name of your IOT thing\n");
-}
-
-bool s_cmdOptionExists(char **begin, char **end, const String &option)
-{
-    return std::find(begin, end, option) != end;
-}
-
-char *s_getCmdOption(char **begin, char **end, const String &option)
-{
-    char **itr = std::find(begin, end, option);
-    if (itr != end && ++itr != end)
-    {
-        return *itr;
-    }
-    return 0;
-}
 
 int main(int argc, char *argv[])
 {
@@ -77,22 +45,22 @@ int main(int argc, char *argv[])
     String thingName;
 
     /*********************** Parse Arguments ***************************/
-    if (!(s_cmdOptionExists(argv, argv + argc, "--endpoint") && s_cmdOptionExists(argv, argv + argc, "--cert") &&
-          s_cmdOptionExists(argv, argv + argc, "--key") && s_cmdOptionExists(argv, argv + argc, "--thing_name")))
-    {
-        s_printHelp();
-        return 0;
-    }
+    Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
+    cmdUtils.RegisterProgramName("tunnel_notification");
+    cmdUtils.AddCommonMQTTCommands();
+    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing");
+    cmdUtils.SendArguments(argv, argv + argc);
 
-    endpoint = s_getCmdOption(argv, argv + argc, "--endpoint");
-    certificatePath = s_getCmdOption(argv, argv + argc, "--cert");
-    keyPath = s_getCmdOption(argv, argv + argc, "--key");
-    thingName = s_getCmdOption(argv, argv + argc, "--thing_name");
-
-    if (s_cmdOptionExists(argv, argv + argc, "--ca_file"))
+    if (cmdUtils.HasCommand("help"))
     {
-        caFile = s_getCmdOption(argv, argv + argc, "--ca_file");
+        cmdUtils.PrintHelp();
+        exit(-1);
     }
+    endpoint = cmdUtils.GetCommandRequired("endpoint");
+    certificatePath = cmdUtils.GetCommandRequired("cert");
+    keyPath = cmdUtils.GetCommandRequired("key");
+    thingName = cmdUtils.GetCommandRequired("thing_name");
+    caFile = cmdUtils.GetCommandOrDefault("ca_file", caFile);
 
     /********************** Now Setup an Mqtt Client ******************/
     /*
@@ -172,7 +140,8 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
+    {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -188,7 +157,8 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
+    {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -209,7 +179,8 @@ int main(int argc, char *argv[])
     }
 
     auto onSubscribeToTunnelsNotifyResponse = [&](Aws::Iotsecuretunneling::SecureTunnelingNotifyResponse *response,
-                                                  int ioErr) -> void {
+                                                  int ioErr) -> void
+    {
         if (ioErr == 0)
         {
             fprintf(stdout, "Received MQTT Tunnel Notification\n");
@@ -247,7 +218,8 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto OnSubscribeComplete = [&](int ioErr) -> void {
+    auto OnSubscribeComplete = [&](int ioErr) -> void
+    {
         if (ioErr)
         {
             fprintf(stderr, "MQTT Connection failed with error %d\n", ioErr);

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -95,8 +95,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -140,8 +139,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -157,8 +155,7 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionClosedPromise.set_value();
@@ -179,8 +176,7 @@ int main(int argc, char *argv[])
     }
 
     auto onSubscribeToTunnelsNotifyResponse = [&](Aws::Iotsecuretunneling::SecureTunnelingNotifyResponse *response,
-                                                  int ioErr) -> void
-    {
+                                                  int ioErr) -> void {
         if (ioErr == 0)
         {
             fprintf(stdout, "Received MQTT Tunnel Notification\n");
@@ -190,10 +186,7 @@ int main(int argc, char *argv[])
             std::string region = response->Region->c_str();
 
             fprintf(
-                stdout,
-                "Recv: Token:%s, Mode:%s, Region:%s\n",
-                clientAccessToken.c_str(),
-                clientMode.c_str(),
+                stdout, "Recv: Token:%s, Mode:%s, Region:%s\n", clientAccessToken.c_str(), clientMode.c_str(),
                 region.c_str());
 
             size_t nServices = response->Services->size();
@@ -218,8 +211,7 @@ int main(int argc, char *argv[])
         }
     };
 
-    auto OnSubscribeComplete = [&](int ioErr) -> void
-    {
+    auto OnSubscribeComplete = [&](int ioErr) -> void {
         if (ioErr)
         {
             fprintf(stderr, "MQTT Connection failed with error %d\n", ioErr);

--- a/samples/shadow/shadow_sync/CMakeLists.txt
+++ b/samples/shadow/shadow_sync/CMakeLists.txt
@@ -4,6 +4,8 @@ project(shadow-sync CXX)
 
 file(GLOB SRC_FILES
        "*.cpp"
+       "../../utils/CommandLineUtils.cpp"
+       "../../utils/CommandLineUtils.h"
 )
 
 add_executable(${PROJECT_NAME} ${SRC_FILES})

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -100,10 +100,10 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("shadow_sync");
     cmdUtils.AddCommonMQTTCommands();
-    cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing.");
+    cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand(
         "shadow_property",
-        "<Name of property in shadow to keep in sync>",
+        "<str>",
         "The name of the shadow property you want to change.");
     cmdUtils.SendArguments(argv, argv + argc);
 

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -80,7 +80,7 @@ static void s_changeShadowValue(
     client.PublishUpdateShadow(updateShadowRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, std::move(publishCompleted));
 }
 
-int main(int argc, char *argv[])
+int main(const int argc, const char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -30,10 +30,7 @@ using namespace Aws::Iotshadow;
 static const char *SHADOW_VALUE_DEFAULT = "off";
 
 static void s_changeShadowValue(
-    IotShadowClient &client,
-    const String &thingName,
-    const String &shadowProperty,
-    const String &value)
+    IotShadowClient &client, const String &thingName, const String &shadowProperty, const String &value)
 {
     fprintf(stdout, "Changing local shadow value to %s.\n", value.c_str());
 
@@ -67,8 +64,7 @@ static void s_changeShadowValue(
     updateShadowRequest.ThingName = thingName;
     updateShadowRequest.State = state;
 
-    auto publishCompleted = [thingName, value](int ioErr)
-    {
+    auto publishCompleted = [thingName, value](int ioErr) {
         if (ioErr != AWS_OP_SUCCESS)
         {
             fprintf(stderr, "failed to update %s shadow state: error %s\n", thingName.c_str(), ErrorDebugString(ioErr));
@@ -103,8 +99,7 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand(
-        "shadow_property",
-        "<Name of property in shadow to keep in sync>",
+        "shadow_property", "<Name of property in shadow to keep in sync>",
         "The name of the shadow property you want to change.");
     cmdUtils.SendArguments(argv, argv + argc);
 
@@ -153,8 +148,7 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr,
-            "Client Configuration initialization failed with error %s\n",
+            stderr, "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -197,8 +191,7 @@ int main(int argc, char *argv[])
     /*
      * This will execute when an mqtt connect has completed or failed.
      */
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool)
-    {
+    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
         if (errorCode)
         {
             fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
@@ -214,8 +207,7 @@ int main(int argc, char *argv[])
     /*
      * Invoked when a disconnect message has completed.
      */
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/)
-    {
+    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
         {
             fprintf(stdout, "Disconnect completed\n");
             connectionCompletedPromise.set_value(true);
@@ -243,8 +235,7 @@ int main(int argc, char *argv[])
         std::promise<void> subscribeDeltaAcceptedCompletedPromise;
         std::promise<void> subscribeDeltaRejectedCompletedPromise;
 
-        auto onDeltaUpdatedSubAck = [&](int ioErr)
-        {
+        auto onDeltaUpdatedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error subscribing to shadow delta: %s\n", ErrorDebugString(ioErr));
@@ -253,8 +244,7 @@ int main(int argc, char *argv[])
             subscribeDeltaCompletedPromise.set_value();
         };
 
-        auto onDeltaUpdatedAcceptedSubAck = [&](int ioErr)
-        {
+        auto onDeltaUpdatedAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error subscribing to shadow delta accepted: %s\n", ErrorDebugString(ioErr));
@@ -263,8 +253,7 @@ int main(int argc, char *argv[])
             subscribeDeltaAcceptedCompletedPromise.set_value();
         };
 
-        auto onDeltaUpdatedRejectedSubAck = [&](int ioErr)
-        {
+        auto onDeltaUpdatedRejectedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
             {
                 fprintf(stderr, "Error subscribing to shadow delta rejected: %s\n", ErrorDebugString(ioErr));
@@ -273,8 +262,7 @@ int main(int argc, char *argv[])
             subscribeDeltaRejectedCompletedPromise.set_value();
         };
 
-        auto onDeltaUpdated = [&](ShadowDeltaUpdatedEvent *event, int ioErr)
-        {
+        auto onDeltaUpdated = [&](ShadowDeltaUpdatedEvent *event, int ioErr) {
             if (event)
             {
                 fprintf(stdout, "Received shadow delta event.\n");
@@ -284,8 +272,7 @@ int main(int argc, char *argv[])
                     if (objectView.IsNull())
                     {
                         fprintf(
-                            stdout,
-                            "Delta reports that %s was deleted. Resetting defaults...\n",
+                            stdout, "Delta reports that %s was deleted. Resetting defaults...\n",
                             shadowProperty.c_str());
                         s_changeShadowValue(shadowClient, thingName, shadowProperty, SHADOW_VALUE_DEFAULT);
                     }
@@ -294,8 +281,7 @@ int main(int argc, char *argv[])
                         fprintf(
                             stdout,
                             "Delta reports that \"%s\" has a desired value of \"%s\", Changing local value...\n",
-                            shadowProperty.c_str(),
-                            event->State->View().GetString(shadowProperty).c_str());
+                            shadowProperty.c_str(), event->State->View().GetString(shadowProperty).c_str());
                         s_changeShadowValue(
                             shadowClient, thingName, shadowProperty, event->State->View().GetString(shadowProperty));
                     }
@@ -313,8 +299,7 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onUpdateShadowAccepted = [&](UpdateShadowResponse *response, int ioErr)
-        {
+        auto onUpdateShadowAccepted = [&](UpdateShadowResponse *response, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 if (response->State->Reported)
@@ -337,14 +322,11 @@ int main(int argc, char *argv[])
             }
         };
 
-        auto onUpdateShadowRejected = [&](ErrorResponse *error, int ioErr)
-        {
+        auto onUpdateShadowRejected = [&](ErrorResponse *error, int ioErr) {
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout,
-                    "Update of shadow state failed with message %s and code %d.",
-                    error->Message->c_str(),
+                    stdout, "Update of shadow state failed with message %s and code %d.", error->Message->c_str(),
                     *error->Code);
             }
             else
@@ -364,15 +346,11 @@ int main(int argc, char *argv[])
         updateShadowSubscriptionRequest.ThingName = thingName;
 
         shadowClient.SubscribeToUpdateShadowAccepted(
-            updateShadowSubscriptionRequest,
-            AWS_MQTT_QOS_AT_LEAST_ONCE,
-            onUpdateShadowAccepted,
+            updateShadowSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onUpdateShadowAccepted,
             onDeltaUpdatedAcceptedSubAck);
 
         shadowClient.SubscribeToUpdateShadowRejected(
-            updateShadowSubscriptionRequest,
-            AWS_MQTT_QOS_AT_LEAST_ONCE,
-            onUpdateShadowRejected,
+            updateShadowSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onUpdateShadowRejected,
             onDeltaUpdatedRejectedSubAck);
 
         subscribeDeltaCompletedPromise.get_future().wait();

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -29,8 +29,7 @@ using namespace Aws::Iotshadow;
 
 static const char *SHADOW_VALUE_DEFAULT = "off";
 
-static void s_changeShadowValue(
-    IotShadowClient &client, const String &thingName, const String &shadowProperty, const String &value)
+static void s_changeShadowValue(IotShadowClient &client, const String &thingName, const String &shadowProperty, const String &value)
 {
     fprintf(stdout, "Changing local shadow value to %s.\n", value.c_str());
 
@@ -99,7 +98,8 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<thing name>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand(
-        "shadow_property", "<Name of property in shadow to keep in sync>",
+        "shadow_property",
+        "<Name of property in shadow to keep in sync>",
         "The name of the shadow property you want to change.");
     cmdUtils.SendArguments(argv, argv + argc);
 
@@ -148,7 +148,8 @@ int main(int argc, char *argv[])
     if (!clientConfig)
     {
         fprintf(
-            stderr, "Client Configuration initialization failed with error %s\n",
+            stderr,
+            "Client Configuration initialization failed with error %s\n",
             ErrorDebugString(clientConfig.LastError()));
         exit(-1);
     }
@@ -272,7 +273,8 @@ int main(int argc, char *argv[])
                     if (objectView.IsNull())
                     {
                         fprintf(
-                            stdout, "Delta reports that %s was deleted. Resetting defaults...\n",
+                            stdout,
+                            "Delta reports that %s was deleted. Resetting defaults...\n",
                             shadowProperty.c_str());
                         s_changeShadowValue(shadowClient, thingName, shadowProperty, SHADOW_VALUE_DEFAULT);
                     }
@@ -281,7 +283,8 @@ int main(int argc, char *argv[])
                         fprintf(
                             stdout,
                             "Delta reports that \"%s\" has a desired value of \"%s\", Changing local value...\n",
-                            shadowProperty.c_str(), event->State->View().GetString(shadowProperty).c_str());
+                            shadowProperty.c_str(),
+                            event->State->View().GetString(shadowProperty).c_str());
                         s_changeShadowValue(
                             shadowClient, thingName, shadowProperty, event->State->View().GetString(shadowProperty));
                     }
@@ -326,7 +329,9 @@ int main(int argc, char *argv[])
             if (ioErr == AWS_OP_SUCCESS)
             {
                 fprintf(
-                    stdout, "Update of shadow state failed with message %s and code %d.", error->Message->c_str(),
+                    stdout,
+                    "Update of shadow state failed with message %s and code %d.",
+                    error->Message->c_str(),
                     *error->Code);
             }
             else
@@ -346,11 +351,15 @@ int main(int argc, char *argv[])
         updateShadowSubscriptionRequest.ThingName = thingName;
 
         shadowClient.SubscribeToUpdateShadowAccepted(
-            updateShadowSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onUpdateShadowAccepted,
+            updateShadowSubscriptionRequest,
+            AWS_MQTT_QOS_AT_LEAST_ONCE,
+            onUpdateShadowAccepted,
             onDeltaUpdatedAcceptedSubAck);
 
         shadowClient.SubscribeToUpdateShadowRejected(
-            updateShadowSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onUpdateShadowRejected,
+            updateShadowSubscriptionRequest,
+            AWS_MQTT_QOS_AT_LEAST_ONCE,
+            onUpdateShadowRejected,
             onDeltaUpdatedRejectedSubAck);
 
         subscribeDeltaCompletedPromise.get_future().wait();

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -80,7 +80,7 @@ static void s_changeShadowValue(
     client.PublishUpdateShadow(updateShadowRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, std::move(publishCompleted));
 }
 
-int main(const int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
     /************************ Setup the Lib ****************************/
     /*
@@ -102,7 +102,8 @@ int main(const int argc, const char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("shadow_property", "<str>", "The name of the shadow property you want to change.");
-    cmdUtils.SendArguments(argv, argv + argc);
+    const char** const_argv = (const char**)argv;
+    cmdUtils.SendArguments( const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -29,7 +29,11 @@ using namespace Aws::Iotshadow;
 
 static const char *SHADOW_VALUE_DEFAULT = "off";
 
-static void s_changeShadowValue(IotShadowClient &client, const String &thingName, const String &shadowProperty, const String &value)
+static void s_changeShadowValue(
+    IotShadowClient &client,
+    const String &thingName,
+    const String &shadowProperty,
+    const String &value)
 {
     fprintf(stdout, "Changing local shadow value to %s.\n", value.c_str());
 

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -102,8 +102,8 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("shadow_property", "<str>", "The name of the shadow property you want to change.");
-    const char** const_argv = (const char**)argv;
-    cmdUtils.SendArguments( const_argv, const_argv + argc);
+    const char **const_argv = (const char **)argv;
+    cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -101,10 +101,7 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterProgramName("shadow_sync");
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
-    cmdUtils.RegisterCommand(
-        "shadow_property",
-        "<str>",
-        "The name of the shadow property you want to change.");
+    cmdUtils.RegisterCommand("shadow_property", "<str>", "The name of the shadow property you want to change.");
     cmdUtils.SendArguments(argv, argv + argc);
 
     if (cmdUtils.HasCommand("help"))

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -17,7 +17,7 @@ namespace Utils
             fprintf(stdout, "Cannot register command: %s: Command already registered!", option.CommandName.c_str());
             return;
         }
-        RegisteredCommands.insert({ option.CommandName, option });
+        RegisteredCommands.insert({option.CommandName, option});
     }
 
     void CommandLineUtils::RegisterCommand(
@@ -94,7 +94,6 @@ namespace Utils
             fprintf(stderr, "%s\n", OptionalAdditionalMessage.c_str());
         }
         exit(-1);
-        return Aws::Crt::String();
     }
 
     void CommandLineUtils::PrintHelp()

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -128,4 +128,47 @@ namespace Utils
         RegisterCommand(Utils::CommandLineOption(
             "ca_file", "<path>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
     }
+
+    void CommandLineUtils::AddCommonProxyCommands()
+    {
+        RegisterCommand("proxy_host", "<str>", "Host name of the proxy server to connect through (optional)");
+        RegisterCommand("proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
+    }
+
+    void CommandLineUtils::AddCommonx509Commands()
+    {
+        RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
+        RegisterCommand(
+            "x509_role_alias", "<str>", "Role alias to use with the x509 credentials provider (required for x509)");
+        RegisterCommand("x509_endpoint", "<str>", "Endpoint to fetch x509 credentials from (required for x509)");
+        RegisterCommand("x509_thing", "<str>", "Thing name to fetch x509 credentials on behalf of (required for x509)");
+        RegisterCommand(
+            "x509_cert",
+            "<path>",
+            "Path to the IoT thing certificate used in fetching x509 credentials (required for x509)");
+        RegisterCommand(
+            "x509_key",
+            "<path>",
+            "Path to the IoT thing private key used in fetching x509 credentials (required for x509)");
+        RegisterCommand(
+            "x509_ca_file",
+            "<path>",
+            "Path to the root certificate used in fetching x509 credentials (required for x509)");
+    }
+
+    void CommandLineUtils::AddCommonTopicMessageCommands()
+    {
+        RegisterCommand("message", "<str>", "The message to send in the payload (optional, default='Hello world!')");
+        RegisterCommand("topic", "<str>", "Topic to publish, subscribe to. (optional, default='test/topic')");
+    }
+
+    void CommandLineUtils::AddCommonWebsocketCommands()
+    {
+        RegisterCommand("use_websocket", "", "If specified, uses a websocket over https (optional)");
+        RegisterCommand(
+            "signing_region",
+            "<str>",
+            "Used for websocket signer it should only be specific if websockets are used. (required for websockets)");
+    }
+
 } // namespace Utils

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -135,7 +135,7 @@ namespace Utils
         RegisterCommand("proxy_port", "<int>", "Port of the proxy server to connect through (optional, default='8080'");
     }
 
-    void CommandLineUtils::AddCommonx509Commands()
+    void CommandLineUtils::AddCommonX509Commands()
     {
         RegisterCommand("x509", "", "Use the x509 credentials provider while using websockets (optional)");
         RegisterCommand(

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -1,0 +1,125 @@
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+#include "CommandLineUtils.h"
+#include <iostream>
+#include <aws/crt/Types.h>
+
+namespace Utils
+{
+    void CommandLineUtils::RegisterProgramName(Aws::Crt::String NewProgramName)
+    {
+        ProgramName = NewProgramName;
+    }
+
+    void CommandLineUtils::RegisterCommand(CommandLineOption option)
+    {
+        if (RegisteredCommands.count(option.CommandName))
+        {
+            fprintf(stdout, "Cannot register command: %s: Command already registered!", option.CommandName.c_str());
+            return;
+        }
+        RegisteredCommands.insert({option.CommandName, option});
+    }
+
+    void CommandLineUtils::RegisterCommand(Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput)
+    {
+        RegisterCommand(CommandLineOption(CommandName, ExampleInput, HelpOutput));
+    }
+
+    void CommandLineUtils::RemoveCommand(Aws::Crt::String CommandName)
+    {
+        if (RegisteredCommands.count(CommandName))
+        {
+            RegisteredCommands.erase(CommandName);
+        }
+    }
+
+    void CommandLineUtils::UpdateCommandHelp(Aws::Crt::String CommandName, Aws::Crt::String NewCommandHelp)
+    {
+        if (RegisteredCommands.count(CommandName))
+        {
+            RegisteredCommands.at(CommandName).HelpOutput = NewCommandHelp;
+        }
+    }
+
+    void CommandLineUtils::SendArguments(char** begin, char** end)
+    {
+        if (BeginPosition != nullptr || EndPosition != nullptr)
+        {
+            fprintf(stdout, "Arguments already sent!");
+            return;
+        }
+        BeginPosition = begin;
+        EndPosition = end;
+    }
+
+    bool CommandLineUtils::HasCommand(Aws::Crt::String command)
+    {
+        return std::find(BeginPosition, EndPosition, "--" + command) != EndPosition;
+    }
+
+    Aws::Crt::String CommandLineUtils::GetCommand(Aws::Crt::String command)
+    {
+        char **itr = std::find(BeginPosition, EndPosition, "--" + command);
+        if (itr != EndPosition && ++itr != EndPosition)
+        {
+            return Aws::Crt::String(*itr);
+        }
+        return "";
+    }
+
+    Aws::Crt::String CommandLineUtils::GetCommandOrDefault(Aws::Crt::String command, Aws::Crt::String CommandDefault)
+    {
+        if (HasCommand(command))
+        {
+            return Aws::Crt::String(GetCommand(command));
+        }
+        return CommandDefault;
+    }
+
+    Aws::Crt::String CommandLineUtils::GetCommandRequired(Aws::Crt::String command, Aws::Crt::String OptionalAdditionalMessage)
+    {
+        if (HasCommand(command))
+        {
+            return GetCommand(command);
+        }
+        PrintHelp();
+        fprintf(stderr, "Missing required argument: %s\n", command.c_str());
+        if (OptionalAdditionalMessage != "")
+        {
+            fprintf(stderr, "%s\n", OptionalAdditionalMessage.c_str());
+        }
+        exit(-1);
+        return Aws::Crt::String();
+    }
+
+    void CommandLineUtils::PrintHelp()
+    {
+        fprintf(stdout, "Usage:\n");
+        fprintf(stdout, "%s", ProgramName.c_str());
+
+        for (auto const& pair : RegisteredCommands)
+        {
+            fprintf(stdout, " --%s %s", pair.first.c_str(), pair.second.ExampleInput.c_str());
+        }
+
+        fprintf(stdout, "\n\n");
+
+        for (auto const& pair : RegisteredCommands)
+        {
+            fprintf(stdout, "* %s:\t\t%s\n", pair.first.c_str(), pair.second.HelpOutput.c_str());
+        }
+
+        fprintf(stdout, "\n");
+    }
+
+    void CommandLineUtils::AddCommonMQTTCommands()
+    {
+        RegisterCommand(Utils::CommandLineOption("endpoint", "<endpoint>", "The endpoint of the mqtt server not including a port."));
+        RegisterCommand(Utils::CommandLineOption("key", "<path to key>", "Path to your key in PEM format."));
+        RegisterCommand(Utils::CommandLineOption("cert", "<path to cert>", "Path to your client certificate in PEM format."));
+        RegisterCommand(Utils::CommandLineOption("ca_file", "<ca file>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
+    }
+}

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -17,11 +17,13 @@ namespace Utils
             fprintf(stdout, "Cannot register command: %s: Command already registered!", option.CommandName.c_str());
             return;
         }
-        RegisteredCommands.insert({option.CommandName, option});
+        RegisteredCommands.insert({ option.CommandName, option });
     }
 
     void CommandLineUtils::RegisterCommand(
-        Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput)
+        Aws::Crt::String CommandName,
+        Aws::Crt::String ExampleInput,
+        Aws::Crt::String HelpOutput)
     {
         RegisterCommand(CommandLineOption(CommandName, ExampleInput, HelpOutput));
     }
@@ -78,7 +80,8 @@ namespace Utils
     }
 
     Aws::Crt::String CommandLineUtils::GetCommandRequired(
-        Aws::Crt::String command, Aws::Crt::String OptionalAdditionalMessage)
+        Aws::Crt::String command,
+        Aws::Crt::String OptionalAdditionalMessage)
     {
         if (HasCommand(command))
         {

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -21,9 +21,7 @@ namespace Utils
     }
 
     void CommandLineUtils::RegisterCommand(
-        Aws::Crt::String CommandName,
-        Aws::Crt::String ExampleInput,
-        Aws::Crt::String HelpOutput)
+        Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput)
     {
         RegisterCommand(CommandLineOption(CommandName, ExampleInput, HelpOutput));
     }
@@ -80,8 +78,7 @@ namespace Utils
     }
 
     Aws::Crt::String CommandLineUtils::GetCommandRequired(
-        Aws::Crt::String command,
-        Aws::Crt::String OptionalAdditionalMessage)
+        Aws::Crt::String command, Aws::Crt::String OptionalAdditionalMessage)
     {
         if (HasCommand(command))
         {

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -118,11 +118,10 @@ namespace Utils
 
     void CommandLineUtils::AddCommonMQTTCommands()
     {
-        RegisterCommand(Utils::CommandLineOption(
-            "endpoint", "<str>", "The endpoint of the mqtt server not including a port."));
-        RegisterCommand(Utils::CommandLineOption("key", "<path>", "Path to your key in PEM format."));
         RegisterCommand(
-            Utils::CommandLineOption("cert", "<path>", "Path to your client certificate in PEM format."));
+            Utils::CommandLineOption("endpoint", "<str>", "The endpoint of the mqtt server not including a port."));
+        RegisterCommand(Utils::CommandLineOption("key", "<path>", "Path to your key in PEM format."));
+        RegisterCommand(Utils::CommandLineOption("cert", "<path>", "Path to your client certificate in PEM format."));
         RegisterCommand(Utils::CommandLineOption(
             "ca_file", "<path>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
     }

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -119,11 +119,11 @@ namespace Utils
     void CommandLineUtils::AddCommonMQTTCommands()
     {
         RegisterCommand(Utils::CommandLineOption(
-            "endpoint", "<endpoint>", "The endpoint of the mqtt server not including a port."));
-        RegisterCommand(Utils::CommandLineOption("key", "<path to key>", "Path to your key in PEM format."));
+            "endpoint", "<str>", "The endpoint of the mqtt server not including a port."));
+        RegisterCommand(Utils::CommandLineOption("key", "<path>", "Path to your key in PEM format."));
         RegisterCommand(
-            Utils::CommandLineOption("cert", "<path to cert>", "Path to your client certificate in PEM format."));
+            Utils::CommandLineOption("cert", "<path>", "Path to your client certificate in PEM format."));
         RegisterCommand(Utils::CommandLineOption(
-            "ca_file", "<ca file>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
+            "ca_file", "<path>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
     }
 } // namespace Utils

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -3,15 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 #include "CommandLineUtils.h"
-#include <iostream>
 #include <aws/crt/Types.h>
+#include <iostream>
 
 namespace Utils
 {
-    void CommandLineUtils::RegisterProgramName(Aws::Crt::String NewProgramName)
-    {
-        ProgramName = NewProgramName;
-    }
+    void CommandLineUtils::RegisterProgramName(Aws::Crt::String NewProgramName) { ProgramName = NewProgramName; }
 
     void CommandLineUtils::RegisterCommand(CommandLineOption option)
     {
@@ -23,7 +20,10 @@ namespace Utils
         RegisteredCommands.insert({option.CommandName, option});
     }
 
-    void CommandLineUtils::RegisterCommand(Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput)
+    void CommandLineUtils::RegisterCommand(
+        Aws::Crt::String CommandName,
+        Aws::Crt::String ExampleInput,
+        Aws::Crt::String HelpOutput)
     {
         RegisterCommand(CommandLineOption(CommandName, ExampleInput, HelpOutput));
     }
@@ -44,7 +44,7 @@ namespace Utils
         }
     }
 
-    void CommandLineUtils::SendArguments(char** begin, char** end)
+    void CommandLineUtils::SendArguments(char **begin, char **end)
     {
         if (BeginPosition != nullptr || EndPosition != nullptr)
         {
@@ -79,14 +79,16 @@ namespace Utils
         return CommandDefault;
     }
 
-    Aws::Crt::String CommandLineUtils::GetCommandRequired(Aws::Crt::String command, Aws::Crt::String OptionalAdditionalMessage)
+    Aws::Crt::String CommandLineUtils::GetCommandRequired(
+        Aws::Crt::String command,
+        Aws::Crt::String OptionalAdditionalMessage)
     {
         if (HasCommand(command))
         {
             return GetCommand(command);
         }
         PrintHelp();
-        fprintf(stderr, "Missing required argument: %s\n", command.c_str());
+        fprintf(stderr, "Missing required argument: --%s\n", command.c_str());
         if (OptionalAdditionalMessage != "")
         {
             fprintf(stderr, "%s\n", OptionalAdditionalMessage.c_str());
@@ -100,14 +102,14 @@ namespace Utils
         fprintf(stdout, "Usage:\n");
         fprintf(stdout, "%s", ProgramName.c_str());
 
-        for (auto const& pair : RegisteredCommands)
+        for (auto const &pair : RegisteredCommands)
         {
             fprintf(stdout, " --%s %s", pair.first.c_str(), pair.second.ExampleInput.c_str());
         }
 
         fprintf(stdout, "\n\n");
 
-        for (auto const& pair : RegisteredCommands)
+        for (auto const &pair : RegisteredCommands)
         {
             fprintf(stdout, "* %s:\t\t%s\n", pair.first.c_str(), pair.second.HelpOutput.c_str());
         }
@@ -117,9 +119,12 @@ namespace Utils
 
     void CommandLineUtils::AddCommonMQTTCommands()
     {
-        RegisterCommand(Utils::CommandLineOption("endpoint", "<endpoint>", "The endpoint of the mqtt server not including a port."));
+        RegisterCommand(Utils::CommandLineOption(
+            "endpoint", "<endpoint>", "The endpoint of the mqtt server not including a port."));
         RegisterCommand(Utils::CommandLineOption("key", "<path to key>", "Path to your key in PEM format."));
-        RegisterCommand(Utils::CommandLineOption("cert", "<path to cert>", "Path to your client certificate in PEM format."));
-        RegisterCommand(Utils::CommandLineOption("ca_file", "<ca file>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
+        RegisterCommand(
+            Utils::CommandLineOption("cert", "<path to cert>", "Path to your client certificate in PEM format."));
+        RegisterCommand(Utils::CommandLineOption(
+            "ca_file", "<ca file>", "Path to AmazonRootCA1.pem (optional, system trust store used by default)."));
     }
-}
+} // namespace Utils

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -17,7 +17,10 @@ namespace Utils
         Aws::Crt::String m_exampleInput;
         Aws::Crt::String m_helpOutput;
 
-        CommandLineOption(Aws::Crt::String inputName, Aws::Crt::String inputExampleInput, Aws::Crt::String inputHelp = "")
+        CommandLineOption(
+            Aws::Crt::String inputName,
+            Aws::Crt::String inputExampleInput,
+            Aws::Crt::String inputHelp = "")
         {
             m_commandName = std::move(inputName);
             m_exampleInput = std::move(inputExampleInput);

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -51,7 +51,9 @@ namespace Utils
          * @param HelpOutput The message to show with the command when printing all commands via help
          */
         void RegisterCommand(
-            Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput = "");
+            Aws::Crt::String CommandName,
+            Aws::Crt::String ExampleInput,
+            Aws::Crt::String HelpOutput = "");
 
         /**
          * Removes the command if it has already been registered
@@ -115,7 +117,8 @@ namespace Utils
          * @return Aws::Crt::String The value passed into the program at the command name
          */
         Aws::Crt::String GetCommandRequired(
-            Aws::Crt::String CommandName, Aws::Crt::String OptionalAdditionalMessage = "");
+            Aws::Crt::String CommandName,
+            Aws::Crt::String OptionalAdditionalMessage = "");
 
         /**
          * Prints to the console/terminal all of the commands and their descriptions.

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -17,7 +17,7 @@ namespace Utils
         Aws::Crt::String ExampleInput;
         Aws::Crt::String HelpOutput;
 
-        CommandLineOption(Aws::Crt::String p_Name, Aws::Crt::String p_ExampleInput, Aws::Crt::String p_Help="")
+        CommandLineOption(Aws::Crt::String p_Name, Aws::Crt::String p_ExampleInput, Aws::Crt::String p_Help = "")
         {
             CommandName = p_Name;
             ExampleInput = p_ExampleInput;
@@ -26,106 +26,114 @@ namespace Utils
     };
 
     /**
-     * A helper class that makes it easier to register, find, and parse commands passed to the program from the terminal/console.
+     * A helper class that makes it easier to register, find, and parse commands passed to the program from the
+     * terminal/console.
      */
     class CommandLineUtils
     {
-        public:
-            /**
-             * Changes the program name to the name given. The program name is shown when calling help and showing all the commands.
-             * @param NewProgramName The program name to show when executing PrintHelp
-             */
-            void RegisterProgramName(Aws::Crt::String NewProgramName);
+      public:
+        /**
+         * Changes the program name to the name given. The program name is shown when calling help and showing all the
+         * commands.
+         * @param NewProgramName The program name to show when executing PrintHelp
+         */
+        void RegisterProgramName(Aws::Crt::String NewProgramName);
 
-            /**
-             * Adds a new command to the utility. Used to show command data when printing all commands.
-             * @param NewCommand The command struct containing the new command/argument data
-             */
-            void RegisterCommand(CommandLineOption NewCommand);
-            /**
-             * Adds a new command to the utility. Used to show command data when printing all commands.
-             * @param CommandName The name of the command
-             * @param ExampleInput Example input for the command (example "<endpoint>")
-             * @param HelpOutput The message to show with the command when printing all commands via help
-             */
-            void RegisterCommand(Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput="");
+        /**
+         * Adds a new command to the utility. Used to show command data when printing all commands.
+         * @param NewCommand The command struct containing the new command/argument data
+         */
+        void RegisterCommand(CommandLineOption NewCommand);
+        /**
+         * Adds a new command to the utility. Used to show command data when printing all commands.
+         * @param CommandName The name of the command
+         * @param ExampleInput Example input for the command (example "<endpoint>")
+         * @param HelpOutput The message to show with the command when printing all commands via help
+         */
+        void RegisterCommand(
+            Aws::Crt::String CommandName,
+            Aws::Crt::String ExampleInput,
+            Aws::Crt::String HelpOutput = "");
 
-            /**
-             * Removes the command if it has already been registered
-             * @param CommandName 
-             */
-            void RemoveCommand(Aws::Crt::String CommandName);
+        /**
+         * Removes the command if it has already been registered
+         * @param CommandName
+         */
+        void RemoveCommand(Aws::Crt::String CommandName);
 
-            /**
-             * Updates the help text of a registered command. If the given command does not exist, nothing happens
-             * @param NewCommandHelp 
-             */
-            void UpdateCommandHelp(Aws::Crt::String CommandName, Aws::Crt::String NewCommandHelp);
+        /**
+         * Updates the help text of a registered command. If the given command does not exist, nothing happens
+         * @param NewCommandHelp
+         */
+        void UpdateCommandHelp(Aws::Crt::String CommandName, Aws::Crt::String NewCommandHelp);
 
-            /**
-             * Called to give the class a copy of the begin and end character pointers that contain the arguments from the terminal/console
-             * @param begin The beginning of terminal/console input
-             * @param end The end of terminal/console input
-             */
-            void SendArguments(char** begin, char** end);
+        /**
+         * Called to give the class a copy of the begin and end character pointers that contain the arguments from the
+         * terminal/console
+         * @param begin The beginning of terminal/console input
+         * @param end The end of terminal/console input
+         */
+        void SendArguments(char **begin, char **end);
 
-            /**
-             * Returns true if the command was inputted into the terminal/console
-             * 
-             * You must call SendArguments and pass terminal/console input first in order for the function to work.
-             * 
-             * @param CommandName The name of the command you are looking for
-             * @return true If the command is found
-             * @return false If the command is not found
-             */
-            bool HasCommand(Aws::Crt::String CommandName);
+        /**
+         * Returns true if the command was inputted into the terminal/console
+         *
+         * You must call SendArguments and pass terminal/console input first in order for the function to work.
+         *
+         * @param CommandName The name of the command you are looking for
+         * @return true If the command is found
+         * @return false If the command is not found
+         */
+        bool HasCommand(Aws::Crt::String CommandName);
 
-            /**
-             * Gets the value of the command passed into the console/terminal. This function assumes the command exists
-             * and was passed into the program through the console/terminal.
-             * 
-             * You must call SendArguments and pass console/terminal input first in order for the function to work.
-             * 
-             * @param CommandName The name of the command you want to get the value of
-             * @return Aws::Crt::String The value passed into the program at the command name
-             */
-            Aws::Crt::String GetCommand(Aws::Crt::String CommandName);
+        /**
+         * Gets the value of the command passed into the console/terminal. This function assumes the command exists
+         * and was passed into the program through the console/terminal.
+         *
+         * You must call SendArguments and pass console/terminal input first in order for the function to work.
+         *
+         * @param CommandName The name of the command you want to get the value of
+         * @return Aws::Crt::String The value passed into the program at the command name
+         */
+        Aws::Crt::String GetCommand(Aws::Crt::String CommandName);
 
-            /**
-             * Gets the value of the command passed into the console/terminal if it exists, otherwise it returns
-             * whatever value is appsed into CommandDefault
-             * 
-             * You must call SendArguments and pass console/terminal input first in order for the function to work.
-             *
-             * @param CommandName The name of the command you want to get the value of
-             * @param CommandDefault The value to assign if the command does not exist
-             * @return Aws::Crt::String The value passed into the program at the command name
-             */
-            Aws::Crt::String GetCommandOrDefault(Aws::Crt::String CommandName, Aws::Crt::String CommandDefault);
+        /**
+         * Gets the value of the command passed into the console/terminal if it exists, otherwise it returns
+         * whatever value is appsed into CommandDefault
+         *
+         * You must call SendArguments and pass console/terminal input first in order for the function to work.
+         *
+         * @param CommandName The name of the command you want to get the value of
+         * @param CommandDefault The value to assign if the command does not exist
+         * @return Aws::Crt::String The value passed into the program at the command name
+         */
+        Aws::Crt::String GetCommandOrDefault(Aws::Crt::String CommandName, Aws::Crt::String CommandDefault);
 
-            /**
-             * Gets the value of the command passed into the console/terminal if it exists. If it does not exist,
-             * the program will exit with an error message.
-             * 
-             * @param CommandName The name of the command you want to get the value of
-             * @return Aws::Crt::String The value passed into the program at the command name
-             */
-            Aws::Crt::String GetCommandRequired(Aws::Crt::String CommandName, Aws::Crt::String OptionalAdditionalMessage="");
+        /**
+         * Gets the value of the command passed into the console/terminal if it exists. If it does not exist,
+         * the program will exit with an error message.
+         *
+         * @param CommandName The name of the command you want to get the value of
+         * @return Aws::Crt::String The value passed into the program at the command name
+         */
+        Aws::Crt::String GetCommandRequired(
+            Aws::Crt::String CommandName,
+            Aws::Crt::String OptionalAdditionalMessage = "");
 
-            /**
-             * Prints to the console/terminal all of the commands and their descriptions.
-             */
-            void PrintHelp();
+        /**
+         * Prints to the console/terminal all of the commands and their descriptions.
+         */
+        void PrintHelp();
 
-            /**
-             * A helper function that adds endpoint, key, cert, and ca_file commands
-             */
-            void AddCommonMQTTCommands();
+        /**
+         * A helper function that adds endpoint, key, cert, and ca_file commands
+         */
+        void AddCommonMQTTCommands();
 
-        private:
-            Aws::Crt::String ProgramName = "Application";
-            char** BeginPosition = nullptr;
-            char** EndPosition = nullptr;
-            Aws::Crt::Map<Aws::Crt::String, CommandLineOption> RegisteredCommands;    
+      private:
+        Aws::Crt::String ProgramName = "Application";
+        char **BeginPosition = nullptr;
+        char **EndPosition = nullptr;
+        Aws::Crt::Map<Aws::Crt::String, CommandLineOption> RegisteredCommands;
     };
-}
+} // namespace Utils

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -143,7 +143,7 @@ namespace Utils
          * A helper function that adds x509, x509_role_alias, x509_endpoint, x509_thing, x509_cert,
          * x509_key, and x509_ca_file commands
          */
-        void AddCommonx509Commands();
+        void AddCommonX509Commands();
 
         /**
          * A helper function that adds topic and message commands

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -1,0 +1,131 @@
+#pragma once
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#include <aws/crt/Types.h>
+
+namespace Utils
+{
+    /**
+     * A struct to hold the command line options that can be passed to the program from the terminal/console.
+     */
+    struct CommandLineOption
+    {
+        Aws::Crt::String CommandName;
+        Aws::Crt::String ExampleInput;
+        Aws::Crt::String HelpOutput;
+
+        CommandLineOption(Aws::Crt::String p_Name, Aws::Crt::String p_ExampleInput, Aws::Crt::String p_Help="")
+        {
+            CommandName = p_Name;
+            ExampleInput = p_ExampleInput;
+            HelpOutput = p_Help;
+        }
+    };
+
+    /**
+     * A helper class that makes it easier to register, find, and parse commands passed to the program from the terminal/console.
+     */
+    class CommandLineUtils
+    {
+        public:
+            /**
+             * Changes the program name to the name given. The program name is shown when calling help and showing all the commands.
+             * @param NewProgramName The program name to show when executing PrintHelp
+             */
+            void RegisterProgramName(Aws::Crt::String NewProgramName);
+
+            /**
+             * Adds a new command to the utility. Used to show command data when printing all commands.
+             * @param NewCommand The command struct containing the new command/argument data
+             */
+            void RegisterCommand(CommandLineOption NewCommand);
+            /**
+             * Adds a new command to the utility. Used to show command data when printing all commands.
+             * @param CommandName The name of the command
+             * @param ExampleInput Example input for the command (example "<endpoint>")
+             * @param HelpOutput The message to show with the command when printing all commands via help
+             */
+            void RegisterCommand(Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput="");
+
+            /**
+             * Removes the command if it has already been registered
+             * @param CommandName 
+             */
+            void RemoveCommand(Aws::Crt::String CommandName);
+
+            /**
+             * Updates the help text of a registered command. If the given command does not exist, nothing happens
+             * @param NewCommandHelp 
+             */
+            void UpdateCommandHelp(Aws::Crt::String CommandName, Aws::Crt::String NewCommandHelp);
+
+            /**
+             * Called to give the class a copy of the begin and end character pointers that contain the arguments from the terminal/console
+             * @param begin The beginning of terminal/console input
+             * @param end The end of terminal/console input
+             */
+            void SendArguments(char** begin, char** end);
+
+            /**
+             * Returns true if the command was inputted into the terminal/console
+             * 
+             * You must call SendArguments and pass terminal/console input first in order for the function to work.
+             * 
+             * @param CommandName The name of the command you are looking for
+             * @return true If the command is found
+             * @return false If the command is not found
+             */
+            bool HasCommand(Aws::Crt::String CommandName);
+
+            /**
+             * Gets the value of the command passed into the console/terminal. This function assumes the command exists
+             * and was passed into the program through the console/terminal.
+             * 
+             * You must call SendArguments and pass console/terminal input first in order for the function to work.
+             * 
+             * @param CommandName The name of the command you want to get the value of
+             * @return Aws::Crt::String The value passed into the program at the command name
+             */
+            Aws::Crt::String GetCommand(Aws::Crt::String CommandName);
+
+            /**
+             * Gets the value of the command passed into the console/terminal if it exists, otherwise it returns
+             * whatever value is appsed into CommandDefault
+             * 
+             * You must call SendArguments and pass console/terminal input first in order for the function to work.
+             *
+             * @param CommandName The name of the command you want to get the value of
+             * @param CommandDefault The value to assign if the command does not exist
+             * @return Aws::Crt::String The value passed into the program at the command name
+             */
+            Aws::Crt::String GetCommandOrDefault(Aws::Crt::String CommandName, Aws::Crt::String CommandDefault);
+
+            /**
+             * Gets the value of the command passed into the console/terminal if it exists. If it does not exist,
+             * the program will exit with an error message.
+             * 
+             * @param CommandName The name of the command you want to get the value of
+             * @return Aws::Crt::String The value passed into the program at the command name
+             */
+            Aws::Crt::String GetCommandRequired(Aws::Crt::String CommandName, Aws::Crt::String OptionalAdditionalMessage="");
+
+            /**
+             * Prints to the console/terminal all of the commands and their descriptions.
+             */
+            void PrintHelp();
+
+            /**
+             * A helper function that adds endpoint, key, cert, and ca_file commands
+             */
+            void AddCommonMQTTCommands();
+
+        private:
+            Aws::Crt::String ProgramName = "Application";
+            char** BeginPosition = nullptr;
+            char** EndPosition = nullptr;
+            Aws::Crt::Map<Aws::Crt::String, CommandLineOption> RegisteredCommands;    
+    };
+}

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -134,6 +134,27 @@ namespace Utils
          */
         void AddCommonMQTTCommands();
 
+        /**
+         * A helper function that adds proxy_port, proxy_username, proxy_password, and proxy_host commands.
+         */
+        void AddCommonProxyCommands();
+
+        /**
+         * A helper function that adds x509, x509_role_alias, x509_endpoint, x509_thing, x509_cert,
+         * x509_key, and x509_ca_file commands
+         */
+        void AddCommonx509Commands();
+
+        /**
+         * A helper function that adds topic and message commands
+         */
+        void AddCommonTopicMessageCommands();
+
+        /**
+         * A helper function that adds use_websocket and signing_region
+         */
+        void AddCommonWebsocketCommands();
+
       private:
         Aws::Crt::String m_programName = "Application";
         const char **m_beginPosition = nullptr;

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -51,9 +51,7 @@ namespace Utils
          * @param HelpOutput The message to show with the command when printing all commands via help
          */
         void RegisterCommand(
-            Aws::Crt::String CommandName,
-            Aws::Crt::String ExampleInput,
-            Aws::Crt::String HelpOutput = "");
+            Aws::Crt::String CommandName, Aws::Crt::String ExampleInput, Aws::Crt::String HelpOutput = "");
 
         /**
          * Removes the command if it has already been registered
@@ -117,8 +115,7 @@ namespace Utils
          * @return Aws::Crt::String The value passed into the program at the command name
          */
         Aws::Crt::String GetCommandRequired(
-            Aws::Crt::String CommandName,
-            Aws::Crt::String OptionalAdditionalMessage = "");
+            Aws::Crt::String CommandName, Aws::Crt::String OptionalAdditionalMessage = "");
 
         /**
          * Prints to the console/terminal all of the commands and their descriptions.

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -13,15 +13,15 @@ namespace Utils
      */
     struct CommandLineOption
     {
-        Aws::Crt::String CommandName;
-        Aws::Crt::String ExampleInput;
-        Aws::Crt::String HelpOutput;
+        Aws::Crt::String m_commandName;
+        Aws::Crt::String m_exampleInput;
+        Aws::Crt::String m_helpOutput;
 
-        CommandLineOption(Aws::Crt::String p_Name, Aws::Crt::String p_ExampleInput, Aws::Crt::String p_Help = "")
+        CommandLineOption(Aws::Crt::String inputName, Aws::Crt::String inputExampleInput, Aws::Crt::String inputHelp = "")
         {
-            CommandName = p_Name;
-            ExampleInput = p_ExampleInput;
-            HelpOutput = p_Help;
+            m_commandName = std::move(inputName);
+            m_exampleInput = std::move(inputExampleInput);
+            m_helpOutput = std::move(inputHelp);
         }
     };
 
@@ -35,45 +35,46 @@ namespace Utils
         /**
          * Changes the program name to the name given. The program name is shown when calling help and showing all the
          * commands.
-         * @param NewProgramName The program name to show when executing PrintHelp
+         * @param newProgramName The program name to show when executing PrintHelp
          */
-        void RegisterProgramName(Aws::Crt::String NewProgramName);
+        void RegisterProgramName(Aws::Crt::String newProgramName);
 
         /**
          * Adds a new command to the utility. Used to show command data when printing all commands.
-         * @param NewCommand The command struct containing the new command/argument data
+         * @param newCommand The command struct containing the new command/argument data
          */
-        void RegisterCommand(CommandLineOption NewCommand);
+        void RegisterCommand(CommandLineOption newCommand);
         /**
          * Adds a new command to the utility. Used to show command data when printing all commands.
-         * @param CommandName The name of the command
-         * @param ExampleInput Example input for the command (example "<endpoint>")
-         * @param HelpOutput The message to show with the command when printing all commands via help
+         * @param commandName The name of the command
+         * @param exampleInput Example input for the command (example "<endpoint>")
+         * @param helpOutput The message to show with the command when printing all commands via help
          */
         void RegisterCommand(
-            Aws::Crt::String CommandName,
-            Aws::Crt::String ExampleInput,
-            Aws::Crt::String HelpOutput = "");
+            Aws::Crt::String commandName,
+            Aws::Crt::String exampleInput,
+            Aws::Crt::String helpOutput = "");
 
         /**
          * Removes the command if it has already been registered
-         * @param CommandName
+         * @param commandName
          */
-        void RemoveCommand(Aws::Crt::String CommandName);
+        void RemoveCommand(Aws::Crt::String commandName);
 
         /**
          * Updates the help text of a registered command. If the given command does not exist, nothing happens
-         * @param NewCommandHelp
+         * @param commandName The name of the command
+         * @param newCommandHelp
          */
-        void UpdateCommandHelp(Aws::Crt::String CommandName, Aws::Crt::String NewCommandHelp);
+        void UpdateCommandHelp(Aws::Crt::String commandName, Aws::Crt::String newCommandHelp);
 
         /**
          * Called to give the class a copy of the begin and end character pointers that contain the arguments from the
          * terminal/console
-         * @param begin The beginning of terminal/console input
-         * @param end The end of terminal/console input
+         * @param argv The beginning of terminal/console input
+         * @param argc The end of terminal/console input
          */
-        void SendArguments(char **begin, char **end);
+        void SendArguments(const char **argv, const char **argc);
 
         /**
          * Returns true if the command was inputted into the terminal/console
@@ -131,9 +132,9 @@ namespace Utils
         void AddCommonMQTTCommands();
 
       private:
-        Aws::Crt::String ProgramName = "Application";
-        char **BeginPosition = nullptr;
-        char **EndPosition = nullptr;
-        Aws::Crt::Map<Aws::Crt::String, CommandLineOption> RegisteredCommands;
+        Aws::Crt::String m_programName = "Application";
+        const char **m_beginPosition = nullptr;
+        const char **m_endPosition = nullptr;
+        Aws::Crt::Map<Aws::Crt::String, CommandLineOption> m_registeredCommands;
     };
 } // namespace Utils


### PR DESCRIPTION
*Description of changes:*

Refactors command line parsing into a single file shared across all samples. This reduces the duplicate code, makes the samples smaller, and also has the benefit of additions made to the command line parsing file benefiting all samples.

This PR modifies all of the samples to use this shared file, modifies some wording for better consistency across samples, and adjusts the secure_tunnel sample to use the `Aws::String` class instead of `std::string`.

_____________

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*
