### PR TITLE
Add verbosity command to samples

### DIFF
--- a/samples/device_defender/basic_report/main.cpp
+++ b/samples/device_defender/basic_report/main.cpp
@@ -82,8 +82,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand(
         "report_time", "<int>", "The frequency to send Device Defender reports in seconds (optional, default='60')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of reports to send (optional, default='10')");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     if (cmdUtils.HasCommand("help"))
     {

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -45,7 +45,9 @@ int main(int argc, char *argv[])
     cmdUtils.UpdateCommandHelp(
         "message",
         "The message to send. If no message is provided, you will be prompted to input one (optional, default='')");
+    cmdUtils.AddLoggingCommands();
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String certificatePath = cmdUtils.GetCommandRequired("cert");
     String thingName = cmdUtils.GetCommandRequired("thing_name");

--- a/samples/greengrass/ipc/main.cpp
+++ b/samples/greengrass/ipc/main.cpp
@@ -27,8 +27,10 @@ int main(int argc, char *argv[])
     Utils::CommandLineUtils cmdUtils = Utils::CommandLineUtils();
     cmdUtils.RegisterProgramName("greengrass-ipc");
     cmdUtils.AddCommonTopicMessageCommands();
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String topic = cmdUtils.GetCommandOrDefault("topic", "test/topic");
     String message = cmdUtils.GetCommandOrDefault("message", "Hello World");

--- a/samples/identity/fleet_provisioning/main.cpp
+++ b/samples/identity/fleet_provisioning/main.cpp
@@ -75,8 +75,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("template_name", "<str>", "The name of your provisioning template");
     cmdUtils.RegisterCommand("template_parameters", "<json>", "Template parameters json");
     cmdUtils.RegisterCommand("csr", "<path>", "Path to CSR in PEM format (optional)");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String templateName = cmdUtils.GetCommandRequired("template_name");
     String templateParameters = cmdUtils.GetCommandRequired("template_parameters");

--- a/samples/jobs/describe_job_execution/main.cpp
+++ b/samples/jobs/describe_job_execution/main.cpp
@@ -42,8 +42,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("cert", "<path>", "Path to your client certificate in PEM format.");
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("job_id", "<str>", "The job id you want to describe.");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String thingName = cmdUtils.GetCommandRequired("thing_name");
     String jobId = cmdUtils.GetCommandRequired("job_id");

--- a/samples/mqtt/basic_connect/main.cpp
+++ b/samples/mqtt/basic_connect/main.cpp
@@ -26,8 +26,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("cert", "<path>", "Path to your client certificate in PEM format.");
     cmdUtils.AddCommonProxyCommands();
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     // Make a MQTT client and create a connection using a certificate and key
     // Note: The data for the connection is gotten from cmdUtils

--- a/samples/mqtt/custom_authorizer_connect/main.cpp
+++ b/samples/mqtt/custom_authorizer_connect/main.cpp
@@ -24,8 +24,11 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonMQTTCommands();
     cmdUtils.AddCommonCustomAuthorizerCommands();
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
+    cmdUtils.RemoveCommand("ca_file");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     // Make a MQTT client and create a connection through a custom authorizer
     // Note: The data for the connection is gotten from cmdUtils

--- a/samples/mqtt/pkcs11_connect/main.cpp
+++ b/samples/mqtt/pkcs11_connect/main.cpp
@@ -29,8 +29,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("slot_id", "<int>", "Slot ID containing PKCS#11 token to use (optional).");
     cmdUtils.RegisterCommand("key_label", "<str>", "Label of private key on the PKCS#11 token (optional).");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     // Make a MQTT client and create a connection using a PKCS11
     // Note: The data for the connection is gotten from cmdUtils

--- a/samples/mqtt/raw_connect/main.cpp
+++ b/samples/mqtt/raw_connect/main.cpp
@@ -51,8 +51,10 @@ int main(int argc, char *argv[])
         "auth_params",
         "<comma delimited list>",
         "Comma delimited list of auth parameters. For websockets these will be set as headers (optional).");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String endpoint = cmdUtils.GetCommandRequired("endpoint");
     String keyPath = cmdUtils.GetCommandOrDefault("key", "");

