### PR TITLE
Add a note to PKCS#11 sample about TLS 1.3

### DIFF
--- a/samples/mqtt/mqtt5_pkcs11/README.md
+++ b/samples/mqtt/mqtt5_pkcs11/README.md
@@ -17,7 +17,10 @@ You can read more about MQTT5 for the CPP IoT Device SDK V2 in the [MQTT5 user g
 
 ## Requirements
 
-**WARNING: Unix (Linux) only**. Currently, TLS integration with PKCS#11 is only available on Unix devices.
+> [!IMPORTANT]
+> TLS integration with PKCS#11 has the following limitations:
+> - Only supported on Unix-like platforms
+> - TLS 1.3 is not supported
 
 This sample assumes you have the required AWS IoT resources available. Information about AWS IoT can be found [HERE](https://docs.aws.amazon.com/iot/latest/developerguide/what-is-aws-iot.html) and instructions on creating AWS IoT resources (AWS IoT Policy, Device Certificate, Private Key) can be found [HERE](https://docs.aws.amazon.com/iot/latest/developerguide/create-iot-resources.html).
 

--- a/samples/service_clients/commands/commands-sandbox/CMakeLists.txt
+++ b/samples/service_clients/commands/commands-sandbox/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.9...3.31)
 project(commands-sandbox CXX)
 
 file(GLOB SRC_FILES
-       "*.cpp",
+       "*.cpp"
        "*.h"
 )
 


### PR DESCRIPTION
Issue: https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/856

Currently, TLS 1.3 is not supported for PKCS#11 keys. Add a note to the corresponding readme.

Also, fix a syntax error in a cmake config in the Commands sample.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
