### PR TITLE
Replace std::make_shared with Crt::MakeShared

### DIFF
--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -120,7 +120,8 @@ std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
                     clientEndpoint,
                     certificateFile,
                     privateKeyFile));
-std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocator());
 util::String clientId = "client_id";
 connectOptions->WithClientId(clientId);
 builder->WithConnectOptions(connectOptions);
@@ -365,8 +366,8 @@ rc = client->PublishAsync(Utf8String::Create("my/topic"),
 #### Example of publishing in the v2 SDK
 
 ```cpp
-std::shared_ptr<Mqtt5::PublishPacket> publish =
-        std::make_shared<Mqtt5::PublishPacket>(
+std::shared_ptr<Mqtt5::PublishPacket> publish = Aws::Crt::MakeShared<Mqtt5::PublishPacket>(
+                Aws::Crt::DefaultAllocator(),
                 "my topic",
                 "hello",
                 Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
@@ -458,7 +459,7 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 Mqtt5::Subscription sub1("my/own/topic",
                          Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
 std::shared_ptr<Mqtt5::SubscribePacket> subPacket =
-        std::make_shared<Mqtt5::SubscribePacket>();
+        Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocator());
 subPacket->WithSubscription(std::move(sub1));
 
 auto onSubAck = [&](int error_code,
@@ -533,7 +534,7 @@ ResponseCode rc = client->UnsubscribeAsync(
 
 ```cpp
 std::shared_ptr<Mqtt5::UnsubscribePacket> unsub =
-        std::make_shared<Mqtt5::UnsubscribePacket>();
+        Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocator());
 unsub->WithTopicFilter("my/topic");
 auto unsubAck = [&](int, std::shared_ptr<Mqtt5::UnSubAckPacket>) {
     /* callback */

--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -121,7 +121,7 @@ std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
                     certificateFile,
                     privateKeyFile));
 std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
-        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocator());
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
 util::String clientId = "client_id";
 connectOptions->WithClientId(clientId);
 builder->WithConnectOptions(connectOptions);
