### PR TITLE
Check reason string in MQTT5 samples

### DIFF
--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
                 {
                     if (reasonCode > Mqtt5::SubAckReasonCode::AWS_MQTT5_SARC_UNSPECIFIED_ERROR)
                     {
-                        fprintf(stdout, "MQTT5 Client Subscription failed with server error code %d\n", reasonCode);
+                        fprintf(stdout, "MQTT5 Client Subscription failed with server error code: %d\n", reasonCode);
                         if (suback->getReasonString().has_value())
                         {
                             fprintf(stdout, "\tError reason string: %s\n", suback->getReasonString()->c_str());

--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -141,11 +141,11 @@ int main(int argc, char *argv[])
                 {
                     if (reasonCode > Mqtt5::SubAckReasonCode::AWS_MQTT5_SARC_UNSPECIFIED_ERROR)
                     {
-                        fprintf(
-                            stdout,
-                            "MQTT5 Client Subscription failed with server error code: (%d)%s\n",
-                            reasonCode,
-                            suback->getReasonString()->c_str());
+                        fprintf(stdout, "MQTT5 Client Subscription failed with server error code %d\n", reasonCode);
+                        if (suback->getReasonString().has_value())
+                        {
+                            fprintf(stdout, "\tError reason string: %s\n", suback->getReasonString()->c_str());
+                        }
                         subscribeSuccess.set_value(false);
                         return;
                     }
@@ -185,13 +185,13 @@ int main(int argc, char *argv[])
                         }
                         else
                         {
-                            fprintf(
-                                stdout,
-                                "PubACK reason code: %d : %s\n",
-                                puback->getReasonCode(),
-                                puback->getReasonString()->c_str());
+                            fprintf(stdout, "PubACK reason code: %d\n", puback->getReasonCode());
+                            if (puback->getReasonString().has_value())
+                            {
+                                fprintf(stdout, "\nError reason string: %s\n", puback->getReasonString()->c_str());
+                            }
                         }
-                    };
+                    }
                 };
 
                 uint32_t publishedCount = 0;

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
             {
                 if (reasonCode >= Mqtt5::SubAckReasonCode::AWS_MQTT5_SARC_UNSPECIFIED_ERROR)
                 {
-                    fprintf(stdout, "MQTT5 Client Subscription failed with server error code: (%d)\n", reasonCode);
+                    fprintf(stdout, "MQTT5 Client Subscription failed with server error code: %d\n", reasonCode);
                     if (suback->getReasonString().has_value())
                     {
                         fprintf(stdout, "\tError reason string: %s\n", suback->getReasonString()->c_str());

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -246,11 +246,11 @@ int main(int argc, char *argv[])
             {
                 if (reasonCode >= Mqtt5::SubAckReasonCode::AWS_MQTT5_SARC_UNSPECIFIED_ERROR)
                 {
-                    fprintf(
-                        stdout,
-                        "MQTT5 Client Subscription failed with server error code: (%d)%s\n",
-                        reasonCode,
-                        suback->getReasonString()->c_str());
+                    fprintf(stdout, "MQTT5 Client Subscription failed with server error code: (%d)\n", reasonCode);
+                    if (suback->getReasonString().has_value())
+                    {
+                        fprintf(stdout, "\tError reason string: %s\n", suback->getReasonString()->c_str());
+                    }
                     subscribeSuccess.set_value(reasonCode);
                     return;
                 }
@@ -331,12 +331,15 @@ int main(int argc, char *argv[])
             {
                 fprintf(
                     stdout,
-                    "[%s] Publish failed. PubACK reason code: %d : %s\n",
+                    "[%s] Publish failed. PubACK reason code: %d\n",
                     publisher->name.c_str(),
-                    puback->getReasonCode(),
-                    puback->getReasonString()->c_str());
+                    puback->getReasonCode());
+                if (puback->getReasonString().has_value())
+                {
+                    fprintf(stdout, "\nError reason string: %s\n", puback->getReasonString()->c_str());
+                }
             }
-        };
+        }
     };
 
     uint64_t publishedCount = 0;


### PR DESCRIPTION
*Issue #, if available:*

In MQTT5 protocol, if subscription fail, SubAck packet not necessarily contains a reason string. In MQTT5 samples, we try to print a SubAck reason string unconditionally, which sometimes crashes samples.
The same applies to publish operations.

*Description of changes:*

Add check for a reason string value before using it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
