### PR TITLE
Fix release script failing on releases with zero

### DIFF
--- a/utils/update_semantic_version.py
+++ b/utils/update_semantic_version.py
@@ -46,7 +46,7 @@ def main():
                     highest = i_version_tuple
                     continue
 
-        if (highest[0] != 0 and highest[1] != 0 and highest[2] != 0):
+        if (highest[0] != 0 or highest[1] != 0 or highest[2] != 0):
             print(f"v{highest[0]}.{highest[1]}.{highest[2]}")
             sys.exit(0)
         else:


### PR DESCRIPTION
*Description of changes:*

The script had a silly error where it would prevent releases if the tag had `0` at ANY point rather than preventing releases if the tag is ONLY `0.0.0`.
This PR fixes that issue.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
