### PR TITLE
Remove clang-3 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,6 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - clang-3
           - clang-6
           - clang-8
           - clang-9

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ __Jump To:__
 
 ### Minimum Requirements
 * C++ 11 or higher
-    * Clang 3.9+ or GCC 4.8+ or MSVC 2015+
+    * Clang 6+ or GCC 4.8+ or MSVC 2015+
 * CMake 3.9+
 
 [Step-by-step instructions](./documents/PREREQUISITES.md)


### PR DESCRIPTION
Remove clang-3 from CI

CI uses aws-crt-builder, which when instructed to use clang-3, has failed to find it and has been falling back on GNU 7.5 for the past year+. This means while clang-3 is listed in our CI as having been tested, it isn't. Fixing aws-crt-builder to use clang-3 has revealed a large number of build failures across aws-c-* libraries. Lack of issues related to this implies that clang-3 is not in use and can be removed from CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
