### PR TITLE
Stop checking CMAKE_BUILD_TYPE in CMake scripts

### DIFF
--- a/devicedefender/CMakeLists.txt
+++ b/devicedefender/CMakeLists.txt
@@ -58,9 +58,7 @@ else ()
     target_compile_options(IotDeviceDefender-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(IotDeviceDefender-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(IotDeviceDefender-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(IotDeviceDefender-cpp PUBLIC "-DAWS_IOTDEVICEDEFENDER_USE_IMPORT_EXPORT")

--- a/discovery/CMakeLists.txt
+++ b/discovery/CMakeLists.txt
@@ -57,9 +57,7 @@ else ()
     target_compile_options(Discovery-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(Discovery-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(Discovery-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(Discovery-cpp PUBLIC "-DAWS_DISCOVERY_USE_IMPORT_EXPORT")

--- a/eventstream_rpc/CMakeLists.txt
+++ b/eventstream_rpc/CMakeLists.txt
@@ -57,9 +57,7 @@ else ()
     target_compile_options(EventstreamRpc-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(EventstreamRpc-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(EventstreamRpc-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(EventstreamRpc-cpp PUBLIC "-DAWS_EVENTSTREAMRPC_USE_IMPORT_EXPORT")

--- a/greengrass_ipc/CMakeLists.txt
+++ b/greengrass_ipc/CMakeLists.txt
@@ -64,10 +64,7 @@ if (MSVC)
     target_compile_options(GreengrassIpc-cpp PRIVATE /bigobj)
 endif ()
 
-
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(GreengrassIpc-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(GreengrassIpc-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(GreengrassIpc-cpp PUBLIC "-DAWS_GREENGRASSIPC_USE_IMPORT_EXPORT")

--- a/identity/CMakeLists.txt
+++ b/identity/CMakeLists.txt
@@ -57,9 +57,7 @@ else ()
     target_compile_options(IotIdentity-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(IotIdentity-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(IotIdentity-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(IotIdentity-cpp PUBLIC "-DAWS_IOTIDENTITY_USE_IMPORT_EXPORT")

--- a/iotdevicecommon/CMakeLists.txt
+++ b/iotdevicecommon/CMakeLists.txt
@@ -59,9 +59,7 @@ else ()
     target_compile_options(IotDeviceCommon-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(IotDeviceCommon-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(IotDeviceCommon-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(IotDeviceCommon-cpp PUBLIC "-DAWS_IOTDEVICECOMMON_USE_IMPORT_EXPORT")

--- a/secure_tunneling/CMakeLists.txt
+++ b/secure_tunneling/CMakeLists.txt
@@ -57,9 +57,7 @@ else ()
     target_compile_options(IotSecureTunneling-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(IotSecureTunneling-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(IotSecureTunneling-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(IotSecureTunneling-cpp PUBLIC "-DAWS_IOTSECURETUNNELING_USE_IMPORT_EXPORT")

--- a/shadow/CMakeLists.txt
+++ b/shadow/CMakeLists.txt
@@ -57,9 +57,7 @@ else ()
     target_compile_options(IotShadow-cpp PRIVATE -Wall -Wno-long-long -pedantic -Werror)
 endif ()
 
-if (CMAKE_BUILD_TYPE STREQUAL "" OR CMAKE_BUILD_TYPE MATCHES Debug)
-    target_compile_definitions(IotShadow-cpp PRIVATE "-DDEBUG_BUILD")
-endif ()
+target_compile_definitions(IotShadow-cpp PRIVATE $<$<CONFIG:Debug>:DEBUG_BUILD>)
 
 if (BUILD_SHARED_LIBS)
     target_compile_definitions(IotShadow-cpp PUBLIC "-DAWS_IOTSHADOW_USE_IMPORT_EXPORT")


### PR DESCRIPTION
**Issue:**

If a windows user does:
```
cmake -B build -S .
cmake --build build --config Release
```

Their Release code will compile with `-DDEBUG_BUILD` defined.

**Description of Changes:**

CMake scripts should use `$<CONFIG>` generator expressions, instead of checking `${CMAKE_BUILD_TYPE}`. Multi-config generators like Visual Studio ignore `CMAKE_BUILD_TYPE`, so many users (and IDEs like VSCode with the CMake Tools plugin) don't bother setting `CMAKE_BUILD_TYPE`. See: https://cmake.org/cmake/help/v3.22/manual/cmake-buildsystem.7.html#build-configurations



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
