### PR TITLE
Fix arm based ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,13 +62,13 @@ jobs:
           role-to-assume: ${{ env.CI_IOT_CONTAINERS }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Install qemu/docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        run: run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
           ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ matrix.image }} build -p ${{ env.PACKAGE_NAME }}
   raspberry:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +84,7 @@ jobs:
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       # set arm arch
       - name: Install qemu/docker
-        run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+        run: docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
@@ -644,7 +644,7 @@ jobs:
 
   # check that docs can still build
   check-docs:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v2
         with:
@@ -677,7 +677,7 @@ jobs:
         uses: awslabs/aws-crt-builder/.github/actions/check-submodules@main
 
   check-codegen-edits:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           role-to-assume: ${{ env.CI_IOT_CONTAINERS }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Install qemu/docker
-        run: run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   update-version:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-22.04 # latest
     permissions:
       contents: write # allow push
       pull-requests: write # allow making PR


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We rely on qemu to test aarch64 on x86-64 github runners.
Qemu had a bug where they had a bug with incorrectly mapping address space. That mostly worked fine until kernel patch that increased entropy in their address randomization. TLDR; qemu likes to segfault a lot against new kernels on our aarch64 test. Solution is to switch to a different github qemu user static image that forces a latest version of qemu, that has the bug fixed.
if you want to read more - https://github.com/tonistiigi/binfmt/issues/240

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
