### PR TITLE
pub_sub/basic_pub_sub: fix error: ‘sleep_for’ is not a member of ‘std…

### DIFF
--- a/samples/pub_sub/basic_pub_sub/main.cpp
+++ b/samples/pub_sub/basic_pub_sub/main.cpp
@@ -13,6 +13,7 @@
 #include <aws/crt/UUID.h>
 #include <chrono>
 #include <mutex>
+#include <thread>
 
 #include "../../utils/CommandLineUtils.h"
 


### PR DESCRIPTION
…::this_thread’

when compiling with yocto master branch - gcc12 - there is an error
error: ‘sleep_for’ is not a member of ‘std::this_thread’

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
