### PR TITLE
fix for secure tunnel exceptions

### DIFF
--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -639,7 +639,7 @@ namespace Aws
                   clientBootstrap,
                   socketOptions,
                   accessToken,
-                  nullptr,
+                  "",
                   localProxyMode,
                   endpointHost,
                   nullptr,
@@ -688,7 +688,7 @@ namespace Aws
                   Crt::ApiHandle::GetOrCreateStaticDefaultClientBootstrap(),
                   socketOptions,
                   accessToken,
-                  nullptr,
+                  "",
                   localProxyMode,
                   endpointHost,
                   nullptr,
@@ -976,6 +976,7 @@ namespace Aws
                         payload_buf.allocator = NULL;
                         payload_buf.buffer = message->payload->ptr;
                         payload_buf.len = message->payload->len;
+                        payload_buf.capacity = message->payload->len;
                         secureTunnel->m_OnDataReceive(payload_buf);
                         return;
                     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-iot-device-client/issues/395

*Description of changes:*
- replace nullptr string assignment with empty string
- manually set capacity of byte_buf


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
