### PR TITLE
document using system installation of libcrypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ cmake --build . --target install --config "Debug"
 * Due to maximum path length limitations in the Windows API, we recommend cloning to a short path like: `C:\dev\iotsdk`
 * `--config` is only REQUIRED for multi-configuration build tools (VisualStudio/MsBuild being the most common).
 
+**Linux specific notes**:
+
+If your application uses OpenSSL, configure with `-DUSE_OPENSSL=ON`.
+
+The IoT SDK does not use OpenSSL for TLS.
+On Apple and Windows, the OS's default TLS library is used.
+On Linux, [s2n-tls](https://github.com/aws/s2n-tls) is used.
+But s2n-tls uses libcrypto, the cryptography math library bundled with OpenSSL.
+To simplify the build process, the source code for s2n-tls and libcrypto are
+included as git submodules and built along with the IoT SDK.
+But if your application is also loading the system installation of OpenSSL
+(i.e. your application uses libcurl which uses libssl which uses libcrypto)
+there may be crashes as the application tries to use two different versions of libcrypto at once.
+
+Setting `-DUSE_OPENSSL=ON` will cause the IoT SDK to link against your system's
+existing `libcrypto`, instead of building its own copy.
+
 ## Samples
 
 [Samples README](./samples)


### PR DESCRIPTION
**Issue:**
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/499

User encountering crashes when they build an application that used the IoT SDK and libcurl, which created a dependency on two different versions of libcrypto.

**Description of Changes:**
Explain the `-DUSE_OPENSSL=ON` build option, and when you'd want to use it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