--- a/samples/mqtt/websocket_connect/main.cpp
+++ b/samples/mqtt/websocket_connect/main.cpp
@@ -34,8 +34,10 @@ int main(int argc, char *argv[])
     cmdUtils.AddCommonProxyCommands();
     cmdUtils.RegisterCommand("signing_region", "<str>", "The signing region used for the websocket signer");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     // Make a MQTT client and create a connection using websockets
     // Note: The data for the connection is gotten from cmdUtils

--- a/samples/mqtt/windows_cert_connect/main.cpp
+++ b/samples/mqtt/windows_cert_connect/main.cpp
@@ -31,8 +31,10 @@ int main(int argc, char *argv[])
         "Your client certificate in the Windows certificate store. e.g. "
         "'CurrentUser\\MY\\6ac133ac58f0a88b83e9c794eba156a98da39b4c'");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*').");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String endpoint = cmdUtils.GetCommandRequired("endpoint");
     String windowsCertStorePath = cmdUtils.GetCommandRequired("cert");

--- a/samples/mqtt/x509_credentials_provider_connect/main.cpp
+++ b/samples/mqtt/x509_credentials_provider_connect/main.cpp
@@ -36,8 +36,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("signing_region", "<str>", "Used for websocket signer");
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     // Make a MQTT client and create a connection using websockets and x509
     // Note: The data for the connection is gotten from cmdUtils

