### PR TITLE
Fix deadlock in discovery sample

### DIFF
--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -246,8 +246,6 @@ int main(int argc, char *argv[])
     // Print the discovery response information and then exit. Does not use the discovery info.
     if (cmdData.input_PrintDiscoverRespOnly)
     {
-        // Print the discovery response information and then exit (unless in CI, in which case just note it
-        // was successful).
         if (!cmdData.input_isCI)
         {
             printGreengrassResponse(*discoverResponse.GGGroups);

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -239,7 +239,8 @@ int main(int argc, char *argv[])
 
     // Wait for the discovery process to return actual discovery results, or error if something went wrong.
     auto isDiscoverySucceeded = discoveryStatusPromise.get_future().get();
-    if (!isDiscoverySucceeded) {
+    if (!isDiscoverySucceeded)
+    {
         return 1;
     }
 

--- a/samples/greengrass/basic_discovery/main.cpp
+++ b/samples/greengrass/basic_discovery/main.cpp
@@ -22,13 +22,13 @@ using namespace Aws::Discovery;
 
 static std::shared_ptr<Mqtt::MqttConnection> getMqttConnection(
     Aws::Iot::MqttClient &mqttClient,
-    const DiscoverResponse &discoverResponse,
+    const Aws::Crt::Vector<GGGroup> &ggGroups,
     Utils::cmdData &cmdData,
     std::promise<void> &shutdownCompletedPromise)
 {
     std::shared_ptr<Mqtt::MqttConnection> connection;
 
-    for (const auto &groupToUse : *discoverResponse.GGGroups)
+    for (const auto &groupToUse : ggGroups)
     {
         for (const auto &connectivityInfo : *groupToUse.Cores->at(0).Connectivity)
         {
@@ -262,7 +262,7 @@ int main(int argc, char *argv[])
     }
 
     // Try to establish a connection with one of the discovered Greengrass cores.
-    connection = getMqttConnection(mqttClient, discoverResponse, cmdData, shutdownCompletedPromise);
+    connection = getMqttConnection(mqttClient, *discoverResponse.GGGroups, cmdData, shutdownCompletedPromise);
     if (!connection)
     {
         fprintf(stderr, "All connection attempts failed\n");


### PR DESCRIPTION
*Issue #, if available:*

The Greengrass basic discovery sample sometimes deadlock on attempting to establish an MQTT connection.

*Description of changes:*

Remove waiting on a promise from a callback executed by the event loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
