### PR TITLE
fix(eventstream): move ContinuationCallbackData into ClientContinuation to fix memory leak

### DIFF
--- a/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -328,6 +328,7 @@ namespace Aws
             Crt::Allocator *m_allocator;
             ClientContinuationHandler &m_continuationHandler;
             struct aws_event_stream_rpc_client_continuation_token *m_continuationToken;
+            ContinuationCallbackData *m_callbackData;
             static void s_onContinuationMessage(
                 struct aws_event_stream_rpc_client_continuation_token *continuationToken,
                 const struct aws_event_stream_rpc_message_args *messageArgs,
@@ -619,8 +620,6 @@ namespace Aws
                 CONNECTED,
                 DISCONNECTING,
             };
-            std::mutex m_continuationVectorMutex;
-            Crt::Vector<ContinuationCallbackData *> m_continuationCallbackVector;
             /* This recursive mutex protects m_clientState & m_connectionWillSetup */
             std::recursive_mutex m_stateMutex;
             Crt::Allocator *m_allocator;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes a memory leak in event stream due to `ContinuationCallbackData` being held by the actual connection and only destroyed on connection shutdown. This means that every single request will cause a leak of ~127 bytes which won't be cleaned until the whole connection dies. This change removes the vector of callback data from the connection and instead stores the continuation callback data with the actual continuation which created it. It is then destroyed in the continuation's destructor.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
