### PR TITLE
Use windows-2025 image in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,8 @@ jobs:
         run: |
           cd ${{ env.CI_FOLDER }}/aws-iot-device-sdk-cpp-v2
           python ./deviceadvisor/script/DATestRun.py
-  windows-vs14:
-    runs-on: windows-2019 # windows-2019 is last env with Visual Studio 2015 (v14.0)
+  windows-vs17:
+    runs-on: windows-2025
     strategy:
       matrix:
         arch: [Win32, x64]
@@ -216,7 +216,7 @@ jobs:
           md ${{ env.CI_FOLDER }}
           cd ${{ env.CI_FOLDER }}
           python -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder.pyz')"
-          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-Tv140 --cmake-extra=-A${{ matrix.arch }}
+          python builder.pyz build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-Tv143 --cmake-extra=-A${{ matrix.arch }}
       - name: Running samples in CI setup
         run: |
           python -m pip install boto3
@@ -302,7 +302,7 @@ jobs:
           cd ${{ env.CI_FOLDER }}/aws-iot-device-sdk-cpp-v2
           python ./deviceadvisor/script/DATestRun.py
   windows-app-verifier:
-    runs-on: windows-2022 # latest
+    runs-on: windows-2025 # latest
     permissions:
       id-token: write # This is required for requesting the JWT
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,8 @@ jobs:
           role-to-assume: ${{ env.CI_IOT_CONTAINERS }}
           aws-region: ${{ env.AWS_DEFAULT_REGION }}
       - name: Build ${{ env.PACKAGE_NAME }} + consumers
+        # The "--cmake-extra=-Tv143" explicitly sets VS 17 2022 to be used for compilation.
+        # See https://cmake.org/cmake/help/latest/generator/Visual%20Studio%2017%202022.html#toolset-selection
         run: |
           md ${{ env.CI_FOLDER }}
           cd ${{ env.CI_FOLDER }}

--- a/eventstream_rpc/source/EventStreamClient.cpp
+++ b/eventstream_rpc/source/EventStreamClient.cpp
@@ -1396,7 +1396,10 @@ namespace Aws
             return true;
         }
 
-        void StreamResponseHandler::OnStreamEvent(Crt::ScopedResource<AbstractShapeBase> response) {}
+        void StreamResponseHandler::OnStreamEvent(Crt::ScopedResource<AbstractShapeBase> response)
+        {
+            (void)response;
+        }
 
         void StreamResponseHandler::OnStreamClosed() {}
 


### PR DESCRIPTION
- Windows 2019 will be fully unsupported by 2025-06-30, https://github.com/actions/runner-images/issues/12045. Remove it with msvc-15 and below.
- Use latest windows-2025 and msvc-17

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
