### PR TITLE
Fix shadow samples in CI

### DIFF
--- a/samples/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/shadow/mqtt5_shadow_sync/main.cpp
@@ -350,7 +350,8 @@ int main(int argc, char *argv[])
             {
                 // If another client requested shadow for the same thing at the same time, this callback might be
                 // triggered more than once. Ignore everything after first data arrived.
-                if (isInitialShadowReceived) {
+                if (isInitialShadowReceived)
+                {
                     fprintf(stderr, "Initial shadow is already set, ignore\n");
                     return;
                 }
@@ -393,7 +394,8 @@ int main(int argc, char *argv[])
             }
             // If another client requested shadow for the same thing at the same time, this callback might be
             // triggered more than once. Ignore everything after first data arrived.
-            if (isInitialShadowReceived) {
+            if (isInitialShadowReceived)
+            {
                 fprintf(stderr, "Initial shadow is already set, ignore\n");
                 return;
             }

--- a/samples/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/shadow/mqtt5_shadow_sync/main.cpp
@@ -311,6 +311,7 @@ int main(int argc, char *argv[])
         std::promise<void> subscribeGetShadowRejectedCompletedPromise;
         std::promise<void> onGetShadowRequestCompletedPromise;
         std::promise<void> gotInitialShadowPromise;
+        bool isInitialShadowReceived = false;
 
         auto onGetShadowUpdatedAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
@@ -347,6 +348,14 @@ int main(int argc, char *argv[])
             }
             if (response)
             {
+                // If another client requested shadow for the same thing at the same time, this callback might be
+                // triggered more than once. Ignore everything after first data arrived.
+                if (isInitialShadowReceived) {
+                    fprintf(stderr, "Initial shadow is already set, ignore\n");
+                    return;
+                }
+                isInitialShadowReceived = true;
+
                 fprintf(stdout, "Received shadow document.\n");
                 if (response->State && response->State->Reported->View().ValueExists(cmdData.input_shadowProperty))
                 {
@@ -382,6 +391,14 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Error on getting shadow document: %s.\n", ErrorDebugString(ioErr));
                 exit(-1);
             }
+            // If another client requested shadow for the same thing at the same time, this callback might be
+            // triggered more than once. Ignore everything after first data arrived.
+            if (isInitialShadowReceived) {
+                fprintf(stderr, "Initial shadow is already set, ignore\n");
+                return;
+            }
+            isInitialShadowReceived = true;
+
             fprintf(
                 stdout,
                 "Getting shadow document failed with message %s and code %d.\n",

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -379,7 +379,8 @@ int main(int argc, char *argv[])
             {
                 // If another client requested shadow for the same thing at the same time, this callback might be
                 // triggered more than once. Ignore everything after first data arrived.
-                if (isInitialShadowReceived) {
+                if (isInitialShadowReceived)
+                {
                     fprintf(stderr, "Initial shadow is already set, ignore\n");
                     return;
                 }

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -340,6 +340,7 @@ int main(int argc, char *argv[])
         std::promise<void> subscribeGetShadowRejectedCompletedPromise;
         std::promise<void> onGetShadowRequestCompletedPromise;
         std::promise<void> gotInitialShadowPromise;
+        bool isInitialShadowReceived = false;
 
         auto onGetShadowUpdatedAcceptedSubAck = [&](int ioErr) {
             if (ioErr != AWS_OP_SUCCESS)
@@ -376,6 +377,14 @@ int main(int argc, char *argv[])
             }
             if (response)
             {
+                // If another client requested shadow for the same thing at the same time, this callback might be
+                // triggered more than once. Ignore everything after first data arrived.
+                if (isInitialShadowReceived) {
+                    fprintf(stderr, "Initial shadow is already set, ignore\n");
+                    return;
+                }
+                isInitialShadowReceived = true;
+
                 fprintf(stdout, "Received shadow document.\n");
                 if (response->State && response->State->Reported->View().ValueExists(cmdData.input_shadowProperty))
                 {
@@ -411,6 +420,14 @@ int main(int argc, char *argv[])
                 fprintf(stderr, "Error on getting shadow document: %s.\n", ErrorDebugString(ioErr));
                 exit(-1);
             }
+            // If another client requested shadow for the same thing at the same time, this callback might be
+            // triggered more than once. Ignore everything after first data arrived.
+            if (isInitialShadowReceived) {
+                fprintf(stderr, "Initial shadow is already set, ignore\n");
+                return;
+            }
+            isInitialShadowReceived = true;
+
             fprintf(
                 stdout,
                 "Getting shadow document failed with message %s and code %d.\n",

--- a/samples/shadow/shadow_sync/main.cpp
+++ b/samples/shadow/shadow_sync/main.cpp
@@ -422,7 +422,8 @@ int main(int argc, char *argv[])
             }
             // If another client requested shadow for the same thing at the same time, this callback might be
             // triggered more than once. Ignore everything after first data arrived.
-            if (isInitialShadowReceived) {
+            if (isInitialShadowReceived)
+            {
                 fprintf(stderr, "Initial shadow is already set, ignore\n");
                 return;
             }


### PR DESCRIPTION
*Issue #, if available:*

When multiple instances of shadow samples are running in CI, they use the same thing and interfere with each other causing crashes:
```
Received shadow document.
Shadow contains "color". Updating local value to "Shadow_Value_0"...

stderr:
terminate called after throwing an instance of 'std::future_error'
  what():  std::future_error: Promise already satisfied
```

*Description of changes:*

Handle multiple incoming shadow messages.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
