### PR TITLE
Fix macos CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: run MQTT3 PubSub sample
         run: |
+          source .venv/bin/activate
           python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_pubsub_cfg.json
 #      - name: run PKCS12 sample
 #        run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,9 @@ jobs:
           ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3 --break-system-packages
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python3 -m pip install boto3
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,12 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
   osx:
-    runs-on: macos-13
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        runner:
+          - macos-13
+          - macos-latest
     permissions:
       id-token: write # This is required for requesting the JWT
       security-events: write # This is required for pkcs12 sample to sign the key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: run MQTT5 PubSub sample
         run: |
+          source .venv/bin/activate
           python3 ${{ env.CI_UTILS_FOLDER }}/run_sample_ci.py --file ${{ env.CI_SAMPLES_CFG_FOLDER }}/ci_run_mqtt5_pubsub_cfg.json
       - name: configure AWS credentials (Device Advisor)
         uses: aws-actions/configure-aws-credentials@v2
@@ -386,6 +387,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: run DeviceAdvisor
         run: |
+          source .venv/bin/activate
           cd ./aws-iot-device-sdk-cpp-v2
           python3 ./deviceadvisor/script/DATestRun.py
   # Not strictly needed, but allows us to run Device Advisor and PubSub on Linux without needing to run all samples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3 --break-system-packages
+          python -m pip install boto3
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -211,7 +211,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-Tv140 --cmake-extra=-A${{ matrix.arch }}
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3 --break-system-packages
+          python -m pip install boto3
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -256,7 +256,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3 --break-system-packages
+          python -m pip install boto3
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -301,7 +301,7 @@ jobs:
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
     - name: Running samples in CI setup
       run: |
-        python -m pip install boto3 --break-system-packages
+        python -m pip install boto3
     - name: configure AWS credentials (CyclePubSub)
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -399,7 +399,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3 --break-system-packages
+          python3 -m pip install boto3
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -462,7 +462,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3 --break-system-packages
+          python3 -m pip install boto3
           sudo apt-get update -y
           sudo apt-get install softhsm -y
           softhsm2-util --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3
+          python -m pip install boto3 --break-system-packages
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -211,7 +211,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-Tv140 --cmake-extra=-A${{ matrix.arch }}
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3
+          python -m pip install boto3 --break-system-packages
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -256,7 +256,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
       - name: Running samples in CI setup
         run: |
-          python -m pip install boto3
+          python -m pip install boto3 --break-system-packages
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -301,7 +301,7 @@ jobs:
         python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DUSE_CPU_EXTENSIONS=OFF
     - name: Running samples in CI setup
       run: |
-        python -m pip install boto3
+        python -m pip install boto3 --break-system-packages
     - name: configure AWS credentials (CyclePubSub)
       uses: aws-actions/configure-aws-credentials@v2
       with:
@@ -342,7 +342,7 @@ jobs:
           ./builder build -p ${{ env.PACKAGE_NAME }} --spec=downstream
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3
+          python3 -m pip install boto3 --break-system-packages
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -399,7 +399,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3
+          python3 -m pip install boto3 --break-system-packages
       - name: configure AWS credentials (PubSub)
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -462,7 +462,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }}
       - name: Running samples in CI setup
         run: |
-          python3 -m pip install boto3
+          python3 -m pip install boto3 --break-system-packages
           sudo apt-get update -y
           sudo apt-get install softhsm -y
           softhsm2-util --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,7 +325,7 @@ jobs:
           python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBUILD_SHARED_LIBS=ON
 
   osx:
-    runs-on: macos-latest
+    runs-on: macos-13
     permissions:
       id-token: write # This is required for requesting the JWT
       security-events: write # This is required for pkcs12 sample to sign the key


### PR DESCRIPTION
- Add macos-13 image to OSX job.
- Use Python virtual env to install packages. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