--- a/samples/pub_sub/basic_pub_sub/main.cpp
+++ b/samples/pub_sub/basic_pub_sub/main.cpp
@@ -39,8 +39,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("client_id", "<str>", "Client id to use (optional, default='test-*')");
     cmdUtils.RegisterCommand("count", "<int>", "The number of messages to send (optional, default='10')");
     cmdUtils.RegisterCommand("port_override", "<int>", "The port override to use when connecting (optional)");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String topic = cmdUtils.GetCommandOrDefault("topic", "test/topic");
     String clientId = cmdUtils.GetCommandOrDefault("client_id", String("test-") + Aws::Crt::UUID().ToString());

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -49,8 +49,10 @@ int main(int argc, char *argv[])
         "proxy_user_name", "<str>", "User name passed if proxy server requires a user name (optional)");
     cmdUtils.RegisterCommand(
         "proxy_password", "<str>", "Password passed if proxy server requires a password (optional)");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     /*
      * Generate secure tunneling endpoint using region

--- a/samples/secure_tunneling/tunnel_notification/main.cpp
+++ b/samples/secure_tunneling/tunnel_notification/main.cpp
@@ -45,8 +45,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("key", "<path>", "Path to your key in PEM format.");
     cmdUtils.RegisterCommand("cert", "<path>", "Path to your client certificate in PEM format.");
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String thingName = cmdUtils.GetCommandRequired("thing_name");
 

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -103,8 +103,10 @@ int main(int argc, char *argv[])
     cmdUtils.RegisterCommand("cert", "<path>", "Path to your client certificate in PEM format.");
     cmdUtils.RegisterCommand("thing_name", "<str>", "The name of your IOT thing.");
     cmdUtils.RegisterCommand("shadow_property", "<str>", "The name of the shadow property you want to change.");
+    cmdUtils.AddLoggingCommands();
     const char **const_argv = (const char **)argv;
     cmdUtils.SendArguments(const_argv, const_argv + argc);
+    cmdUtils.StartLoggingBasedOnCommand(&apiHandle);
 
     String thingName = cmdUtils.GetCommandRequired("thing_name");
     String shadowProperty = cmdUtils.GetCommandRequired("shadow_property");

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -203,7 +203,7 @@ namespace Utils
         RegisterCommand(
             m_cmd_verbosity,
             "<log level>",
-            "The logging level to use. Choices are 'trace', 'debug', 'info', 'warn', 'error', 'fatal', and 'none'. "
+            "The logging level to use. Choices are 'Trace', 'Debug', 'Info', 'Warn', 'Error', 'Fatal', and 'None'. "
             "(optional, default='none')");
     }
 
@@ -213,27 +213,27 @@ namespace Utils
         if (HasCommand("verbosity"))
         {
             Aws::Crt::String verbosity = GetCommand(m_cmd_verbosity);
-            if (verbosity == "fatal")
+            if (verbosity == "Fatal")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Fatal, stderr);
             }
-            else if (verbosity == "error")
+            else if (verbosity == "Error")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Error, stderr);
             }
-            else if (verbosity == "warn")
+            else if (verbosity == "Warn")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Warn, stderr);
             }
-            else if (verbosity == "info")
+            else if (verbosity == "Info")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Info, stderr);
             }
-            else if (verbosity == "debug")
+            else if (verbosity == "Debug")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Debug, stderr);
             }
-            else if (verbosity == "trace")
+            else if (verbosity == "Trace")
             {
                 apiHandle->InitializeLogging(Aws::Crt::LogLevel::Trace, stderr);
             }

--- a/samples/utils/CommandLineUtils.cpp
+++ b/samples/utils/CommandLineUtils.cpp
@@ -198,6 +198,52 @@ namespace Utils
             "The password to send when connecting through a custom authorizer (optional)");
     }
 
+    void CommandLineUtils::AddLoggingCommands()
+    {
+        RegisterCommand(
+            m_cmd_verbosity,
+            "<log level>",
+            "The logging level to use. Choices are 'trace', 'debug', 'info', 'warn', 'error', 'fatal', and 'none'. "
+            "(optional, default='none')");
+    }
+
+    void CommandLineUtils::StartLoggingBasedOnCommand(Aws::Crt::ApiHandle *apiHandle)
+    {
+        // Process logging command
+        if (HasCommand("verbosity"))
+        {
+            Aws::Crt::String verbosity = GetCommand(m_cmd_verbosity);
+            if (verbosity == "fatal")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Fatal, stderr);
+            }
+            else if (verbosity == "error")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Error, stderr);
+            }
+            else if (verbosity == "warn")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Warn, stderr);
+            }
+            else if (verbosity == "info")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Info, stderr);
+            }
+            else if (verbosity == "debug")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Debug, stderr);
+            }
+            else if (verbosity == "trace")
+            {
+                apiHandle->InitializeLogging(Aws::Crt::LogLevel::Trace, stderr);
+            }
+            else
+            {
+                // If none or unknown, then do nothing
+            }
+        }
+    }
+
     std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> CommandLineUtils::BuildPKCS11MQTTConnection(
         Aws::Iot::MqttClient *client)
     {

--- a/samples/utils/CommandLineUtils.h
+++ b/samples/utils/CommandLineUtils.h
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+#include <aws/crt/Api.h>
 #include <aws/crt/Types.h>
 #include <aws/iot/MqttClient.h>
 
@@ -154,10 +155,20 @@ namespace Utils
         void AddCommonTopicMessageCommands();
 
         /**
-         * A helper function taht adds custom_auth_username, custom_auth_authorizer_name,
+         * A helper function that adds custom_auth_username, custom_auth_authorizer_name,
          * custom_auth_authorizer_signature and custom_auth_password commands
          */
         void AddCommonCustomAuthorizerCommands();
+
+        /**
+         * A helper function that adds the verbosity command for controlling logging in the samples
+         */
+        void AddLoggingCommands();
+
+        /**
+         * Starts logging based on the result of the verbosity command
+         */
+        void StartLoggingBasedOnCommand(Aws::Crt::ApiHandle *apiHandle);
 
         /**
          * A helper function that builds and returns a PKCS11 direct MQTT connection.
@@ -269,5 +280,6 @@ namespace Utils
         const Aws::Crt::String m_cmd_custom_auth_authorizer_name = "custom_auth_authorizer_name";
         const Aws::Crt::String m_cmd_custom_auth_authorizer_signature = "custom_auth_authorizer_signature";
         const Aws::Crt::String m_cmd_custom_auth_password = "custom_auth_password";
+        const Aws::Crt::String m_cmd_verbosity = "verbosity";
     };
 } // namespace Utils


### PR DESCRIPTION
*Description of changes:*

Adds the `verbosity` command to all of the samples, making it easier to debug without needing to recompile when you want to change logging verbosity. Also increases consistency with the other SDKs.
(*Also removed `ca_file` from the custom authorizer sample as it is not used in the sample.*)

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
