### PR TITLE
fix(eventstream): move callback data shutdown into ClientContinuation destructor

### DIFF
--- a/eventstream_rpc/source/EventStreamClient.cpp
+++ b/eventstream_rpc/source/EventStreamClient.cpp
@@ -871,18 +871,15 @@ namespace Aws
             }
             if (m_callbackData != nullptr)
             {
+                {
+                    const std::lock_guard<std::mutex> lock(m_callbackData->callbackMutex);
+                    m_callbackData->continuationDestroyed = true;
+                }
                 Crt::Delete<ContinuationCallbackData>(m_callbackData, m_allocator);
             }
         }
 
-        ClientContinuationHandler::~ClientContinuationHandler() noexcept
-        {
-            if (m_callbackData)
-            {
-                const std::lock_guard<std::mutex> lock(m_callbackData->callbackMutex);
-                m_callbackData->continuationDestroyed = true;
-            }
-        }
+        ClientContinuationHandler::~ClientContinuationHandler() noexcept {}
 
         void ClientContinuation::s_onContinuationMessage(
             struct aws_event_stream_rpc_client_continuation_token *continuationToken,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previous change #436 introduced a bug on destruction of the ClientContinuationHandler which throws SIGABT on macos due to trying to use a mutex on a freed object. This change fixes that and simplifies the destruction, putting ClientContinuation in charge of it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
