### PR TITLE
Fix race conditions in samples and service tests

### DIFF
--- a/samples/device_defender/mqtt5_basic_report/main.cpp
+++ b/samples/device_defender/mqtt5_basic_report/main.cpp
@@ -73,10 +73,9 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputDeviceDefender(argc, argv, &apiHandle);
 
     // Create the MQTT builder and populate it with data from cmdData.
-    auto clientConfigBuilder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto clientConfigBuilder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
     if (clientConfigBuilder == nullptr)
     {
         fprintf(

--- a/samples/device_defender/mqtt5_basic_report/main.cpp
+++ b/samples/device_defender/mqtt5_basic_report/main.cpp
@@ -73,8 +73,20 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputDeviceDefender(argc, argv, &apiHandle);
 
     // Create the MQTT builder and populate it with data from cmdData.
-    auto clientConfigBuilder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
+    auto clientConfigBuilder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
+        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+    if (clientConfigBuilder == nullptr)
+    {
+        fprintf(
+            stdout,
+            "Failed to setup MQTT5 client builder with error code %d: %s",
+            LastError(),
+            ErrorDebugString(LastError()));
+        return -1;
+    }
+
     if (cmdData.input_ca != "")
     {
         clientConfigBuilder->WithCertificateAuthority(cmdData.input_ca.c_str());
@@ -118,9 +130,6 @@ int main(int argc, char *argv[])
 
     // Create Mqtt5Client
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = clientConfigBuilder->Build();
-
-    // Clean up the builder
-    delete clientConfigBuilder;
 
     if (client == nullptr)
     {

--- a/samples/fleet_provisioning/fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/fleet_provisioning/main.cpp
@@ -426,7 +426,7 @@ int main(int argc, char *argv[])
 {
     /************************ Setup ****************************/
 
-    //  Do the global initialization for the API
+    // Do the global initialization for the API
     ApiHandle apiHandle;
 
     /**

--- a/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmd
         [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
 
     // Check if the builder setup correctly.
-    if (!builder)
+    if (builder == nullptr)
     {
         printf(
             "Failed to setup mqtt5 client builder with error code %d: %s", LastError(), ErrorDebugString(LastError()));

--- a/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -82,11 +82,13 @@ struct RegisterThingContext
 std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmdData &cmdData, Mqtt5ClientContext &ctx)
 {
     // Create the MQTT5 builder and populate it with data from cmdData.
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
+    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
+        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
 
     // Check if the builder setup correctly.
-    if (builder == nullptr)
+    if (!builder)
     {
         printf(
             "Failed to setup mqtt5 client builder with error code %d: %s", LastError(), ErrorDebugString(LastError()));
@@ -128,7 +130,6 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmd
 
     // Create Mqtt5Client
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
-    delete builder;
 
     return client;
 }

--- a/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -82,10 +82,9 @@ struct RegisterThingContext
 std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmdData &cmdData, Mqtt5ClientContext &ctx)
 {
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -79,7 +79,7 @@ struct RegisterThingContext
 /**
  * Create MQTT5 client.
  */
-std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(Mqtt5ClientContext &ctx, const Utils::cmdData &cmdData)
+std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmdData &cmdData, Mqtt5ClientContext &ctx)
 {
     // Create the MQTT5 builder and populate it with data from cmdData.
     Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
@@ -418,7 +418,7 @@ int main(int argc, char *argv[])
 {
     /************************ Setup ****************************/
 
-    //  Do the global initialization for the API
+    // Do the global initialization for the API
     ApiHandle apiHandle;
 
     /**
@@ -429,7 +429,7 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputFleetProvisioning(argc, argv, &apiHandle);
 
     Mqtt5ClientContext mqtt5ClientContext;
-    auto client = createMqtt5Client(mqtt5ClientContext, cmdData);
+    auto client = createMqtt5Client(cmdData, mqtt5ClientContext);
 
     /************************ Run the sample ****************************/
 

--- a/samples/jobs/mqtt5_job_execution/main.cpp
+++ b/samples/jobs/mqtt5_job_execution/main.cpp
@@ -57,10 +57,9 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputJobs(argc, argv, &apiHandle);
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/jobs/mqtt5_job_execution/main.cpp
+++ b/samples/jobs/mqtt5_job_execution/main.cpp
@@ -57,8 +57,10 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputJobs(argc, argv, &apiHandle);
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
+    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
+        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
 
     // Check if the builder setup correctly.
     if (builder == nullptr)
@@ -101,7 +103,6 @@ int main(int argc, char *argv[])
 
     // Create Mqtt5Client
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
-    delete builder;
     /************************ Run the sample ****************************/
 
     fprintf(stdout, "Connecting...\n");

--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -34,10 +34,9 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputPubSub(argc, argv, &apiHandle, "mqtt5-pubsub");
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -34,8 +34,10 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputPubSub(argc, argv, &apiHandle, "mqtt5-pubsub");
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
+    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
+        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
 
     // Check if the builder setup correctly.
     if (builder == nullptr)
@@ -106,9 +108,6 @@ int main(int argc, char *argv[])
 
     // Create Mqtt5Client
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
-
-    // Clean up the builder
-    delete builder;
 
     if (client == nullptr)
     {

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -45,8 +45,10 @@ class sample_mqtt5_client
         std::shared_ptr<sample_mqtt5_client> result = std::make_shared<sample_mqtt5_client>();
         result->name = input_clientName;
 
-        Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            input_endpoint, input_cert.c_str(), input_key.c_str());
+        auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+            Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+                input_endpoint, input_cert.c_str(), input_key.c_str()),
+            [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
         if (builder == nullptr)
         {
             return nullptr;
@@ -136,7 +138,6 @@ class sample_mqtt5_client
         });
 
         result->client = builder->Build();
-        delete builder;
         return result;
     }
 };

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -45,10 +45,9 @@ class sample_mqtt5_client
         std::shared_ptr<sample_mqtt5_client> result = std::make_shared<sample_mqtt5_client>();
         result->name = input_clientName;
 
-        auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
             Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-                input_endpoint, input_cert.c_str(), input_key.c_str()),
-            [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+                input_endpoint, input_cert.c_str(), input_key.c_str()));
         if (builder == nullptr)
         {
             return nullptr;

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -133,6 +133,7 @@ int main(int argc, char *argv[])
      * In a real world application you probably don't want to enforce synchronous behavior
      * but this is a sample console application, so we'll just do that with a condition variable.
      */
+    std::promise<void> clientConnectedPromise;
     std::promise<bool> clientStoppedPromise;
 
     // service id storage for use in sample
@@ -285,6 +286,7 @@ int main(int argc, char *argv[])
                 fprintf(stdout, "Sending Stream Start request\n");
                 secureTunnel->SendStreamStart();
             }
+            clientConnectedPromise.set_value();
         }
     });
 
