### PR TITLE
Fix release workflow

### DIFF
--- a/update-version.sh
+++ b/update-version.sh
@@ -73,7 +73,7 @@ else
     git push "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/aws/aws-iot-device-sdk-cpp-v2.git" --tags
 
     # now recreate the release on the updated tag
-    gh release create ${version} --title "${title_value}" -p -n "${tag_message}"
+    gh release create ${version} --title "${title_value}" -n "${tag_message}"
 fi
 
 popd > /dev/null


### PR DESCRIPTION
*Description of changes:*

When I made the version stamping changes for the C++ V2 SDK, I forgot to run `chmod` on it so it can be executed, and so it failed. Thankfully for C++ it is just for version stamping, but this PR fixes it. It also makes the release **not** a pre-release but rather a full release.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
