### PR TITLE
Fix fleet provisioning samples

### DIFF
--- a/samples/service_clients/fleet_provisioning/provision-basic/main.cpp
+++ b/samples/service_clients/fleet_provisioning/provision-basic/main.cpp
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
         [&createKeysResultPromise](CreateKeysAndCertificateResult &&result)
         { createKeysResultPromise.set_value(std::move(result)); });
 
-    const auto &createKeysResult = createKeysResultPromise.get_future().get().value();
+    auto createKeysResult = createKeysResultPromise.get_future().get().value();
     if (!createKeysResult.IsSuccess())
     {
         s_onServiceError(createKeysResult.GetError(), "create-keys-and-certificate");
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
         [&registerThingResultPromise](RegisterThingResult &&result)
         { registerThingResultPromise.set_value(std::move(result)); });
 
-    const auto &registerThingResult = registerThingResultPromise.get_future().get().value();
+    auto registerThingResult = registerThingResultPromise.get_future().get().value();
     if (!registerThingResult.IsSuccess())
     {
         s_onServiceError(registerThingResult.GetError(), "register-thing");

--- a/samples/service_clients/fleet_provisioning/provision-csr/main.cpp
+++ b/samples/service_clients/fleet_provisioning/provision-csr/main.cpp
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
         [&createFromCsrResultPromise](CreateCertificateFromCsrResult &&result)
         { createFromCsrResultPromise.set_value(std::move(result)); });
 
-    const auto &createFromCsrResult = createFromCsrResultPromise.get_future().get().value();
+    auto createFromCsrResult = createFromCsrResultPromise.get_future().get().value();
     if (!createFromCsrResult.IsSuccess())
     {
         s_onServiceError(createFromCsrResult.GetError(), "create-certificate-from-csr");
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
         [&registerThingResultPromise](RegisterThingResult &&result)
         { registerThingResultPromise.set_value(std::move(result)); });
 
-    const auto &registerThingResult = registerThingResultPromise.get_future().get().value();
+    auto registerThingResult = registerThingResultPromise.get_future().get().value();
     if (!registerThingResult.IsSuccess())
     {
         s_onServiceError(registerThingResult.GetError(), "register-thing");


### PR DESCRIPTION
*Issue #, if available:*

Const ref doesn't always prolong the lifetime of a variable.

*Description of changes:*

It's possible to still use const ref by splitting getting the future value into multiple statements. But using value semantics is also fine as move semantics will be used.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