@@ -344,6 +346,8 @@ int main(int argc, char *argv[])
         fprintf(stderr, "Secure Tunnel Connect call failed: %s\n", ErrorDebugString(LastError()));
         exit(-1);
     }
+
+    clientConnectedPromise.get_future().wait_for(std::chrono::seconds(5));
 
     /*
      * In Destination mode the Secure Tunnel Client will remain open and echo messages that come in.

--- a/samples/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/shadow/mqtt5_shadow_sync/main.cpp
@@ -104,9 +104,10 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputShadow(argc, argv, &apiHandle);
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
-
+    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
+        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {
@@ -148,7 +149,6 @@ int main(int argc, char *argv[])
 
     // Create Mqtt5Client
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
-    delete builder;
     /************************ Run the sample ****************************/
 
     fprintf(stdout, "Connecting...\n");

--- a/samples/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/shadow/mqtt5_shadow_sync/main.cpp
@@ -104,10 +104,9 @@ int main(int argc, char *argv[])
     Utils::cmdData cmdData = Utils::parseSampleInputShadow(argc, argv, &apiHandle);
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -91,7 +91,7 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmd
         [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
 
     // Check if the builder setup correctly.
-    if (!builder)
+    if (builder == nullptr)
     {
         printf(
             "Failed to setup mqtt5 client builder with error code %d: %s", LastError(), ErrorDebugString(LastError()));

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -2,11 +2,9 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
 #include <aws/crt/Api.h>
 #include <aws/crt/JsonObject.h>
-#include <aws/crt/UUID.h>
-#include <aws/crt/io/HostResolver.h>
-
 #include <aws/crt/mqtt/Mqtt5Packets.h>
 #include <aws/iot/Mqtt5Client.h>
 #include <aws/iot/MqttClient.h>
@@ -23,43 +21,166 @@
 #include <aws/iotidentity/RegisterThingResponse.h>
 #include <aws/iotidentity/RegisterThingSubscriptionRequest.h>
 
-#include <algorithm>
-#include <aws/mqtt/mqtt.h>
-#include <chrono>
-#include <condition_variable>
 #include <fstream>
-#include <future>
-#include <iostream>
-#include <mutex>
-#include <sstream>
-#include <streambuf>
-#include <string>
-#include <thread>
 
 #include "../../../samples/utils/CommandLineUtils.h"
 
 using namespace Aws::Crt;
 using namespace Aws::Iotidentity;
 
-static std::promise<void> gotResponse;
-
-static std::string getFileData(std::string const &fileName)
+static String getFileData(const String &fileName)
 {
-    std::ifstream ifs(fileName);
+    std::ifstream ifs(fileName.c_str());
     std::string str;
     getline(ifs, str, (char)ifs.eof());
-    return str;
+    return str.c_str();
 }
 
-std::shared_ptr<IotIdentityClient> build_mqtt3_client(
-    Utils::cmdData &cmdData,
-    std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> &connection,
-    std::promise<bool> &connectionCompletedPromise,
-    std::promise<void> &connectionClosedPromise)
+/**
+ * Auxiliary structure for holding data used by MQTT3 connection.
+ */
+struct Mqtt3ConnectionContext
 {
-    Aws::Iot::MqttClientConnectionConfigBuilder clientConfigBuilder;
+    std::promise<bool> connectionCompletedPromise;
+    std::promise<void> connectionClosedPromise;
+};
+
+/**
+ * Auxiliary structure for holding data used by MQTT5 connection.
+ */
+struct Mqtt5ClientContext
+{
+    std::promise<bool> connectionPromise;
+    std::promise<void> stoppedPromise;
+    std::promise<void> disconnectPromise;
+    std::promise<bool> subscribeSuccess;
+};
+
+/**
+ * Auxiliary structure for holding data used when creating a certificate.
+ */
+struct CreateCertificateContext
+{
+    std::promise<void> pubAckPromise;
+    std::promise<void> acceptedSubAckPromise;
+    std::promise<void> rejectedSubAckPromise;
+    std::promise<String> tokenPromise;
+};
+
+/**
+ * Auxiliary structure for holding data used when registering a thing.
+ */
+struct RegisterThingContext
+{
+    std::promise<void> pubAckPromise;
+    std::promise<void> acceptedSubAckPromise;
+    std::promise<void> rejectedSubAckPromise;
+    std::promise<void> thingCreatedPromise;
+};
+
+/**
+ * Create MQTT5 client.
+ */
+std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmdData &cmdData, Mqtt5ClientContext &ctx)
+{
+    // Create the MQTT5 builder and populate it with data from cmdData.
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+        cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str());
+
+    // Check if the builder setup correctly.
+    if (builder == nullptr)
+    {
+        printf(
+            "Failed to setup mqtt5 client builder with error code %d: %s", LastError(), ErrorDebugString(LastError()));
+        return nullptr;
+    }
+
+    // Setup connection options
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    connectOptions->WithClientId(cmdData.input_clientId);
+    builder->WithConnectOptions(connectOptions);
+    if (cmdData.input_port != 0)
+    {
+        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
+    }
+
+    // Setup lifecycle callbacks
+    builder->WithClientConnectionSuccessCallback([&ctx](const Mqtt5::OnConnectionSuccessEventData &eventData) {
+        fprintf(
+            stdout,
+            "Mqtt5 Client connection succeed, clientid: %s.\n",
+            eventData.negotiatedSettings->getClientId().c_str());
+        ctx.connectionPromise.set_value(true);
+    });
+    builder->WithClientConnectionFailureCallback([&ctx](const Mqtt5::OnConnectionFailureEventData &eventData) {
+        fprintf(stdout, "Mqtt5 Client connection failed with error: %s.\n", aws_error_debug_str(eventData.errorCode));
+        ctx.connectionPromise.set_value(false);
+    });
+    builder->WithClientStoppedCallback([&ctx](const Mqtt5::OnStoppedEventData &) {
+        fprintf(stdout, "Mqtt5 Client stopped.\n");
+        ctx.stoppedPromise.set_value();
+    });
+    builder->WithClientAttemptingConnectCallback([](const Mqtt5::OnAttemptingConnectEventData &) {
+        fprintf(stdout, "Mqtt5 Client attempting connection...\n");
+    });
+    builder->WithClientDisconnectionCallback([&ctx](const Mqtt5::OnDisconnectionEventData &eventData) {
+        fprintf(stdout, "Mqtt5 Client disconnection with reason: %s.\n", aws_error_debug_str(eventData.errorCode));
+        ctx.disconnectPromise.set_value();
+    });
+
+    // Create Mqtt5Client
+    auto client = builder->Build();
+    delete builder;
+
+    fprintf(stdout, "Connecting...\n");
+    if (!client->Start())
+    {
+        fprintf(stderr, "MQTT5 Connection failed to start");
+        return nullptr;
+    }
+
+    if (!ctx.connectionPromise.get_future().get())
+    {
+        return nullptr;
+    }
+
+    return client;
+}
+
+/**
+ * Create MQTT3 connection.
+ */
+std::shared_ptr<Mqtt::MqttConnection> createMqtt3Connection(const Utils::cmdData &cmdData, Mqtt3ConnectionContext &ctx)
+{
+    /**
+     * In a real world application you probably don't want to enforce synchronous behavior
+     * but this is a sample console application, so we'll just do that with a promise.
+     */
+
+    // Invoked when a MQTT connect has completed or failed
+    auto onConnectionCompleted = [&ctx](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
+        if (errorCode)
+        {
+            fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
+            ctx.connectionCompletedPromise.set_value(false);
+        }
+        else
+        {
+            fprintf(stdout, "Connection completed with return code %d\n", returnCode);
+            ctx.connectionCompletedPromise.set_value(true);
+        }
+    };
+
+    // Invoked when a disconnect has been completed
+    auto onDisconnect = [&ctx](Mqtt::MqttConnection & /*conn*/) {
+        {
+            fprintf(stdout, "Disconnect completed\n");
+            ctx.connectionClosedPromise.set_value();
+        }
+    };
+
     // Create the MQTT builder and populate it with data from cmdData.
-    clientConfigBuilder =
+    auto clientConfigBuilder =
         Aws::Iot::MqttClientConnectionConfigBuilder(cmdData.input_cert.c_str(), cmdData.input_key.c_str());
     clientConfigBuilder.WithEndpoint(cmdData.input_endpoint);
     if (cmdData.input_ca != "")
@@ -75,157 +196,257 @@ std::shared_ptr<IotIdentityClient> build_mqtt3_client(
             stderr,
             "Client Configuration initialization failed with error %s\n",
             Aws::Crt::ErrorDebugString(clientConfig.LastError()));
-        exit(-1);
+        return nullptr;
     }
