### PR TITLE
Fix segmentation fault in iot client init functions

### DIFF
--- a/identity/source/IotIdentityClient.cpp
+++ b/identity/source/IotIdentityClient.cpp
@@ -26,7 +26,7 @@ namespace Aws
         {
         }
 
-        IotIdentityClient::operator bool() const noexcept { return *m_connection; }
+        IotIdentityClient::operator bool() const noexcept { return m_connection && *m_connection; }
 
         int IotIdentityClient::GetLastError() const noexcept { return aws_last_error(); }
 

--- a/jobs/source/IotJobsClient.cpp
+++ b/jobs/source/IotJobsClient.cpp
@@ -33,7 +33,7 @@ namespace Aws
         {
         }
 
-        IotJobsClient::operator bool() const noexcept { return *m_connection; }
+        IotJobsClient::operator bool() const noexcept { return m_connection && *m_connection; }
 
         int IotJobsClient::GetLastError() const noexcept { return aws_last_error(); }
 

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -15,6 +15,7 @@
 #include <aws/iotjobs/RejectedError.h>
 
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <iostream>
 #include <mutex>
@@ -167,6 +168,9 @@ int main(int argc, char *argv[])
             std::move(describeJobExecutionRequest), AWS_MQTT_QOS_AT_LEAST_ONCE, publishHandler);
         publishDescribeJobExeCompletedPromise.get_future().wait();
     }
+
+    /* Wait just a little bit to let the console print */
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
     /* Disconnect */
     if (connection->Disconnect())

--- a/secure_tunneling/source/IotSecureTunnelingClient.cpp
+++ b/secure_tunneling/source/IotSecureTunnelingClient.cpp
@@ -29,7 +29,7 @@ namespace Aws
         {
         }
 
-        IotSecureTunnelingClient::operator bool() const noexcept { return *m_connection; }
+        IotSecureTunnelingClient::operator bool() const noexcept { return m_connection && *m_connection; }
 
         int IotSecureTunnelingClient::GetLastError() const noexcept { return aws_last_error(); }
 

--- a/shadow/source/IotShadowClient.cpp
+++ b/shadow/source/IotShadowClient.cpp
@@ -38,7 +38,7 @@ namespace Aws
         {
         }
 
-        IotShadowClient::operator bool() const noexcept { return *m_connection; }
+        IotShadowClient::operator bool() const noexcept { return m_connection && *m_connection; }
 
         int IotShadowClient::GetLastError() const noexcept { return aws_last_error(); }
 


### PR DESCRIPTION
*Description of changes:*

Fixes issue where a segmentation fault will occur if a uninitialized shared pointer is passed in the constructor of the IoT Client classes (Job, Shadow, Secure Tunnel, etc).

___________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
