### PR TITLE
Shared Subscription sample readme adjustment

### DIFF
--- a/samples/mqtt5/mqtt5_shared_subscription/README.md
+++ b/samples/mqtt5/mqtt5_shared_subscription/README.md
@@ -6,7 +6,7 @@ This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
 for AWS IoT to send and receive messages over an MQTT5 connection using a shared subscription.
 
-MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](https://github.com/awslabs/aws-crt-nodejs/blob/main/MQTT5-UserGuide.md).
+MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 

--- a/samples/mqtt5/mqtt5_shared_subscription/README.md
+++ b/samples/mqtt5/mqtt5_shared_subscription/README.md
@@ -6,7 +6,7 @@ This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
 for AWS IoT to send and receive messages over a MQTT5 connection using a shared subscription.
 
-MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
+MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the C++ V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 

--- a/samples/mqtt5/mqtt5_shared_subscription/README.md
+++ b/samples/mqtt5/mqtt5_shared_subscription/README.md
@@ -4,20 +4,20 @@
 
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
-for AWS IoT to send and receive messages through an MQTT connection using MQTT5 using a Shared Subscription.
+for AWS IoT to send and receive messages over an MQTT5 connection using a shared subscription.
 
-MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the C++ V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
+MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](https://github.com/awslabs/aws-crt-nodejs/blob/main/MQTT5-UserGuide.md).
 
 Note: MQTT5 support is currently in **developer preview**. We encourage feedback at all times, but feedback during the preview window is especially valuable in shaping the final product. During the preview period we may make backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
 
-Shared Subscriptions allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to processed.
+[Shared Subscriptions](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901250) allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to be processed.
 
-Shared Subscriptions rely on what is called a group identifier, which tells the MQTT5 broker/server which IoT devices are in what group. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices tp treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
 * `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
-* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. THis is the group of MQTT5 clients that will be worked through as part of the round-robin when a message comes in. For example: `my-iot-group`.
+* `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. Messages published to a matching topic will be distributed round-robin amongst the group.
 * `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.
 
-As mentioned, Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
+Shared Subscriptions use a round-robbin like method of distributing messages. For example, say you have three MQTT5 clients all subscribed to the same Shared Subscription group and topic. If five messages are sent to the Shared Subscription topic, the messages will likely be delivered in the following order:
 * Message 1 -> Client one
 * Message 2 -> Client two
 * Message 3 -> Client three

--- a/samples/mqtt5/mqtt5_shared_subscription/README.md
+++ b/samples/mqtt5/mqtt5_shared_subscription/README.md
@@ -4,7 +4,7 @@
 
 This sample uses the
 [Message Broker](https://docs.aws.amazon.com/iot/latest/developerguide/iot-message-broker.html)
-for AWS IoT to send and receive messages over an MQTT5 connection using a shared subscription.
+for AWS IoT to send and receive messages over a MQTT5 connection using a shared subscription.
 
 MQTT5 introduces additional features and enhancements that improve the development experience with MQTT. You can read more about MQTT5 in the Javascript V2 SDK by checking out the [MQTT5 user guide](../../../documents/MQTT5_Userguide.md).
 
@@ -12,7 +12,7 @@ Note: MQTT5 support is currently in **developer preview**. We encourage feedback
 
 [Shared Subscriptions](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901250) allow IoT devices to connect to a group where messages sent to a topic are then relayed to the group in a round-robin-like fashion. This is useful for distributing message load across multiple subscribing MQTT5 clients automatically. This is helpful for load balancing when you have many messages that need to be processed.
 
-Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices tp treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
+Shared Subscriptions rely on a group identifier, which tells the MQTT5 broker/server which IoT devices to treat as a group for message distribution. This is done when subscribing by formatting the subscription topic like the following: `$share/<group identifier>/<topic>`.
 * `$share`: Tells the MQTT5 broker/server that the device is subscribing to a Shared Subscription.
 * `<group identifier>`: Tells the MQTT5 broker/server which group to add this Shared Subscription to. Messages published to a matching topic will be distributed round-robin amongst the group.
 * `<topic>`: The topic that the Shared Subscription is for. Messages published to this topic will be processed in a round-robin fashion. For example, `test/topic`.

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -14,12 +14,6 @@
 using namespace Aws::Crt;
 
 /**
- * MQTT5 support is currently in <b>developer preview</b>.  We encourage feedback at all times, but feedback during the
- * preview window is especially valuable in shaping the final product.  During the preview period we may make
- * backwards-incompatible changes to the public API, but in general, this is something we will try our best to avoid.
- */
-
-/**
  * For the purposes of this sample, we need to associate certain variables with a particular MQTT5 client
  * and to do so we use this class to hold all the data for a particular client used in the sample.
  */


### PR DESCRIPTION
*Description of changes:*

Makes a quick adjustment to the README of the shared subscription sample to adjust its wording. Also removes the note about MQTT5 being in developer preview from the sample source directly.

________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