-
-    Aws::Iot::MqttClient client3 = Aws::Iot::MqttClient();
-    connection = client3.NewConnection(clientConfig);
+    Aws::Iot::MqttClient client = Aws::Iot::MqttClient();
+    auto connection = client.NewConnection(clientConfig);
     if (!*connection)
     {
         fprintf(
             stderr,
             "MQTT Connection Creation failed with error %s\n",
             Aws::Crt::ErrorDebugString(connection->LastError()));
-        exit(-1);
+        return nullptr;
     }
-
-    // Invoked when a MQTT connect has completed or failed
-    auto onConnectionCompleted = [&](Mqtt::MqttConnection &, int errorCode, Mqtt::ReturnCode returnCode, bool) {
-        if (errorCode)
-        {
-            fprintf(stdout, "Connection failed with error %s\n", ErrorDebugString(errorCode));
-            connectionCompletedPromise.set_value(false);
-        }
-        else
-        {
-            fprintf(stdout, "Connection completed with return code %d\n", returnCode);
-            connectionCompletedPromise.set_value(true);
-        }
-    };
-
-    // Invoked when a disconnect has been completed
-    auto onDisconnect = [&](Mqtt::MqttConnection & /*conn*/) {
-        {
-            fprintf(stdout, "Disconnect completed\n");
-            connectionClosedPromise.set_value();
-        }
-    };
 
     connection->OnConnectionCompleted = std::move(onConnectionCompleted);
     connection->OnDisconnect = std::move(onDisconnect);
 
