### PR TITLE
Compute timestamp only once in streaming test

### DIFF
--- a/eventstream_rpc/tests/EventStreamClientTest.cpp
+++ b/eventstream_rpc/tests/EventStreamClientTest.cpp
@@ -1628,8 +1628,9 @@ AWS_TEST_CASE(EchoClientStreamingOperationEchoSuccessBoolean, s_TestEchoClientSt
 
 static int s_TestEchoClientStreamingOperationEchoSuccessTime(struct aws_allocator *allocator, void *ctx)
 {
+    auto ts = Aws::Crt::DateTime::Now();
     return s_DoTestEchoClientStreamingOperationEchoSuccess(
-        allocator, [](MessageData &messageData) { messageData.SetTimeMessage(Aws::Crt::DateTime::Now()); });
+        allocator, [ts](MessageData &messageData) { messageData.SetTimeMessage(ts); });
 }
 
 AWS_TEST_CASE(EchoClientStreamingOperationEchoSuccessTime, s_TestEchoClientStreamingOperationEchoSuccessTime);


### PR DESCRIPTION
*Issue #, if available:*

Two sequential `DateTime::Now` calls made on an edge between two seconds give different results, which fails the `EchoClientStreamingOperationEchoSuccessTime` test.

*Description of changes:*

Compute timestamp only once, reuse the result in comparison operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
