### PR TITLE
CI small fix

### DIFF
--- a/utils/ci_iot_thing.py
+++ b/utils/ci_iot_thing.py
@@ -3,8 +3,46 @@
 
 import sys
 
-import boto3
+import boto3, time
+from botocore.exceptions import ClientError, WaiterError
 
+class ThingDetachedWaiter:
+    """
+    Wait until principal (cert or Cognito identity) is detached from a thing.
+    Raise WaiterError after timeout seconds.
+    """
+
+    def __init__(self, client, delay=2.0, max_delay=10.0, timeout=60.0):
+        self._client = client
+        self._delay = delay
+        self._max_delay = max_delay
+        self._timeout = timeout
+
+    def wait(self, thing_name):
+        start = time.monotonic()
+        sleep = self._delay
+
+        while True:
+            try:
+                resp = self._client.list_thing_principals(thingName=thing_name)
+            except ClientError as e:
+                if e.response["Error"]["Code"] == "ResourceNotFoundException":
+                    return
+                raise
+
+            if not resp.get("principals"):
+                # No principals, we can move on.
+                return
+
+            if time.monotonic() - start > self._timeout:
+                raise WaiterError(
+                    name="ThingDetached",
+                    reason="timeout",
+                    last_response=resp,
+                )
+
+            time.sleep(sleep)
+            sleep = min(sleep * 1.6, self._max_delay) # exponential backoff on retrys
 
 def create_iot_thing(thing_name, region, policy_name, certificate_path, key_path, thing_group=None):
     """ Create IoT thing along with policy and credentials. """
@@ -67,9 +105,12 @@ def delete_iot_thing(thing_name, region):
             iot_client.update_certificate(certificateId=certificate_id, newStatus='INACTIVE')
             iot_client.delete_certificate(certificateId=certificate_id, forceDelete=True)
     except Exception:
-        print(f"ERROR: Could not delete certificate for IoT thing {thing_name}, probably thing does not exist",
+        print("ERROR: Could not delete certificate for IoT thing {thing_name}, probably thing does not exist",
               file=sys.stderr)
         raise
+
+    # Wait for thing to be free of principals
+    ThingDetachedWaiter(iot_client, timeout=10).wait(thing_name)
 
     # Delete thing.
     try:


### PR DESCRIPTION
Deleting an IoT thing before its principals are all released was causing CI to fail. Wait for the principals to be released before moving onto deleting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