+    fprintf(stdout, "Connecting...\n");
     if (!connection->Connect(cmdData.input_clientId.c_str(), true, 0))
     {
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
-        exit(-1);
-    }
-    return std::make_shared<IotIdentityClient>(connection);
-}
-
-std::shared_ptr<IotIdentityClient> build_mqtt5_client(
-    Utils::cmdData &cmdData,
-    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> &client5,
-    std::promise<bool> &connectionCompletedPromise,
-    std::promise<void> &connectionClosedPromise)
-{
-    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
-
-    // Check if the builder setup correctly.
-    if (builder == nullptr)
-    {
-        printf(
-            "Failed to setup mqtt5 client builder with error code %d: %s", LastError(), ErrorDebugString(LastError()));
         return nullptr;
     }
-    // Create the MQTT5 builder and populate it with data from cmdData.
-    // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
-    connectOptions->WithClientId(cmdData.input_clientId);
-    builder->WithConnectOptions(connectOptions);
-    if (cmdData.input_port != 0)
-    {
-        builder->WithPort(static_cast<uint32_t>(cmdData.input_port));
-    }
-    // Setup lifecycle callbacks
-    builder->WithClientConnectionSuccessCallback(
-        [&connectionCompletedPromise](const Mqtt5::OnConnectionSuccessEventData &eventData) {
-            fprintf(
-                stdout,
-                "Mqtt5 Client connection succeed, clientid: %s.\n",
-                eventData.negotiatedSettings->getClientId().c_str());
-            connectionCompletedPromise.set_value(true);
-        });
-    builder->WithClientConnectionFailureCallback([&connectionCompletedPromise](
-                                                     const Mqtt5::OnConnectionFailureEventData &eventData) {
-        fprintf(stdout, "Mqtt5 Client connection failed with error: %s.\n", aws_error_debug_str(eventData.errorCode));
-        connectionCompletedPromise.set_value(false);
-    });
-    builder->WithClientStoppedCallback([&connectionClosedPromise](const Mqtt5::OnStoppedEventData &) {
-        fprintf(stdout, "Mqtt5 Client stopped.\n");
-        connectionClosedPromise.set_value();
-    });
 
-    client5 = builder->Build();
-    if (client5 == nullptr)
+    if (!ctx.connectionCompletedPromise.get_future().get())
     {
-        fprintf(
-            stdout, "Failed to Init Mqtt5Client with error code %d: %s.\n", LastError(), ErrorDebugString(LastError()));
-        exit(-1);
+        return nullptr;
     }
 
-    if (!client5->Start())
-    {
-        fprintf(stderr, "MQTT5 Connection failed to start");
-        exit(-1);
-    }
-    return std::make_shared<IotIdentityClient>(client5);
+    return connection;
 }
 
