### PR TITLE
move mac-only tls behavior information to main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ __Jump To:__
 * [Supported Architectures](#supported-architectures)
 * [Installation](#installation)
 * [Samples](./samples)
+* [Mac-Only TLS Behavior](#mac-only-tls-behavior)
 * [Getting Help](#getting-help)
 * [FAQ](./documents/FAQ.md)
 * [API Docs](https://aws.github.io/aws-iot-device-sdk-cpp-v2/)
@@ -107,6 +108,14 @@ existing `libcrypto`, instead of building its own copy.
 ## Samples
 
 [Samples README](./samples)
+
+### Mac-Only TLS Behavior
+
+Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v1.7.3, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
+
+```
+static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
+```
 
 ## Getting Help
 

--- a/documents/FAQ.md
+++ b/documents/FAQ.md
@@ -8,7 +8,6 @@
 * [Detecting connection loss (tldr use keepAliveTimeSecs and pingTimeoutMs)](#connection-loss)
 * [How to use a Pre-Built aws-crt-cpp (Most useful for development of this package)](#prebuilt-aws-crt-cpp)
 * [I am experiencing deadlocks](#i-am-experiencing-deadlocks)
-* [Mac-Only TLS Behavior](#mac-only-tls-behavior)
 * [How do debug in VSCode?](#how-do-debug-in-vscode)
 * [What certificates do I need?](#what-certificates-do-i-need)
 * [I still have more questions about this sdk?](#i-still-have-more-questions-about-this-sdk)
@@ -81,14 +80,6 @@ cmake --build . --target install
 ### I am experiencing deadlocks
 
 You MUST NOT perform blocking operations on any callback, or you will cause a deadlock. For example: in the on_publish_received callback, do not send a publish, and then wait for the future to complete within the callback. The Client cannot do work until your callback returns, so the thread will be stuck.
-
-### Mac-Only TLS Behavior
-
-Please note that on Mac, once a private key is used with a certificate, that certificate-key pair is imported into the Mac Keychain.  All subsequent uses of that certificate will use the stored private key and ignore anything passed in programmatically.  Beginning in v1.7.3, when a stored private key from the Keychain is used, the following will be logged at the "info" log level:
-
-```
-static: certificate has an existing certificate-key pair that was previously imported into the Keychain.  Using key from Keychain instead of the one provided.
-```
 
 ### How do debug in VSCode?
 


### PR DESCRIPTION
Move Mac-only TLS Behavior information to main README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
