### PR TITLE
optional tls settings on secure tunnel creation

### DIFF
--- a/documents/Secure_Tunnel_Userguide.md
+++ b/documents/Secure_Tunnel_Userguide.md
@@ -43,7 +43,7 @@ When a WebSocket upgrade request fails to connect, this callback will return an 
 ### OnConnectionShutdown
 When the WebSocket connection shuts down, this callback will be invoked.
 
-## OnSendMessageComplete
+### OnSendMessageComplete
 When a message has been completely written to the socket, this callback will be invoked.
 
 ### OnMessageReceived
@@ -142,10 +142,10 @@ if (!secureTunnel->Start())
 }
 ```
 ### Reconnecting
-A Secure Tunnel Client that has been started will attempt to reconnect upon disconnection until `Stop()` is called. The Secure Tunnel Client implements a Full Jitter Backoff Algorithm along with an exponential back off timer. More information on both can be found here: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
+A Secure Tunnel Client that has been started will attempt to reconnect upon a failed connection attempt or disconnection until `Stop()` is called. If the secure tunnel closes or the access tokens change, the Secure Tunnel Client will become disconnected and continue to attempt a reconnection until `Stop()` is called. The Secure Tunnel Client implements a Full Jitter Backoff Algorithm along with an exponential back off timer. More information on both can be found here: https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
 
 ## Stop
-Invoking `Stop()` on the Secure Tunnel Client breaks the current connection (if any) and moves the client into an idle state.
+Invoking `Stop()` on the Secure Tunnel Client breaks the current connection (if any) and moves the client into an idle state. A Secure Tunnel Client that has been stopped will no longer attempt to reconnect and is ready to be cleaned up.
 ```cpp
 if(!secureTunnel->Stop()){
     fprintf(stdout, "Failed to stop the Secure Tunnel connection session. Exiting..\n");

--- a/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
+++ b/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
@@ -617,6 +617,16 @@ namespace Aws
                 const std::string &endpointHost); // Make a copy and save in this object
 
             /* Optional members */
+
+            /**
+             * Sets TLS options to be used by secure tunnel connection.
+             *
+             * @param tslOptions TLS options to use for secure tunnel connection
+             *
+             * @return this builder object
+             */
+            SecureTunnelBuilder &WithTlsConnectionOptions(const Crt::Io::TlsConnectionOptions &tslOptions);
+
             /**
              * Sets rootCA to be used for this secure tunnel connection overriding the default trust store.
              *
@@ -824,6 +834,12 @@ namespace Aws
              * has the desired state of CONNECTED.
              */
             std::string m_clientToken;
+
+            /**
+             * If set, TLS context for secure socket connections.
+             * If undefined, then default options will be used.
+             */
+            Crt::Optional<Crt::Io::TlsConnectionOptions> m_tlsConnectionOptions;
 
             /**
              * If set, this will be used to override the default trust store.
@@ -1130,6 +1146,7 @@ namespace Aws
                 aws_secure_tunneling_local_proxy_mode localProxyMode,
                 const std::string &endpointHost,
 
+                Crt::Io::TlsConnectionOptions *tslOptions,
                 const std::string &rootCa,
                 Crt::Http::HttpClientConnectionProxyOptions *httpClientConnectionProxyOptions,
 

--- a/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
+++ b/secure_tunneling/include/aws/iotsecuretunneling/SecureTunnel.h
@@ -621,7 +621,8 @@ namespace Aws
             /**
              * Sets TLS options to be used by secure tunnel connection.
              *
-             * @param tslOptions TLS options to use for secure tunnel connection
+             * @param tslOptions TLS options to use for secure tunnel connection. If provided, the rootCA settings in
+             * these options will override any rootCA provided to the builder.
              *
              * @return this builder object
              */

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -348,6 +348,13 @@ namespace Aws
         {
         }
 
+        SecureTunnelBuilder &SecureTunnelBuilder::WithTlsConnectionOptions(
+            const Crt::Io::TlsConnectionOptions &tslOptions)
+        {
+            m_tlsConnectionOptions = tslOptions;
+            return *this;
+        }
+
         SecureTunnelBuilder &SecureTunnelBuilder::WithRootCa(const std::string &rootCa)
         {
             m_rootCa = rootCa;
@@ -474,6 +481,7 @@ namespace Aws
                 m_clientToken,
                 m_localProxyMode,
                 m_endpointHost,
+                m_tlsConnectionOptions.has_value() ? &m_tlsConnectionOptions.value() : nullptr,
                 m_rootCa,
                 m_httpClientConnectionProxyOptions.has_value() ? &m_httpClientConnectionProxyOptions.value() : nullptr,
                 m_OnConnectionSuccess,
@@ -518,6 +526,7 @@ namespace Aws
             aws_secure_tunneling_local_proxy_mode localProxyMode,
             const std::string &endpointHost,
 
+            Crt::Io::TlsConnectionOptions *tslOptions,
             const std::string &rootCa,
             Aws::Crt::Http::HttpClientConnectionProxyOptions *httpClientConnectionProxyOptions,
 
@@ -565,6 +574,8 @@ namespace Aws
             config.access_token = aws_byte_cursor_from_c_str(accessToken.c_str());
             config.local_proxy_mode = localProxyMode;
             config.endpoint_host = aws_byte_cursor_from_c_str(endpointHost.c_str());
+
+            config.tls_options = tslOptions ? tslOptions->GetUnderlyingHandle() : nullptr;
 
             if (rootCa.length() > 0)
             {
@@ -631,6 +642,7 @@ namespace Aws
                   nullptr,
                   localProxyMode,
                   endpointHost,
+                  nullptr,
                   rootCa,
                   nullptr,
                   nullptr,
@@ -679,6 +691,7 @@ namespace Aws
                   nullptr,
                   localProxyMode,
                   endpointHost,
+                  nullptr,
                   rootCa,
                   nullptr,
                   nullptr,


### PR DESCRIPTION
* Add option to provide tls options when building a new secure tunnel


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