@@ -367,7 +367,7 @@ rc = client->PublishAsync(Utf8String::Create("my/topic"),
 
 ```cpp
 std::shared_ptr<Mqtt5::PublishPacket> publish = Aws::Crt::MakeShared<Mqtt5::PublishPacket>(
-                Aws::Crt::DefaultAllocator(),
+                Aws::Crt::DefaultAllocatorImplementation(),
                 "my topic",
                 "hello",
                 Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
@@ -459,7 +459,7 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 Mqtt5::Subscription sub1("my/own/topic",
                          Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
 std::shared_ptr<Mqtt5::SubscribePacket> subPacket =
-        Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocator());
+        Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
 subPacket->WithSubscription(std::move(sub1));
 
 auto onSubAck = [&](int error_code,
@@ -534,7 +534,7 @@ ResponseCode rc = client->UnsubscribeAsync(
 
 ```cpp
 std::shared_ptr<Mqtt5::UnsubscribePacket> unsub =
-        Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocator());
+        Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
 unsub->WithTopicFilter("my/topic");
 auto unsubAck = [&](int, std::shared_ptr<Mqtt5::UnSubAckPacket>) {
     /* callback */

--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -660,7 +660,7 @@ The Subscribe operation takes a description of the SUBSCRIBE packet you wish to 
     // Create a SubscribePacket with the subscription list. You can also use packet->WithSubscription(subscription)
     // to push_back a single subscription data.
     std::shared_ptr<Mqtt5::SubscribePacket> packet =
-            Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocator());
+            Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
     packet->WithSubscriptions(subscriptionList);
 
     bool subSuccess = mqtt5Client->Subscribe(
@@ -695,7 +695,7 @@ The Unsubscribe operation takes a description of the UNSUBSCRIBE packet you wish
     topics.push_back(topic1);
     topics.push_back(topic2);
     std::shared_ptr<UnsubscribePacket> unsub =
-            Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocator());
+            Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
     unsub->WithTopicFilters(topics);
     bool unsubSuccess = mqtt5Client->Unsubscribe(
         packet,
@@ -731,7 +731,7 @@ If the PUBLISH was a QoS 1 publish, then the completion callback returns a PubAc
 
     // Create PublishPacket.
     std::shared_ptr<PublishPacket> publish = Aws::Crt::MakeShared<PublishPacket>(
-            Aws::Crt::DefaultAllocator(),
+            Aws::Crt::DefaultAllocatorImplementation(),
             testTopic,
             payload,
             QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);

--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -657,8 +657,10 @@ The Subscribe operation takes a description of the SUBSCRIBE packet you wish to 
     subscriptionList.push_back(data2);
     subscriptionList.push_back(data3);
 
-    // Creaet a SubscribePacket with the subscription list. You can also use packet->WithSubscription(subscription) to push_back a single subscription data.
-    std::shared_ptr<Mqtt5::SubscribePacket> packet = std::make_shared<SubscribePacket>();
+    // Create a SubscribePacket with the subscription list. You can also use packet->WithSubscription(subscription)
+    // to push_back a single subscription data.
+    std::shared_ptr<Mqtt5::SubscribePacket> packet =
+            Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocator());
     packet->WithSubscriptions(subscriptionList);
 
     bool subSuccess = mqtt5Client->Subscribe(
@@ -692,7 +694,8 @@ The Unsubscribe operation takes a description of the UNSUBSCRIBE packet you wish
     Vector<String> topics;
     topics.push_back(topic1);
     topics.push_back(topic2);
-    std::shared_ptr<UnsubscribePacket> unsub = std::make_shared<UnsubscribePacket>();
+    std::shared_ptr<UnsubscribePacket> unsub =
+            Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocator());
     unsub->WithTopicFilters(topics);
     bool unsubSuccess = mqtt5Client->Unsubscribe(
         packet,
@@ -727,7 +730,11 @@ If the PUBLISH was a QoS 1 publish, then the completion callback returns a PubAc
     ByteCursor payload = ByteCursorFromString(message_string);
 
     // Create PublishPacket.
-    std::shared_ptr<PublishPacket> publish = std::make_shared<PublishPacket>(testTopic, payload, QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
+    std::shared_ptr<PublishPacket> publish = Aws::Crt::MakeShared<PublishPacket>(
+            Aws::Crt::DefaultAllocator(),
+            testTopic,
+            payload,
+            QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
 
     // Setup publish completion callback. The callback will get triggered when the pulbish completes and publish result returned from the server
     OnPublishCompletionHandler callback = [](int, std::shared_ptr<PublishResult> result){

--- a/samples/commands/commands-sandbox/main.cpp
+++ b/samples/commands/commands-sandbox/main.cpp
@@ -251,8 +251,8 @@ int main(int argc, char *argv[])
     requestResponseOptions.WithOperationTimeoutInSeconds(30);
 
     auto commandClient = Aws::Iotcommands::NewClientFrom5(*protocolClient, requestResponseOptions);
-    auto commandStreamHandler =
-        std::make_shared<Aws::IotcommandsSample::CommandStreamHandler>(std::move(commandClient));
+    auto commandStreamHandler = Aws::Crt::MakeShared<Aws::IotcommandsSample::CommandStreamHandler>(
+        Aws::Crt::DefaultAllocatorImplementation(), std::move(commandClient));
 
     protocolClient->Start();
     auto isConnected = connectedWaiter.get_future().get();

--- a/samples/deprecated/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
+++ b/samples/deprecated/fleet_provisioning/mqtt5_fleet_provisioning/main.cpp
@@ -95,7 +95,8 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmd
     }
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)

--- a/samples/deprecated/jobs/mqtt5_job_execution/main.cpp
+++ b/samples/deprecated/jobs/mqtt5_job_execution/main.cpp
@@ -70,7 +70,8 @@ int main(int argc, char *argv[])
     }
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)

--- a/samples/deprecated/shadow/mqtt5_shadow_sync/main.cpp
+++ b/samples/deprecated/shadow/mqtt5_shadow_sync/main.cpp
@@ -116,7 +116,8 @@ int main(int argc, char *argv[])
     }
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)

--- a/samples/device_defender/mqtt5_basic_report/main.cpp
+++ b/samples/device_defender/mqtt5_basic_report/main.cpp
@@ -123,7 +123,8 @@ int main(int argc, char *argv[])
     });
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     clientConfigBuilder->WithConnectOptions(connectOptions);
 

