### PR TITLE
Change `port` from uint16_t to uint32_t, to support VSOCK

### DIFF
--- a/discovery/include/aws/discovery/ConnectivityInfo.h
+++ b/discovery/include/aws/discovery/ConnectivityInfo.h
@@ -25,7 +25,7 @@ namespace Aws
             Aws::Crt::Optional<Aws::Crt::String> ID;
             Aws::Crt::Optional<Aws::Crt::String> HostAddress;
             Aws::Crt::Optional<Aws::Crt::String> Metadata;
-            Aws::Crt::Optional<uint16_t> Port;
+            Aws::Crt::Optional<uint32_t> Port;
 
           private:
             static void LoadFromObject(ConnectivityInfo &obj, const Crt::JsonView &doc);

--- a/discovery/source/ConnectivityInfo.cpp
+++ b/discovery/source/ConnectivityInfo.cpp
@@ -22,7 +22,7 @@ namespace Aws
 
             if (doc.KeyExists("PortNumber"))
             {
-                obj.Port = static_cast<uint16_t>(doc.GetInteger("PortNumber"));
+                obj.Port = static_cast<uint32_t>(doc.GetInteger("PortNumber"));
             }
 
             if (doc.KeyExists("Metadata"))

--- a/discovery/source/DiscoveryClient.cpp
+++ b/discovery/source/DiscoveryClient.cpp
@@ -41,7 +41,7 @@ namespace Aws
             }
 
             Crt::Io::TlsConnectionOptions tlsConnectionOptions = clientConfig.TlsContext->NewConnectionOptions();
-            uint16_t port = 443;
+            uint32_t port = 443;
 
             if (Crt::Io::TlsContextOptions::IsAlpnSupported())
             {

--- a/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
+++ b/eventstream_rpc/include/aws/eventstreamrpc/EventStreamClient.h
@@ -151,7 +151,7 @@ namespace Aws
           public:
             ConnectionConfig() noexcept : m_clientBootstrap(nullptr), m_connectRequestCallback(nullptr) {}
             Crt::Optional<Crt::String> GetHostName() const noexcept { return m_hostName; }
-            Crt::Optional<uint16_t> GetPort() const noexcept { return m_port; }
+            Crt::Optional<uint32_t> GetPort() const noexcept { return m_port; }
             Crt::Optional<Crt::Io::SocketOptions> GetSocketOptions() const noexcept { return m_socketOptions; }
             Crt::Optional<MessageAmendment> GetConnectAmendment() const noexcept { return m_connectAmendment; }
             Crt::Optional<Crt::Io::TlsConnectionOptions> GetTlsConnectionOptions() const noexcept
@@ -166,7 +166,7 @@ namespace Aws
             }
 
             void SetHostName(Crt::String hostName) noexcept { m_hostName = hostName; }
-            void SetPort(uint16_t port) noexcept { m_port = port; }
+            void SetPort(uint32_t port) noexcept { m_port = port; }
             void SetSocketOptions(const Crt::Io::SocketOptions &socketOptions) noexcept
             {
                 m_socketOptions = socketOptions;
@@ -190,7 +190,7 @@ namespace Aws
 
           protected:
             Crt::Optional<Crt::String> m_hostName;
-            Crt::Optional<uint16_t> m_port;
+            Crt::Optional<uint32_t> m_port;
             Crt::Optional<Crt::Io::SocketOptions> m_socketOptions;
             Crt::Optional<Crt::Io::TlsConnectionOptions> m_tlsConnectionOptions;
             Crt::Io::ClientBootstrap *m_clientBootstrap;

--- a/samples/device_defender/basic_report/main.cpp
+++ b/samples/device_defender/basic_report/main.cpp
@@ -83,13 +83,13 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder.WithPortOverride(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder.WithPortOverride(static_cast<uint32_t>(cmdData.input_port));
     }
 
     // Create the MQTT connection from the MQTT builder

--- a/samples/device_defender/mqtt5_basic_report/main.cpp
+++ b/samples/device_defender/mqtt5_basic_report/main.cpp
@@ -83,13 +83,13 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder->WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
 
     std::promise<bool> connectionPromise;

--- a/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -95,7 +95,7 @@ int main(int argc, char *argv[])
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
 
     std::promise<bool> connectionPromise;

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char *argv[])
     if (cmdData.input_proxyHost.length() > 0 && cmdData.input_proxyPort != 0)
     {
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         clientConfig.ProxyOptions = proxyOptions;
     }
 

