### PR TITLE
Fix minor mistake in release YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 env:
-  GH_TOKEN: ${{ github.token }}
+  GITHUB_TOKEN: ${{ github.token }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
*Description of changes:*

Fixes a super minor mistake in the release YAML. In my testing repository I had the environment variable as `GH_TOKEN` but in this repository (and the others) I renamed it to `GITHUB_TOKEN` but forgot to change it in the YAML 🤦 

____________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
