### PR TITLE
Disable nojekyll on gh-pages

### DIFF
--- a/make-docs.py
+++ b/make-docs.py
@@ -12,3 +12,7 @@ if os.path.exists('docs'):
 # build
 if os.system('doxygen docsrc/doxygen.config') != 0:
     exit(1)
+
+# disable jekyll on gh-pages, because jekyll ignores html files
+# started with underscore, and doxygen does generate such filenames
+open('docs/.nojekyll', 'w').close()


### PR DESCRIPTION
Add a special file disabling nojekyll on gh-pages.
I verified this fix in a fork, disabling jekyll **does not** change how the pages look.

Main repo returns 404: https://aws.github.io/aws-iot-device-sdk-cpp-v2/_greengrass_core_ipc_model_8h_source.html
Fork repo works: https://sfod.github.io/aws-iot-device-sdk-cpp-v2/_greengrass_core_ipc_model_8h_source.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