--- a/samples/jobs/mqtt5_job_execution/main.cpp
+++ b/samples/jobs/mqtt5_job_execution/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
 
     std::promise<bool> connectionPromise;

--- a/samples/mqtt/basic_connect/main.cpp
+++ b/samples/mqtt/basic_connect/main.cpp
@@ -36,13 +36,13 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder.WithPortOverride(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder.WithPortOverride(static_cast<uint32_t>(cmdData.input_port));
     }
 
     // Create the MQTT connection from the MQTT builder

--- a/samples/mqtt/cognito_connect/main.cpp
+++ b/samples/mqtt/cognito_connect/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }

--- a/samples/mqtt/websocket_connect/main.cpp
+++ b/samples/mqtt/websocket_connect/main.cpp
@@ -44,13 +44,13 @@ void connection_setup(
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder.WithPortOverride(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder.WithPortOverride(static_cast<uint32_t>(cmdData.input_port));
     }
     clientConfigBuilder.WithEndpoint(cmdData.input_endpoint);
 }

--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
 
     std::promise<bool> connectionPromise;

--- a/samples/pub_sub/basic_pub_sub/main.cpp
+++ b/samples/pub_sub/basic_pub_sub/main.cpp
@@ -47,13 +47,13 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder.WithPortOverride(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder.WithPortOverride(static_cast<uint32_t>(cmdData.input_port));
     }
 
     // Create the MQTT connection from the MQTT builder

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[])
     {
         auto proxyOptions = Aws::Crt::Http::HttpClientConnectionProxyOptions();
         proxyOptions.HostName = cmdData.input_proxyHost != "";
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
 
         // Set up Proxy Strategy if a user name and password is provided
         if (cmdData.input_proxyUserName != "" || cmdData.input_proxyPassword != "")

--- a/samples/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/shadow/mqtt5_shadow_sync/main.cpp
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
 
     std::promise<bool> connectionPromise;

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -114,13 +114,13 @@ int main(int argc, char *argv[])
     {
         Aws::Crt::Http::HttpClientConnectionProxyOptions proxyOptions;
         proxyOptions.HostName = cmdData.input_proxyHost;
-        proxyOptions.Port = static_cast<uint16_t>(cmdData.input_proxyPort);
+        proxyOptions.Port = static_cast<uint32_t>(cmdData.input_proxyPort);
         proxyOptions.AuthType = Aws::Crt::Http::AwsHttpProxyAuthenticationType::None;
         clientConfigBuilder.WithHttpProxyOptions(proxyOptions);
     }
     if (cmdData.input_port != 0)
     {
-        clientConfigBuilder.WithPortOverride(static_cast<uint16_t>(cmdData.input_port));
+        clientConfigBuilder.WithPortOverride(static_cast<uint32_t>(cmdData.input_port));
     }
 
     // Create the MQTT connection from the MQTT builder

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -146,7 +146,7 @@ std::shared_ptr<IotIdentityClient> build_mqtt5_client(
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
     // Setup lifecycle callbacks
     builder->WithClientConnectionSuccessCallback(

--- a/servicetests/tests/JobsExecution/main.cpp
+++ b/servicetests/tests/JobsExecution/main.cpp
@@ -138,7 +138,7 @@ std::shared_ptr<IotJobsClient> build_mqtt5_client(
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
     // Setup lifecycle callbacks
     builder->WithClientConnectionSuccessCallback(

--- a/servicetests/tests/ShadowUpdate/main.cpp
+++ b/servicetests/tests/ShadowUpdate/main.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<IotShadowClient> build_mqtt5_client(
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
     {
-        builder->WithPort(static_cast<uint16_t>(cmdData.input_port));
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
     }
     // Setup lifecycle callbacks
     builder->WithClientConnectionSuccessCallback(


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