-void SubscribeToRegisterThing(String input_templateName, std::shared_ptr<IotIdentityClient> iotIdentityClient)
+/**
+ * Keys-and-Certificate workflow.
+ *
+ * @note Subscriptions created here will be active even after the function completes. So, all variables accessed in the
+ * callbacks must be alive for the whole duration of the identityClient's lifetime. An instance of
+ * CreateCertificateContext is used to store variables used by the callbacks.
+ */
+void createKeysAndCertificate(const std::shared_ptr<IotIdentityClient> &identityClient, CreateCertificateContext &ctx)
 {
-    std::promise<void> onSubAckPromise;
-    std::promise<void> registerRejectedCompletedPromise;
-    std::promise<void> registerAcceptedCompletedPromise;
-
-    auto onRegisterThingAccepted = [&](RegisterThingResponse *response, int ioErr) {
-        if (ioErr)
+    auto onKeysPublishPubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
         {
-            fprintf(stderr, "Error: onSuback callback error %d\n", ioErr);
+            fprintf(stderr, "Error publishing to CreateKeysAndCertificate: %s\n", ErrorDebugString(ioErr));
             exit(-1);
         }
-        if (response)
+        ctx.pubAckPromise.set_value();
+    };
+
+    auto onKeysAcceptedSubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
         {
-            fprintf(stdout, "Register thing: %s\n", response->ThingName.value().c_str());
+            fprintf(stderr, "Error subscribing to CreateKeysAndCertificate accepted: %s\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+        ctx.acceptedSubAckPromise.set_value();
+    };
+
+    auto onKeysRejectedSubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
+        {
+            fprintf(stderr, "Error subscribing to CreateKeysAndCertificate rejected: %s\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+        ctx.rejectedSubAckPromise.set_value();
+    };
+
+    auto onKeysAccepted = [&ctx](CreateKeysAndCertificateResponse *response, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
+        {
+            fprintf(stdout, "CreateKeysAndCertificateResponse certificateId: %s.\n", response->CertificateId->c_str());
+            ctx.tokenPromise.set_value(*response->CertificateOwnershipToken);
+        }
+        else
+        {
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
+            exit(-1);
         }
     };
 
-    RegisterThingSubscriptionRequest registerThingSubscriptionRequest;
-    registerThingSubscriptionRequest.TemplateName = input_templateName;
+    auto onKeysRejected = [](ErrorResponse *error, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
+        {
+            fprintf(
+                stdout,
+                "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
+                *error->StatusCode,
+                error->ErrorMessage->c_str(),
+                error->ErrorCode->c_str());
+            exit(-1);
+        }
+        else
+        {
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+    };
 
-    auto onRegisterAcceptedSubAck = [&](int ioErr) {
+    fprintf(stdout, "Subscribing to CreateKeysAndCertificate Accepted and Rejected topics\n");
+    CreateKeysAndCertificateSubscriptionRequest keySubscriptionRequest;
+    identityClient->SubscribeToCreateKeysAndCertificateAccepted(
+        keySubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onKeysAccepted, onKeysAcceptedSubAck);
+    identityClient->SubscribeToCreateKeysAndCertificateRejected(
+        keySubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onKeysRejected, onKeysRejectedSubAck);
+
+    // Wait for the subscriptions to the accept and reject keys-and-certificate topics to be established.
+    ctx.acceptedSubAckPromise.get_future().wait();
+    ctx.rejectedSubAckPromise.get_future().wait();
+
+    // Now, when we subscribed to the keys and certificate topics, we can make a request for a certificate.
+    fprintf(stdout, "Publishing to CreateKeysAndCertificate topic\n");
+    CreateKeysAndCertificateRequest createKeysAndCertificateRequest;
+    identityClient->PublishCreateKeysAndCertificate(
+        createKeysAndCertificateRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onKeysPublishPubAck);
+    ctx.pubAckPromise.get_future().wait();
+}
+
+/**
+ * Certificate-from-CSR workflow.
+ *
+ * @note Subscriptions created here will be active even after the function completes. So, all variables accessed in the
+ * callbacks must be alive for the whole duration of the identityClient's lifetime. An instance of
+ * CreateCertificateContext is used to store variables used by the callbacks.
+ */
+void createCertificateFromCsr(
+    const std::shared_ptr<IotIdentityClient> &identityClient,
+    CreateCertificateContext &ctx,
+    const String &csrFile)
+{
+    auto onCsrPublishPubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
+        {
+            fprintf(stderr, "Error publishing to CreateCertificateFromCsr: %s\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+        ctx.pubAckPromise.set_value();
+    };
+
+    auto onCsrAcceptedSubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
+        {
+            fprintf(stderr, "Error subscribing to CreateCertificateFromCsr accepted: %s\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+        ctx.acceptedSubAckPromise.set_value();
+    };
+
+    auto onCsrRejectedSubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
+        {
+            fprintf(stderr, "Error subscribing to CreateCertificateFromCsr rejected: %s\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+        ctx.rejectedSubAckPromise.set_value();
+    };
+
+    auto onCsrAccepted = [&ctx](CreateCertificateFromCsrResponse *response, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
+        {
+            fprintf(stdout, "CreateCertificateFromCsrResponse certificateId: %s.\n", response->CertificateId->c_str());
+            ctx.tokenPromise.set_value(*response->CertificateOwnershipToken);
+        }
+        else
+        {
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+    };
+
+    auto onCsrRejected = [](ErrorResponse *error, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
+        {
+            fprintf(
+                stdout,
+                "CreateCertificateFromCsr failed with statusCode %d, errorMessage %s and errorCode %s.",
+                *error->StatusCode,
+                error->ErrorMessage->c_str(),
+                error->ErrorCode->c_str());
+            exit(-1);
+        }
+        else
+        {
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+    };
+
+    // CreateCertificateFromCsr workflow
+    fprintf(stdout, "Subscribing to CreateCertificateFromCsr Accepted and Rejected topics\n");
+    CreateCertificateFromCsrSubscriptionRequest csrSubscriptionRequest;
+    identityClient->SubscribeToCreateCertificateFromCsrAccepted(
+        csrSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onCsrAccepted, onCsrAcceptedSubAck);
+
+    identityClient->SubscribeToCreateCertificateFromCsrRejected(
+        csrSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onCsrRejected, onCsrRejectedSubAck);
+
+    // Wait for the subscriptions to the accept and reject certificates topics to be established.
+    ctx.acceptedSubAckPromise.get_future().wait();
+    ctx.rejectedSubAckPromise.get_future().wait();
+
+    // Now, when we subscribed to the certificates topics, we can make a request for a certificate.
+    fprintf(stdout, "Publishing to CreateCertificateFromCsr topic\n");
+    CreateCertificateFromCsrRequest createCertificateFromCsrRequest;
+    createCertificateFromCsrRequest.CertificateSigningRequest = csrFile;
+    identityClient->PublishCreateCertificateFromCsr(
+        createCertificateFromCsrRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onCsrPublishPubAck);
+    ctx.pubAckPromise.get_future().wait();
+}
+
+/**
+ * Provision an AWS IoT thing using a pre-defined template.
+ */
+void registerThing(
+    const std::shared_ptr<IotIdentityClient> &identityClient,
+    RegisterThingContext &ctx,
+    const Utils::cmdData &cmdData,
+    const String &token)
+{
+    auto onRegisterAcceptedSubAck = [&ctx](int ioErr) {
         if (ioErr != AWS_OP_SUCCESS)
         {
             fprintf(stderr, "Error subscribing to RegisterThing accepted: %s\n", ErrorDebugString(ioErr));
             exit(-1);
         }
-        registerAcceptedCompletedPromise.set_value();
+        ctx.acceptedSubAckPromise.set_value();
     };
 
-    iotIdentityClient->SubscribeToRegisterThingAccepted(
-        registerThingSubscriptionRequest,
-        AWS_MQTT_QOS_AT_LEAST_ONCE,
-        onRegisterThingAccepted,
-        onRegisterAcceptedSubAck);
-
-    auto rejectedHandler = [&](ErrorResponse *error, int ioErr) {
-        if (ioErr)
+    auto onRegisterRejectedSubAck = [&ctx](int ioErr) {
+        if (ioErr != AWS_OP_SUCCESS)
         {
-            fprintf(stderr, "Error: rejectedHandler callback error %d\n", ioErr);
+            fprintf(stderr, "Error subscribing to RegisterThing rejected: %s\n", ErrorDebugString(ioErr));
             exit(-1);
         }
+        ctx.rejectedSubAckPromise.set_value();
+    };
+
+    auto onRegisterAccepted = [&ctx](RegisterThingResponse *response, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
+        {
+            fprintf(stdout, "RegisterThingResponse ThingName: %s.\n", response->ThingName->c_str());
+            ctx.thingCreatedPromise.set_value();
+        }
         else
+        {
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
+            exit(-1);
+        }
+    };
+
+    auto onRegisterRejected = [](ErrorResponse *error, int ioErr) {
+        if (ioErr == AWS_OP_SUCCESS)
         {
             fprintf(
                 stdout,
@@ -234,304 +455,66 @@ void SubscribeToRegisterThing(String input_templateName, std::shared_ptr<IotIden
                 error->ErrorMessage->c_str(),
                 error->ErrorCode->c_str());
         }
-    };
-    auto onRegisterRejectedSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
+        else
         {
-            fprintf(stderr, "Error subscribing to RegisterThing rejected: %s\n", ErrorDebugString(ioErr));
+            fprintf(stderr, "Error on subscription: %s.\n", ErrorDebugString(ioErr));
             exit(-1);
         }
-        registerRejectedCompletedPromise.set_value();
-    };
-    iotIdentityClient->SubscribeToRegisterThingRejected(
-        registerThingSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, rejectedHandler, onRegisterRejectedSubAck);
-
-    registerAcceptedCompletedPromise.get_future().wait();
-    registerRejectedCompletedPromise.get_future().wait();
-}
-
-void createKeysAndCertificateWorkflow(
-    String &input_templateName,
-    String &input_templateParameters,
-    std::shared_ptr<IotIdentityClient> iotIdentityClient)
-{
-    std::promise<void> onSubAckPromise;
-
-    std::promise<void> keysPublishCompletedPromise;
-    std::promise<void> keysAcceptedCompletedPromise;
-    std::promise<void> keysRejectedCompletedPromise;
-
-    std::promise<void> registerPublishCompletedPromise;
-    std::promise<void> registerAcceptedCompletedPromise;
-
-    CreateKeysAndCertificateResponse *createKeysAndCertificateResponse = nullptr;
-    String token;
-
-    auto acceptedHandler = [&createKeysAndCertificateResponse,
-                            &token](CreateKeysAndCertificateResponse *response, int ioErr) {
-        fprintf(stderr, "acceptedhandler is called\n");
-        if (ioErr)
-        {
-            fprintf(stderr, "Error: acceptedHandler callback error %d\n", ioErr);
-            exit(-1);
-        }
-        if (response)
-        {
-            if (createKeysAndCertificateResponse == nullptr)
-            {
-                createKeysAndCertificateResponse = response;
-                token = *response->CertificateOwnershipToken;
-            }
-        }
-        gotResponse.set_value();
     };
 
-    auto onKeysAcceptedSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error subscribing to CreateKeysAndCertificate accepted: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-
-        keysAcceptedCompletedPromise.set_value();
-    };
-
-    CreateKeysAndCertificateSubscriptionRequest createKeysAndCertificateSubscriptionRequest;
-    iotIdentityClient->SubscribeToCreateKeysAndCertificateAccepted(
-        createKeysAndCertificateSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, acceptedHandler, onKeysAcceptedSubAck);
-
-    auto rejectedHandler = [&](Aws::Iotidentity::ErrorResponse *error, int ioErr) {
-        if (ioErr == AWS_OP_ERR)
-        {
-            fprintf(stderr, "Error: rejectedHandler callback error %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-        if (error)
-        {
-            fprintf(
-                stdout,
-                "CreateKeysAndCertificate failed with statusCode %d, errorMessage %s and errorCode %s.",
-                *error->StatusCode,
-                error->ErrorMessage->c_str(),
-                error->ErrorCode->c_str());
-        }
-        exit(-1);
-    };
-
-    auto onKeysRejectedSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error subscribing to CreateKeysAndCertificate rejected: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-        keysRejectedCompletedPromise.set_value();
-    };
-    iotIdentityClient->SubscribeToCreateKeysAndCertificateRejected(
-        createKeysAndCertificateSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, rejectedHandler, onKeysRejectedSubAck);
-
-    auto onKeysPublishSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error publishing to CreateKeysAndCertificate: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-
-        keysPublishCompletedPromise.set_value();
-    };
-
-    CreateKeysAndCertificateRequest createKeysAndCertificateRequest;
-    iotIdentityClient->PublishCreateKeysAndCertificate(
-        createKeysAndCertificateRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onKeysPublishSubAck);
-
-    SubscribeToRegisterThing(input_templateName, iotIdentityClient);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    // Verify the response is good
-    if (createKeysAndCertificateResponse == nullptr)
-    {
-        fprintf(stderr, "Error: 1 createKeysAndCertificateResponse is null\n");
-        exit(-1);
-    }
-    // reset gotResponse future
-    gotResponse = std::promise<void>();
-
-    RegisterThingRequest registerThingRequest;
-    registerThingRequest.TemplateName = input_templateName;
-
-    if (!input_templateParameters.empty())
-    {
-        const Aws::Crt::String jsonValue = input_templateParameters;
-        Aws::Crt::JsonObject value(jsonValue);
-        Map<String, JsonView> pm = value.View().GetAllObjects();
-        Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> params = Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String>();
-
-        for (const auto &x : pm)
-        {
-            params.emplace(x.first, x.second.AsString());
-        }
-        registerThingRequest.Parameters = params;
-    }
-    registerThingRequest.CertificateOwnershipToken = token;
-
-    auto onRegisterPublishSubAck = [&](int ioErr) {
+    auto onRegisterPublishPubAck = [&ctx](int ioErr) {
         if (ioErr != AWS_OP_SUCCESS)
         {
             fprintf(stderr, "Error publishing to RegisterThing: %s\n", ErrorDebugString(ioErr));
             exit(-1);
         }
-
-        registerPublishCompletedPromise.set_value();
-    };
-    iotIdentityClient->PublishRegisterThing(registerThingRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRegisterPublishSubAck);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    keysPublishCompletedPromise.get_future().wait();
-    keysAcceptedCompletedPromise.get_future().wait();
-    keysRejectedCompletedPromise.get_future().wait();
-    registerPublishCompletedPromise.get_future().wait();
-}
-
-void createCertificateFromCsrWorkflow(
-    String input_templateName,
-    String input_templateParameters,
-    String input_csrPath,
-    std::shared_ptr<IotIdentityClient> iotIdentityClient)
-{
-    std::promise<void> keysPublishCompletedPromise;
-    std::promise<void> keysAcceptedCompletedPromise;
-    std::promise<void> keysRejectedCompletedPromise;
-
-    std::promise<void> registerPublishCompletedPromise;
-    std::promise<void> registerAcceptedCompletedPromise;
-    CreateCertificateFromCsrResponse *createCertificateFromCsrResponse = nullptr;
-    String token;
-
-    gotResponse = std::promise<void>();
-
-    auto onCreateCertificateFromCsrResponseAccepted = [&createCertificateFromCsrResponse,
-                                                       &token](CreateCertificateFromCsrResponse *response, int ioErr) {
-        if (ioErr)
-        {
-            fprintf(stderr, "Error: onCreateCertificateFromCsrResponseAccepted callback error %d\n", ioErr);
-            exit(-1);
-        }
-        if (response != nullptr)
-        {
-            if (createCertificateFromCsrResponse == nullptr)
-            {
-                createCertificateFromCsrResponse = response;
-                token = *response->CertificateOwnershipToken;
-            }
-        }
-        gotResponse.set_value();
+        ctx.pubAckPromise.set_value();
     };
 
-    auto onSubAck = [&](int ioErr) {
-        if (ioErr)
-        {
-            fprintf(stderr, "Error: onSubAck callback error %d\n", ioErr);
-            exit(-1);
-        }
-        keysAcceptedCompletedPromise.set_value();
-    };
+    fprintf(stdout, "Subscribing to RegisterThing Accepted and Rejected topics\n");
+    RegisterThingSubscriptionRequest registerSubscriptionRequest;
+    registerSubscriptionRequest.TemplateName = cmdData.input_templateName;
 
-    CreateCertificateFromCsrSubscriptionRequest createCertificateFromCsrSubscriptionRequest;
-    iotIdentityClient->SubscribeToCreateCertificateFromCsrAccepted(
-        createCertificateFromCsrSubscriptionRequest,
-        AWS_MQTT_QOS_AT_LEAST_ONCE,
-        onCreateCertificateFromCsrResponseAccepted,
-        onSubAck);
+    identityClient->SubscribeToRegisterThingAccepted(
+        registerSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRegisterAccepted, onRegisterAcceptedSubAck);
 
-    auto onRejectedCsr = [&](ErrorResponse *response, int ioErr) {
-        (void)response;
-        if (ioErr)
-        {
-            fprintf(stderr, "Error: onSubAck callback error %d\n", ioErr);
-            exit(-1);
-        }
-        exit(1);
-    };
+    identityClient->SubscribeToRegisterThingRejected(
+        registerSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRegisterRejected, onRegisterRejectedSubAck);
 
-    auto onKeysRejectedSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error subscribing to CreateKeysAndCertificate rejected: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-        keysRejectedCompletedPromise.set_value();
-    };
+    // Wait for the subscriptions to the accept and reject RegisterThing topics to be established.
+    ctx.acceptedSubAckPromise.get_future().wait();
+    ctx.rejectedSubAckPromise.get_future().wait();
 
-    iotIdentityClient->SubscribeToCreateCertificateFromCsrRejected(
-        createCertificateFromCsrSubscriptionRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRejectedCsr, onKeysRejectedSubAck);
-
-    auto onKeysPublishSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error publishing to CreateKeysAndCertificate: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
-        keysPublishCompletedPromise.set_value();
-    };
-
-    std::string csrContents = getFileData(input_csrPath.c_str());
-    CreateCertificateFromCsrRequest createCertificateFromCsrRequest;
-    createCertificateFromCsrRequest.CertificateSigningRequest = csrContents.c_str();
-
-    iotIdentityClient->PublishCreateCertificateFromCsr(
-        createCertificateFromCsrRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onKeysPublishSubAck);
-
-    // Subscribes to the register thing accepted and rejected topics
-    SubscribeToRegisterThing(input_templateName, iotIdentityClient);
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    // Verify the response is good
-    if (createCertificateFromCsrResponse == nullptr)
-    {
-        fprintf(stderr, "Error: 1 createCertificateFromCsrResponse is null\n");
-        exit(-1);
-    }
-    // reset gotResponse future
-    gotResponse = std::promise<void>();
-
+    fprintf(stdout, "Publishing to RegisterThing topic\n");
     RegisterThingRequest registerThingRequest;
-    registerThingRequest.CertificateOwnershipToken = token;
-    registerThingRequest.TemplateName = input_templateName;
+    registerThingRequest.TemplateName = cmdData.input_templateName;
 
-    if (!input_templateParameters.empty())
+    const Aws::Crt::String jsonValue = cmdData.input_templateParameters;
+    Aws::Crt::JsonObject value(jsonValue);
+    Map<String, JsonView> pm = value.View().GetAllObjects();
+    Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> params = Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String>();
+
+    for (const auto &x : pm)
     {
-        const Aws::Crt::String jsonValue = input_templateParameters;
-        Aws::Crt::JsonObject value(jsonValue);
-        Map<String, JsonView> pm = value.View().GetAllObjects();
-        Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String> params = Aws::Crt::Map<Aws::Crt::String, Aws::Crt::String>();
-
-        for (const auto &x : pm)
-        {
-            params.emplace(x.first, x.second.AsString());
-        }
-        registerThingRequest.Parameters = params;
+        params.emplace(x.first, x.second.AsString());
     }
 
-    auto onRegisterPublishSubAck = [&](int ioErr) {
-        if (ioErr != AWS_OP_SUCCESS)
-        {
-            fprintf(stderr, "Error publishing to RegisterThing: %s\n", ErrorDebugString(ioErr));
-            exit(-1);
-        }
+    registerThingRequest.Parameters = params;
+    // NOTE: In a real application creating multiple certificates you'll probably need to protect token var with
+    // a critical section. This sample makes only one request for a certificate, so no data race is possible.
+    registerThingRequest.CertificateOwnershipToken = token;
 
-        registerPublishCompletedPromise.set_value();
-    };
-    iotIdentityClient->PublishRegisterThing(registerThingRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRegisterPublishSubAck);
+    identityClient->PublishRegisterThing(registerThingRequest, AWS_MQTT_QOS_AT_LEAST_ONCE, onRegisterPublishPubAck);
+    ctx.pubAckPromise.get_future().wait();
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    keysPublishCompletedPromise.get_future().wait();
-    keysAcceptedCompletedPromise.get_future().wait();
-    keysRejectedCompletedPromise.get_future().wait();
-    registerPublishCompletedPromise.get_future().wait();
+    // Wait for registering a thing to succeed.
+    ctx.thingCreatedPromise.get_future().wait();
 }
 
 int main(int argc, char *argv[])
 {
+    /************************ Setup ****************************/
+
     // Do the global initialization for the API
     ApiHandle apiHandle;
 
@@ -542,62 +525,78 @@ int main(int argc, char *argv[])
      */
     Utils::cmdData cmdData = Utils::parseSampleInputFleetProvisioning(argc, argv, &apiHandle);
 
-    /**
-     * In a real world application you probably don't want to enforce synchronous behavior
-     * but this is a sample console application, so we'll just do that with a condition variable.
-     */
-    std::promise<bool> connectionCompletedPromise;
-    std::promise<void> connectionClosedPromise;
-    std::shared_ptr<Aws::Crt::Mqtt::MqttConnection> connection = nullptr;
-    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client5 = nullptr;
-    std::shared_ptr<IotIdentityClient> iotIdentityClient = nullptr;
+    Mqtt5ClientContext mqtt5ClientContext;
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client;
+
+    Mqtt3ConnectionContext mqtt3ConnectionContext;
+    std::shared_ptr<Mqtt::MqttConnection> mqtt3Connection;
+
+    std::shared_ptr<IotIdentityClient> identityClient;
 
     if (cmdData.input_mqtt_version == 5UL)
     {
-        iotIdentityClient = build_mqtt5_client(cmdData, client5, connectionCompletedPromise, connectionClosedPromise);
+        mqtt5Client = createMqtt5Client(cmdData, mqtt5ClientContext);
+        if (!mqtt5Client)
+        {
+            fprintf(stderr, "MQTT5 Connection failed to start");
+            return -1;
+        }
+        identityClient = std::make_shared<IotIdentityClient>(mqtt5Client);
     }
     else if (cmdData.input_mqtt_version == 3UL)
     {
-        iotIdentityClient =
-            build_mqtt3_client(cmdData, connection, connectionCompletedPromise, connectionClosedPromise);
+        mqtt3Connection = createMqtt3Connection(cmdData, mqtt3ConnectionContext);
+        if (!mqtt3Connection)
+        {
+            fprintf(stderr, "MQTT3 Connection failed to start");
+            return -1;
+        }
+        identityClient = std::make_shared<IotIdentityClient>(mqtt3Connection);
     }
     else
     {
         fprintf(stderr, "MQTT Version not supported\n");
-        exit(-1);
+        return -1;
     }
-    if (connectionCompletedPromise.get_future().get())
-    {
-        if (cmdData.input_csrPath.empty())
-        {
-            createKeysAndCertificateWorkflow(
-                cmdData.input_templateName, cmdData.input_templateParameters, iotIdentityClient);
-        }
-        else
-        {
-            createCertificateFromCsrWorkflow(
-                cmdData.input_templateName, cmdData.input_templateParameters, cmdData.input_csrPath, iotIdentityClient);
-        }
-    }
-    // Wait just a little bit to let the console print
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
-    if (cmdData.input_mqtt_version == 5UL)
+    /************************ Run the sample ****************************/
+
+    // Create fleet provisioning client.
+
+    // Create certificate.
+    CreateCertificateContext certificateContext;
+    if (cmdData.input_csrPath != "")
     {
-        // Disconnect
-        if (client5->Stop() == true)
-        {
-            connectionClosedPromise.get_future().wait();
-        }
+        auto csrFile = getFileData(cmdData.input_csrPath);
+        createCertificateFromCsr(identityClient, certificateContext, csrFile);
     }
     else
-    { // mqtt3
+    {
+        createKeysAndCertificate(identityClient, certificateContext);
+    }
 
-        // Disconnect
-        if (connection->Disconnect() == true)
+    // Wait for a certificate token to be obtained.
+    auto token = certificateContext.tokenPromise.get_future().get();
+
+    // After certificate is obtained, it's time to register a thing.
+    RegisterThingContext registerThingContext;
+    registerThing(identityClient, registerThingContext, cmdData, token);
+
+    // Disconnect
+    if (cmdData.input_mqtt_version == 5UL)
+    {
+        if (mqtt5Client->Stop())
         {
-            connectionClosedPromise.get_future().wait();
+            mqtt5ClientContext.stoppedPromise.get_future().wait();
         }
     }
+    else if (cmdData.input_mqtt_version == 3UL)
+    {
+        if (mqtt3Connection->Disconnect())
+        {
+            mqtt3ConnectionContext.connectionClosedPromise.get_future().wait();
+        }
+    }
+
     return 0;
 }

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -84,11 +84,9 @@ struct RegisterThingContext
 std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmdData &cmdData, Mqtt5ClientContext &ctx)
 {
     // Create the MQTT5 builder and populate it with data from cmdData.
-    // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = Aws::Crt::ScopedResource<Aws::Iot::Mqtt5ClientBuilder>(
+    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
         Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()),
-        [](Aws::Iot::Mqtt5ClientBuilder *ptr) { delete ptr; });
+            cmdData.input_endpoint, cmdData.input_cert.c_str(), cmdData.input_key.c_str()));
 
     // Check if the builder setup correctly.
     if (builder == nullptr)


### PR DESCRIPTION
*Issue #, if available:*

There are race conditions in Fleet provisioning service tests and Secure tunnel sample (caught by this PR https://github.com/aws/aws-iot-device-sdk-cpp-v2/pull/703).

*Description of changes:*

- I recently fixed a race condition in Fleet provisioning **sample**, so I reused that code in Fleet provisioning service tests.
- Secure tunnel sample used `sleep` to sync two threads, I added a promise.
- Additional change: use std::unique_ptr instead of raw pointers in samples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