--- a/samples/mqtt5/mqtt5_pubsub/main.cpp
+++ b/samples/mqtt5/mqtt5_pubsub/main.cpp
@@ -47,7 +47,8 @@ int main(int argc, char *argv[])
     }
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
@@ -156,7 +157,8 @@ int main(int argc, char *argv[])
 
         Mqtt5::Subscription sub1(cmdData.input_topic, Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
         sub1.WithNoLocal(false);
-        std::shared_ptr<Mqtt5::SubscribePacket> subPacket = std::make_shared<Mqtt5::SubscribePacket>();
+        std::shared_ptr<Mqtt5::SubscribePacket> subPacket =
+            Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
         subPacket->WithSubscription(std::move(sub1));
 
         if (client->Subscribe(subPacket, onSubAck))
@@ -201,8 +203,11 @@ int main(int argc, char *argv[])
                     String message = "\"" + cmdData.input_message + std::to_string(publishedCount + 1).c_str() + "\"";
                     ByteCursor payload = ByteCursorFromString(message);
 
-                    std::shared_ptr<Mqtt5::PublishPacket> publish = std::make_shared<Mqtt5::PublishPacket>(
-                        cmdData.input_topic, payload, Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
+                    std::shared_ptr<Mqtt5::PublishPacket> publish = Aws::Crt::MakeShared<Mqtt5::PublishPacket>(
+                        Aws::Crt::DefaultAllocatorImplementation(),
+                        cmdData.input_topic,
+                        payload,
+                        Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
                     if (client->Publish(publish, onPublishComplete))
                     {
                         ++publishedCount;
@@ -218,7 +223,8 @@ int main(int argc, char *argv[])
 
                 // Unsubscribe from the topic.
                 std::promise<void> unsubscribeFinishedPromise;
-                std::shared_ptr<Mqtt5::UnsubscribePacket> unsub = std::make_shared<Mqtt5::UnsubscribePacket>();
+                std::shared_ptr<Mqtt5::UnsubscribePacket> unsub =
+                    Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
                 unsub->WithTopicFilter(cmdData.input_topic);
                 if (!client->Unsubscribe(unsub, [&](int, std::shared_ptr<Mqtt5::UnSubAckPacket>) {
                         unsubscribeFinishedPromise.set_value();

--- a/samples/mqtt5/mqtt5_shared_subscription/main.cpp
+++ b/samples/mqtt5/mqtt5_shared_subscription/main.cpp
@@ -42,7 +42,8 @@ class sample_mqtt5_client
         String input_clientId,
         String input_clientName)
     {
-        std::shared_ptr<sample_mqtt5_client> result = std::make_shared<sample_mqtt5_client>();
+        std::shared_ptr<sample_mqtt5_client> result =
+            Aws::Crt::MakeShared<sample_mqtt5_client>(Aws::Crt::DefaultAllocatorImplementation());
         result->name = input_clientName;
 
         auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
@@ -57,7 +58,8 @@ class sample_mqtt5_client
         {
             builder->WithCertificateAuthority(input_ca.c_str());
         }
-        std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+        std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+            Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
         connectOptions->WithClientId(input_clientId);
         builder->WithConnectOptions(connectOptions);
 
@@ -260,7 +262,8 @@ int main(int argc, char *argv[])
     };
     Mqtt5::Subscription sub1(input_sharedTopic, Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
     sub1.WithNoLocal(false);
-    std::shared_ptr<Mqtt5::SubscribePacket> subPacket = std::make_shared<Mqtt5::SubscribePacket>();
+    std::shared_ptr<Mqtt5::SubscribePacket> subPacket =
+        Aws::Crt::MakeShared<Mqtt5::SubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
     subPacket->WithSubscription(std::move(sub1));
 
     if (subscriberOne->client->Subscribe(subPacket, onSubAck))
@@ -348,8 +351,11 @@ int main(int argc, char *argv[])
         // Add \" to 'JSON-ify' the message
         String message = "\"" + cmdData.input_message + std::to_string(publishedCount + 1).c_str() + "\"";
         ByteCursor payload = ByteCursorFromString(message);
-        std::shared_ptr<Mqtt5::PublishPacket> publish = std::make_shared<Mqtt5::PublishPacket>(
-            cmdData.input_topic, payload, Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
+        std::shared_ptr<Mqtt5::PublishPacket> publish = Aws::Crt::MakeShared<Mqtt5::PublishPacket>(
+            Aws::Crt::DefaultAllocatorImplementation(),
+            cmdData.input_topic,
+            payload,
+            Mqtt5::QOS::AWS_MQTT5_QOS_AT_LEAST_ONCE);
         if (publisher->client->Publish(publish, onPublishComplete))
         {
             ++publishedCount;
@@ -362,7 +368,8 @@ int main(int argc, char *argv[])
     /*********************** Unsubscribe the subscribers ***************************/
 
     std::promise<void> unsubscribeFinishedPromise;
-    std::shared_ptr<Mqtt5::UnsubscribePacket> unsub = std::make_shared<Mqtt5::UnsubscribePacket>();
+    std::shared_ptr<Mqtt5::UnsubscribePacket> unsub =
+        Aws::Crt::MakeShared<Mqtt5::UnsubscribePacket>(Aws::Crt::DefaultAllocatorImplementation());
     unsub->WithTopicFilter(input_sharedTopic);
     if (!subscriberOne->client->Unsubscribe(
             unsub, [&](int, std::shared_ptr<Mqtt5::UnSubAckPacket>) { unsubscribeFinishedPromise.set_value(); }))

--- a/samples/secure_tunneling/secure_tunnel/main.cpp
+++ b/samples/secure_tunneling/secure_tunnel/main.cpp
@@ -218,7 +218,8 @@ int main(int argc, char *argv[])
             /* Send an echo message back to the Source Device */
             if (localProxyMode == AWS_SECURE_TUNNELING_DESTINATION_MODE)
             {
-                std::shared_ptr<Message> echoMessage = std::make_shared<Message>(message->getPayload().value());
+                std::shared_ptr<Message> echoMessage =
+                    Aws::Crt::MakeShared<Message>(allocator, message->getPayload().value());
 
                 /* Echo message on same service id received message arrived on */
                 if (message->getServiceId().has_value())
@@ -366,7 +367,8 @@ int main(int argc, char *argv[])
             if (messagesSent <= messageCount)
             {
 
-                std::shared_ptr<Message> message = std::make_shared<Message>(ByteCursorFromCString(toSend.c_str()));
+                std::shared_ptr<Message> message =
+                    Aws::Crt::MakeShared<Message>(allocator, ByteCursorFromCString(toSend.c_str()));
 
                 /* If the secure tunnel has service ids, we will use one for our messages. */
                 if (m_serviceId.has_value())

--- a/secure_tunneling/source/SecureTunnel.cpp
+++ b/secure_tunneling/source/SecureTunnel.cpp
@@ -875,7 +875,7 @@ namespace Aws
         int SecureTunnel::SendData(const Crt::ByteCursor &data)
         {
             // return SendData("", data);
-            std::shared_ptr<Message> message = std::make_shared<Message>(data);
+            std::shared_ptr<Message> message = Aws::Crt::MakeShared<Message>(m_allocator, data);
             return SendMessage(message);
         }
 
@@ -973,8 +973,8 @@ namespace Aws
                 /* Check for full callback */
                 if (secureTunnel->m_OnConnectionSuccess)
                 {
-                    std::shared_ptr<ConnectionData> packet =
-                        std::make_shared<ConnectionData>(*connection, secureTunnel->m_allocator);
+                    std::shared_ptr<ConnectionData> packet = Aws::Crt::MakeShared<ConnectionData>(
+                        secureTunnel->m_allocator, *connection, secureTunnel->m_allocator);
                     ConnectionSuccessEventData eventData;
                     eventData.connectionData = packet;
                     secureTunnel->m_OnConnectionSuccess(secureTunnel, eventData);
@@ -1015,8 +1015,8 @@ namespace Aws
 
             if (secureTunnel->m_OnSendMessageComplete)
             {
-                std::shared_ptr<SendMessageCompleteData> packet =
-                    std::make_shared<SendMessageCompleteData>(type, secureTunnel->m_allocator);
+                std::shared_ptr<SendMessageCompleteData> packet = Aws::Crt::MakeShared<SendMessageCompleteData>(
+                    secureTunnel->m_allocator, type, secureTunnel->m_allocator);
                 SendMessageCompleteEventData eventData;
                 eventData.sendMessageCompleteData = packet;
                 secureTunnel->m_OnSendMessageComplete(secureTunnel, error_code, eventData);
@@ -1040,8 +1040,8 @@ namespace Aws
                     /* V2 Protocol API */
                     if (secureTunnel->m_OnMessageReceived != nullptr)
                     {
-                        std::shared_ptr<Message> packet =
-                            std::make_shared<Message>(*message, secureTunnel->m_allocator);
+                        std::shared_ptr<Message> packet = Aws::Crt::MakeShared<Message>(
+                            secureTunnel->m_allocator, *message, secureTunnel->m_allocator);
                         MessageReceivedEventData eventData;
                         eventData.message = packet;
                         secureTunnel->m_OnMessageReceived(secureTunnel, eventData);
@@ -1082,8 +1082,8 @@ namespace Aws
             {
                 if (secureTunnel->m_OnStreamStarted)
                 {
-                    std::shared_ptr<StreamStartedData> packet =
-                        std::make_shared<StreamStartedData>(*message, secureTunnel->m_allocator);
+                    std::shared_ptr<StreamStartedData> packet = Aws::Crt::MakeShared<StreamStartedData>(
+                        secureTunnel->m_allocator, *message, secureTunnel->m_allocator);
                     StreamStartedEventData eventData;
                     eventData.streamStartedData = packet;
                     secureTunnel->m_OnStreamStarted(secureTunnel, error_code, eventData);
@@ -1109,8 +1109,8 @@ namespace Aws
 
             if (secureTunnel->m_OnStreamStopped)
             {
-                std::shared_ptr<StreamStoppedData> packet =
-                    std::make_shared<StreamStoppedData>(*message, secureTunnel->m_allocator);
+                std::shared_ptr<StreamStoppedData> packet = Aws::Crt::MakeShared<StreamStoppedData>(
+                    secureTunnel->m_allocator, *message, secureTunnel->m_allocator);
                 StreamStoppedEventData eventData;
                 eventData.streamStoppedData = packet;
                 secureTunnel->m_OnStreamStopped(secureTunnel, eventData);
@@ -1134,8 +1134,8 @@ namespace Aws
             {
                 if (secureTunnel->m_OnConnectionStarted)
                 {
-                    std::shared_ptr<ConnectionStartedData> packet =
-                        std::make_shared<ConnectionStartedData>(*message, secureTunnel->m_allocator);
+                    std::shared_ptr<ConnectionStartedData> packet = Aws::Crt::MakeShared<ConnectionStartedData>(
+                        secureTunnel->m_allocator, *message, secureTunnel->m_allocator);
                     ConnectionStartedEventData eventData;
                     eventData.connectionStartedData = packet;
                     secureTunnel->m_OnConnectionStarted(secureTunnel, error_code, eventData);
@@ -1153,8 +1153,8 @@ namespace Aws
 
             if (secureTunnel->m_OnConnectionReset)
             {
-                std::shared_ptr<ConnectionResetData> packet =
-                    std::make_shared<ConnectionResetData>(*message, secureTunnel->m_allocator);
+                std::shared_ptr<ConnectionResetData> packet = Aws::Crt::MakeShared<ConnectionResetData>(
+                    secureTunnel->m_allocator, *message, secureTunnel->m_allocator);
                 ConnectionResetEventData eventData;
                 eventData.connectionResetData = packet;
                 secureTunnel->m_OnConnectionReset(secureTunnel, error_code, eventData);

--- a/secure_tunneling/tests/main.cpp
+++ b/secure_tunneling/tests/main.cpp
@@ -300,7 +300,7 @@ int main(int argc, char *argv[])
     promiseDestinationConnectionStarted.get_future().wait();
 
     std::shared_ptr<Message> message1 =
-        std::make_shared<Message>(ByteCursorFromCString(aws_string_c_str(SECTUN_PAYLOAD_MESSAGE)));
+        Aws::Crt::MakeShared<Message>(allocator, ByteCursorFromCString(aws_string_c_str(SECTUN_PAYLOAD_MESSAGE)));
     message1->WithServiceId(m_serviceId.value());
     message1->WithConnectionId(connectionId2);
     secureTunnelSource->SendMessage(message1);
@@ -309,7 +309,7 @@ int main(int argc, char *argv[])
     promiseDestinationReceivedMessage.get_future().wait();
 
     std::shared_ptr<Message> message2 =
-        std::make_shared<Message>(ByteCursorFromCString(aws_string_c_str(SECTUN_PAYLOAD_MESSAGE)));
+        Aws::Crt::MakeShared<Message>(allocator, ByteCursorFromCString(aws_string_c_str(SECTUN_PAYLOAD_MESSAGE)));
     message2->WithServiceId(m_serviceId.value());
     message2->WithConnectionId(connectionId);
     secureTunnelDestination->SendMessage(message2);

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -97,7 +97,8 @@ std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const Utils::cmd
     }
 
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
@@ -541,7 +542,8 @@ int main(int argc, char *argv[])
             fprintf(stderr, "MQTT5 Connection failed to start");
             return -1;
         }
-        identityClient = std::make_shared<IotIdentityClient>(mqtt5Client);
+        identityClient =
+            Aws::Crt::MakeShared<IotIdentityClient>(Aws::Crt::DefaultAllocatorImplementation(), mqtt5Client);
     }
     else if (cmdData.input_mqtt_version == 3UL)
     {
@@ -551,7 +553,8 @@ int main(int argc, char *argv[])
             fprintf(stderr, "MQTT3 Connection failed to start");
             return -1;
         }
-        identityClient = std::make_shared<IotIdentityClient>(mqtt3Connection);
+        identityClient =
+            Aws::Crt::MakeShared<IotIdentityClient>(Aws::Crt::DefaultAllocatorImplementation(), mqtt3Connection);
     }
     else
     {

--- a/servicetests/tests/JobsExecution/main.cpp
+++ b/servicetests/tests/JobsExecution/main.cpp
@@ -111,7 +111,7 @@ std::shared_ptr<IotJobsClient> build_mqtt3_client(
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
         exit(-1);
     }
-    return std::make_shared<IotJobsClient>(connection);
+    return Aws::Crt::MakeShared<IotJobsClient>(Aws::Crt::DefaultAllocatorImplementation(), connection);
 }
 
 std::shared_ptr<IotJobsClient> build_mqtt5_client(
@@ -133,7 +133,8 @@ std::shared_ptr<IotJobsClient> build_mqtt5_client(
     }
     // Create the MQTT5 builder and populate it with data from cmdData.
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
@@ -172,7 +173,7 @@ std::shared_ptr<IotJobsClient> build_mqtt5_client(
         fprintf(stderr, "MQTT5 Connection failed to start");
         exit(-1);
     }
-    return std::make_shared<IotJobsClient>(client5);
+    return Aws::Crt::MakeShared<IotJobsClient>(Aws::Crt::DefaultAllocatorImplementation(), client5);
 }
 
 int main(int argc, char *argv[])

--- a/servicetests/tests/ShadowUpdate/main.cpp
+++ b/servicetests/tests/ShadowUpdate/main.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<IotShadowClient> build_mqtt3_client(
         fprintf(stderr, "MQTT Connection failed with error %s\n", ErrorDebugString(connection->LastError()));
         exit(-1);
     }
-    return std::make_shared<IotShadowClient>(connection);
+    return Aws::Crt::MakeShared<IotShadowClient>(Aws::Crt::DefaultAllocatorImplementation(), connection);
 }
 
 std::shared_ptr<IotShadowClient> build_mqtt5_client(
@@ -158,7 +158,8 @@ std::shared_ptr<IotShadowClient> build_mqtt5_client(
     }
     // Create the MQTT5 builder and populate it with data from cmdData.
     // Setup connection options
-    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions = std::make_shared<Mqtt5::ConnectPacket>();
+    std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
+        Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
     connectOptions->WithClientId(cmdData.input_clientId);
     builder->WithConnectOptions(connectOptions);
     if (cmdData.input_port != 0)
@@ -201,7 +202,7 @@ std::shared_ptr<IotShadowClient> build_mqtt5_client(
         fprintf(stderr, "MQTT5 Connection failed to start");
         exit(-1);
     }
-    return std::make_shared<IotShadowClient>(client5);
+    return Aws::Crt::MakeShared<IotShadowClient>(Aws::Crt::DefaultAllocatorImplementation(), client5);
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/809 (but doesn't resolve it).

IoT SDK v2 should use CRT internal allocator whenever possible.

*Description of changes:*

Replace `std::make_shared` with `Aws::Crt::MakeShared`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.