### PR TITLE
Minor sample adjustments

### DIFF
--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -42,6 +42,9 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "mode", "<str>", "Mode options: 'both', 'publish', or 'subscribe' (optional, default='both').");
     const char **const_argv = (const char **)argv;
+    cmdUtils.UpdateCommandHelp(
+        "message",
+        "The message to send. If no message is provided, you will be prompted to input one (optional, default='')");
     cmdUtils.SendArguments(const_argv, const_argv + argc);
 
     String certificatePath = cmdUtils.GetCommandRequired("cert");
@@ -51,7 +54,7 @@ int main(int argc, char *argv[])
     String region = cmdUtils.GetCommandRequired("region");
     String topic = cmdUtils.GetCommandOrDefault("topic", "test/topic");
     String mode = cmdUtils.GetCommandOrDefault("mode", "both");
-    String message = cmdUtils.GetCommandOrDefault("message", "Hello World");
+    String message = cmdUtils.GetCommandOrDefault("message", "");
     String proxyHost = cmdUtils.GetCommandOrDefault("proxy_host", "");
     if (cmdUtils.HasCommand("proxy_port"))
     {
@@ -256,22 +259,35 @@ int main(int argc, char *argv[])
         connectionFinishedPromise.get_future().wait();
     }
 
+    bool first_input = true;
     while (true)
     {
-        String input;
+        String input = "";
         if (mode == "both" || mode == "publish")
         {
-            fprintf(
-                stdout,
-                "Enter the message you want to publish to topic %s and press enter. Enter 'exit' to exit this "
-                "program.\n",
-                topic.c_str());
+            if (message == "")
+            {
+                fprintf(
+                    stdout,
+                    "Enter the message you want to publish to topic %s and press enter. Enter 'exit' to exit this "
+                    "program.\n",
+                    topic.c_str());
+                std::getline(std::cin, input);
+                message = input;
+            }
+            else if (first_input == false)
+            {
+                fprintf(stdout, "Enter a new message or enter 'exit' or 'quit' to exit the program.\n");
+                std::getline(std::cin, input);
+                message = input;
+            }
+            first_input = false;
         }
         else
         {
-            fprintf(stdout, "Enter exit or quit to exit the program.\n");
+            fprintf(stdout, "Enter 'exit' or 'quit' to exit the program.\n");
+            std::getline(std::cin, input);
         }
-        std::getline(std::cin, input);
 
         if (input == "exit" || input == "quit")
         {

--- a/samples/pub_sub/basic_pub_sub/main.cpp
+++ b/samples/pub_sub/basic_pub_sub/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonTopicMessageCommands();
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
+    cmdUtils.RegisterCommand("port_override", "<int>", "The port override to use when connecting (optional)");
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
 

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -222,6 +222,14 @@ namespace Utils
         {
             clientConfigBuilder.WithCertificateAuthority(GetCommand(m_cmd_ca_file).c_str());
         }
+        if (HasCommand(m_cmd_port_override))
+        {
+            int tmp_port = atoi(GetCommand(m_cmd_port_override).c_str());
+            if (tmp_port > 0)
+            {
+                clientConfigBuilder.WithPortOverride(tmp_port);
+            }
+        }
 
         clientConfigBuilder.WithEndpoint(GetCommandRequired(m_cmd_endpoint));
         return GetClientConnectionForMQTTConnection(client, &clientConfigBuilder);
@@ -301,6 +309,14 @@ namespace Utils
         {
             clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
         }
+        if (HasCommand(m_cmd_port_override))
+        {
+            int tmp_port = atoi(GetCommand(m_cmd_port_override).c_str());
+            if (tmp_port > 0)
+            {
+                clientConfigBuilder.WithPortOverride(tmp_port);
+            }
+        }
 
         clientConfigBuilder.WithEndpoint(GetCommandRequired(m_cmd_endpoint));
         return GetClientConnectionForMQTTConnection(client, &clientConfigBuilder);
@@ -333,6 +349,14 @@ namespace Utils
         {
             clientConfigBuilder.WithHttpProxyOptions(GetProxyOptionsForMQTTConnection());
         }
+        if (HasCommand(m_cmd_port_override))
+        {
+            int tmp_port = atoi(GetCommand(m_cmd_port_override).c_str());
+            if (tmp_port > 0)
+            {
+                clientConfigBuilder.WithPortOverride(tmp_port);
+            }
+        }
 
         clientConfigBuilder.WithEndpoint(GetCommandRequired(m_cmd_endpoint));
         return GetClientConnectionForMQTTConnection(client, &clientConfigBuilder);
@@ -355,6 +379,14 @@ namespace Utils
         if (HasCommand(m_cmd_proxy_host))
         {
             clientConfigBuilder.WithHttpProxyOptions(GetProxyOptionsForMQTTConnection());
+        }
+        if (HasCommand(m_cmd_port_override))
+        {
+            int tmp_port = atoi(GetCommand(m_cmd_port_override).c_str());
+            if (tmp_port > 0)
+            {
+                clientConfigBuilder.WithPortOverride(tmp_port);
+            }
         }
 
         return GetClientConnectionForMQTTConnection(client, &clientConfigBuilder);

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -245,6 +245,7 @@ namespace Utils
         const Aws::Crt::String m_cmd_pkcs11_key = "key_label";
         const Aws::Crt::String m_cmd_message = "message";
         const Aws::Crt::String m_cmd_topic = "topic";
+        const Aws::Crt::String m_cmd_port_override = "port_override";
         const Aws::Crt::String m_cmd_help = "help";
     };
 } // namespace Utils


### PR DESCRIPTION
*Issue #, if available:*

Closes #286 and #259

*Description of changes:*

Adds a `port_override` argument to the PubSub sample and fixes the `message` argument not being used in the Greengrass discovery sample.

_____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
