### PR TITLE
Set ClientConnect status to DISCONNECTED on connection failure

### DIFF
--- a/eventstream_rpc/source/EventStreamClient.cpp
+++ b/eventstream_rpc/source/EventStreamClient.cpp
@@ -321,6 +321,8 @@ namespace Aws
             {
                 std::promise<RpcError> errorPromise;
                 errorPromise.set_value({baseError, 0});
+		const std::lock_guard<std::recursive_mutex> lock(m_stateMutex);
+		m_clientState = DISCONNECTED;
                 return errorPromise.get_future();
             }
 
@@ -353,6 +355,8 @@ namespace Aws
                     "A CRT error occurred while attempting to establish the connection: %s",
                     Crt::ErrorDebugString(crtError));
                 errorPromise.set_value({EVENT_STREAM_RPC_CRT_ERROR, crtError});
+		const std::lock_guard<std::recursive_mutex> lock(m_stateMutex);
+		m_clientState = DISCONNECTED;
                 return errorPromise.get_future();
             }
             else


### PR DESCRIPTION
Set ClientConnect status to DISCONNECTED on connection failure due to NULL param or socket issue

*Issue #, if available:*

*Description of changes:*

When there is a connection issue with the Green grass IPC Client (Via Eventstreamrpc Client::Connect)

The Greengrass IPC object does not shutdown gracefully

This is due to an infinite wait on promise 
https://github.com/aws/aws-iot-device-sdk-cpp-v2/blob/main/eventstream_rpc/source/EventStreamClient.cpp#L202

Hence on connection failure, The status of connection should be updated to DISCONNECTED

This CR does the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
