### PR TITLE
Migrate Mqtt5ClientBuilder from deprecated New* to Create* APIs

### DIFF
--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -100,26 +100,25 @@ std::shared_ptr<MqttClient>client = std::shared_ptr<MqttClient>(
                 mqtt_timeout,
                 /* disconnect handler */, nullptr,
                 /* reconnect handler */, nullptr,
-                /* resubscribe handler */, nullptr);
+                /* resubscribe handler */, nullptr));
 ```
 
 #### Example of creating a client in the v2 SDK
 
 The v2 SDK supports different connection types. Given the same input parameters as in the v1 example above,
-the most recommended method to create an MQTT5 client will be [NewMqtt5ClientBuilderWithMtlsFromPath](https://aws.github.io/aws-iot-device-sdk-cpp-v2/class_aws_1_1_iot_1_1_mqtt5_client_builder.html#ab595bbc50e08b9d2f78f62e9efeafd65).
+the most recommended method to create an MQTT5 client will be [CreateMqtt5ClientBuilderWithMtlsFromPath](https://aws.github.io/aws-iot-device-sdk-cpp-v2/class_aws_1_1_iot_1_1_mqtt5_client_builder.html#a21c365a232be4447b21eb56cc55d4b62).
 
 ```cpp
 util::String clientEndpoint = "<prefix>-ats.iot.<region>.amazonaws.com";
 util::String certificateFile = "<certificate file>";  // X.509 based certificate file
 util::String privateKeyFile = "<private key file>";   // PEM encoded private key file
-uint32_t clientPort = <port number>
+uint32_t clientPort = <port number>;
 String client_id = "unique client id";
 
-std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
-            Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-                    clientEndpoint,
-                    certificateFile,
-                    privateKeyFile));
+std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder =
+        Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+                clientEndpoint, certificateFile.c_str(), privateKeyFile.c_str());
+
 std::shared_ptr<Mqtt5::ConnectPacket> connectOptions =
         Aws::Crt::MakeShared<Mqtt5::ConnectPacket>(Aws::Crt::DefaultAllocatorImplementation());
 util::String clientId = "client_id";

--- a/documents/MIGRATION_GUIDE.md
+++ b/documents/MIGRATION_GUIDE.md
@@ -618,7 +618,7 @@ except QOS0 publish packets in the offline queue on disconnect:
 
 ```cpp
 std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
-    Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(/* ... */));
+    Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(/* ... */));
 
 builder.WithOfflineQueueBehavior(
         Mqtt5::ClientOperationQueueBehaviorType::

--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -17,8 +17,8 @@
         - [Direct MQTT with Custom Authentication](#direct-mqtt-with-custom-authentication)
         - [MQTT over Websockets with Cognito](#mqtt-over-websockets-with-cognito)
         - [Direct MQTT with Windows Certificate Store Method](#direct-mqtt-with-windows-certificate-store-method)
-        - [Direct MQTT with PKCS11 Method](#direct-mqtt-with-pkcs11-method)
-        - [Direct MQTT with pkcs12 method](#direct-mqtt-with-pkcs12-method)
+        - [Direct MQTT with PKCS11 Method (Unix Only)](#direct-mqtt-with-pkcs11-method-unix-only)
+        - [Direct MQTT with pkcs12 method (macOS Only)](#direct-mqtt-with-pkcs12-method-macos-only)
     + [Adding an HTTP Proxy](#adding-an-http-proxy)
     + [Client Operations](#client-operations)
         - [Subscribe](#subscribe)
@@ -81,7 +81,7 @@ Example:
     std::shared_ptr<Mqtt5Client> client = nullptr;
 
     // Create Mqtt5Client Builder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(...);
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
     // Setup lifecycle callbacks
     builder->WithClientConnectionSuccessCallback(
@@ -115,10 +115,10 @@ Once a MQTT5 client builder has been created, it is ready to make a [MQTT5 clien
 ```cpp
 
     // Create Mqtt5Client Builder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(...);
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {
@@ -142,7 +142,7 @@ The MQTT5 client emits a set of events related to state and network status chang
 ```cpp
 
     // Create Mqtt5Client Builder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(...);
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
 
     /* setup lifecycle event callbacks */
@@ -181,7 +181,7 @@ The MQTT5 client emits a set of events related to state and network status chang
         });
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {
@@ -253,7 +253,7 @@ Emitted once the client has shutdown any associated network connection and enter
 
 ```cpp
     // Create Mqtt5Client Builder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(...);
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
     builder->WithPublishReceivedCallback([](const Mqtt5::PublishReceivedEventData &eventData) {
         if (eventData.publishPacket == nullptr)
@@ -263,7 +263,7 @@ Emitted once the client has shutdown any associated network connection and enter
         fprintf(stdout, "\n");
     });
 
-    std::shared_ptr<Aws::Crt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
 ```
 
 
@@ -277,10 +277,10 @@ Invoking `start()` on the client will put it into an active state where it recur
 ```cpp
 
     // Create Mqtt5Client Builder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(...);
+     std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {
@@ -322,8 +322,9 @@ For X509 based mutual TLS, you can create a client where the certificate and pri
 
 ```cpp
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-        "<clientEndpoint>", "<certificateFilePath>", "<privateKeyFilePath>");
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder =
+        Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            "<clientEndpoint>", "<certificateFilePath>", "<privateKeyFilePath>");
 
     /* You can setup other client options and lifecycle event callbacks before call builder->Build().
     ** Once the the client get built, you could no longer update the client options or connection options
@@ -331,7 +332,7 @@ For X509 based mutual TLS, you can create a client where the certificate and pri
     */
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 
     if (client == nullptr)
     {
@@ -369,8 +370,9 @@ If the default credentials provider chain and AWS region are specified, you do n
     Aws::Iot::WebsocketConfig websocketConfig(<signing region>, provider);
 
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWebsocket(
-        "<clientEndpoint>", websocketConfig);
+    std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder =
+        Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithWebsocket(
+            "<clientEndpoint>", websocketConfig);
 
     /* You can setup other client options and lifecycle event callbacks before call builder->Build().
     ** Once the the client get built, you could no longer update the client options or connection options
@@ -378,7 +380,7 @@ If the default credentials provider chain and AWS region are specified, you do n
     */
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt5Client> mqtt5Client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {
@@ -545,7 +547,7 @@ store, rather than simply being files on disk. To create a MQTT5 builder configu
 Note: This is the primary way to use HSM/TPMs on Windows.
 Note: Windows Certificate Store connection support is only available on Windows devices.
 
-### Direct MQTT with PKCS11 Method
+### Direct MQTT with PKCS11 Method (Unix Only)
 
 A MQTT5 direct connection can be made using a PKCS11 device rather than using a PEM encoded private key,
 the private key for mutual TLS is stored on a PKCS#11 compatible smart card or Hardware Security Module (HSM).
@@ -581,7 +583,7 @@ the private key for mutual TLS is stored on a PKCS#11 compatible smart card or H
 ```
 Note: Currently, TLS integration with PKCS#11 is only available on Unix devices.
 
-### Direct MQTT with PKCS12 Method
+### Direct MQTT with PKCS12 Method (macOS Only)
 A MQTT5 direct connection can be made using a PKCS12 file rather than using a PEM encoded private key.
 To create a MQTT5 builder configured for this connection, see the following code:
 ```cpp

--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -408,7 +408,7 @@ If your custom authenticator does not use signing, you don't specify anything re
     customAuth.WithPassword(<Binary data value of the password field to be passed to the authorizer lambda>);
 
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomCustomAuthorizer(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithCustomAuthorizer(
         "<clientEndpoint>", customAuth);
 
     /* You can setup other client options and lifecycle event callbacks before call builder->Build().
@@ -439,7 +439,7 @@ If your custom authorizer uses signing, you must specify the three signed token 
     customAuth.WithTokenSignature("<The signature of the custom authorizer>")
 
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomCustomAuthorizer(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithCustomAuthorizer(
         "<clientEndpoint>", customAuth);
 
     /* You can setup other client options and lifecycle event callbacks before call builder->Build().
@@ -497,7 +497,7 @@ To create a MQTT5 builder configured for this connection, see the following code
     Aws::Iot::WebsocketConfig websocketConfig(<signing region>, provider);
 
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWebsocket(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithWebsocket(
         "<clientEndpoint>", websocketConfig);
 
     /* You can setup other client options and lifecycle event callbacks before call builder->Build().
@@ -526,7 +526,7 @@ store, rather than simply being files on disk. To create a MQTT5 builder configu
 ```cpp
     String windowsCertPath = "CurrentUser\\MY\\A11F8A9B5DF5B98BA3508FBCA575D09570E0D2C6";
 
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWindowsCertStorePath(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithWindowsCertStorePath(
             "<clientEndpoint>", windowsCertPath);
 
     // Build Mqtt5Client
@@ -566,7 +566,7 @@ the private key for mutual TLS is stored on a PKCS#11 compatible smart card or H
     pkcs11Options.SetTokenLabel("<pkcs11_tokenLabel>");
     pkcs11Options.SetPrivateKeyObjectLabel("<pkcs11_privateKeyLabel>");
 
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs11(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsPkcs11(
 			"<endpoint>", pkcs11Options);
 
     builder->WithPort(8883);
@@ -591,7 +591,7 @@ To create a MQTT5 builder configured for this connection, see the following code
     testPkcs12Options.pkcs12_file = "<pkcs12_key>";
     testPkcs12Options.pkcs12_password = "<pkcs12_password>";
 
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs12(
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsPkcs12(
         "<endpoint>", testPkcs12Options);
 
     std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> mqtt5Client = builder->Build();
@@ -611,7 +611,7 @@ No matter what your connection transport or authentication method is, you may co
 
 ```cpp
     // Create a Client using Mqtt5ClientBuilder
-    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithXXXXX( ... );
+    Aws::Iot::Mqtt5ClientBuilder *builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithXXXXX( ... );
 
     Http::HttpClientConnectionProxyOptions proxyOptions;
     proxyOptions.HostName = "<proxyHost>";

--- a/documents/MQTT5_Userguide.md
+++ b/documents/MQTT5_Userguide.md
@@ -181,7 +181,7 @@ The MQTT5 client emits a set of events related to state and network status chang
         });
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {
@@ -263,7 +263,7 @@ Emitted once the client has shutdown any associated network connection and enter
         fprintf(stdout, "\n");
     });
 
-    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 ```
 
 
@@ -280,7 +280,7 @@ Invoking `start()` on the client will put it into an active state where it recur
      std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(...);
 
     // Build Mqtt5Client
-    std::shared_ptr<Aws::Crt::Mqtt::Mqtt5Client> client = builder->Build();
+    std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> client = builder->Build();
 
     if (mqtt5Client == nullptr)
     {

--- a/samples/mqtt/mqtt5_aws_websocket/README.md
+++ b/samples/mqtt/mqtt5_aws_websocket/README.md
@@ -66,6 +66,11 @@ Note that in a real application, you may want to avoid the use of wildcards in y
 
 </details>
 
+### Determining your signing region
+
+The `signing_region` parameter specifies the AWS region used to sign WebSocket connection requests via [SigV4 authentication](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html). It must match the region of your AWS IoT Core endpoint.
+For example, if your endpoint is `abcdef12345-ats.iot.us-west-2.amazonaws.com`, the signing region is `us-west-2`.
+
 ## How to build
 
 To build the sample, change directory into the sample's folder and run the cmake commands. The sample executable will be built into the `samples/mqtt/mqtt5_aws_websocket/build` folder.

--- a/samples/mqtt/mqtt5_aws_websocket/main.cpp
+++ b/samples/mqtt/mqtt5_aws_websocket/main.cpp
@@ -134,9 +134,8 @@ int main(int argc, char *argv[])
     Aws::Iot::WebsocketConfig websocketConfig(cmdData.signingRegion, provider);
 
     // Create a Client using Mqtt5ClientBuilder
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithWebsocket(
-            cmdData.endpoint, websocketConfig));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithWebsocket(
+        cmdData.endpoint, websocketConfig);
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/mqtt/mqtt5_custom_auth_signed/main.cpp
+++ b/samples/mqtt/mqtt5_custom_auth_signed/main.cpp
@@ -164,8 +164,8 @@ int main(int argc, char *argv[])
     customAuth.WithTokenKeyName(cmdData.authTokenKeyName.c_str());
     customAuth.WithTokenValue(cmdData.authTokenKeyValue.c_str());
 
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizer(cmdData.endpoint, customAuth, DefaultAllocatorImplementation()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithCustomAuthorizer(
+        cmdData.endpoint, customAuth, DefaultAllocatorImplementation());
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/mqtt/mqtt5_custom_auth_unsigned/main.cpp
+++ b/samples/mqtt/mqtt5_custom_auth_unsigned/main.cpp
@@ -138,9 +138,8 @@ int main(int argc, char *argv[])
     customAuth.WithUsername(cmdData.authUsername.c_str());
     customAuth.WithPassword(ByteCursorFromCString(cmdData.authPassword.c_str()));
 
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithCustomAuthorizer(
-            cmdData.endpoint, customAuth, DefaultAllocatorImplementation()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithCustomAuthorizer(
+            cmdData.endpoint, customAuth, DefaultAllocatorImplementation());
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/mqtt/mqtt5_pkcs11/main.cpp
+++ b/samples/mqtt/mqtt5_pkcs11/main.cpp
@@ -189,8 +189,8 @@ int main(int argc, char *argv[])
         pkcs11Options.SetSlotId(cmdData.pkcs11SlotId);
     }
 
-    Aws::Iot::Mqtt5ClientBuilder *builder =
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsPkcs11(cmdData.endpoint, pkcs11Options);
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsPkcs11(
+        cmdData.endpoint, pkcs11Options);
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/samples/mqtt/mqtt5_x509/main.cpp
+++ b/samples/mqtt/mqtt5_x509/main.cpp
@@ -126,9 +126,8 @@ int main(int argc, char *argv[])
      * Create MQTT5 client builder using mutual TLS via X509 Certificate and Private Key,
      * The builder will be used to create the final client
      */
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+        cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/samples/others/device_defender/mqtt5_basic_report/main.cpp
+++ b/samples/others/device_defender/mqtt5_basic_report/main.cpp
@@ -176,9 +176,9 @@ int main(int argc, char *argv[])
     ApiHandle apiHandle;
 
     // Create the MQTT builder and populate it with data from cmdData.
-    auto clientConfigBuilder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto clientConfigBuilder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
+            
     if (clientConfigBuilder == nullptr)
     {
         fprintf(

--- a/samples/service_clients/commands/commands-sandbox/main.cpp
+++ b/samples/service_clients/commands/commands-sandbox/main.cpp
@@ -275,9 +275,8 @@ int main(int argc, char *argv[])
     Aws::Crt::ApiHandle apiHandle;
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/samples/service_clients/fleet_provisioning/provision-basic/main.cpp
+++ b/samples/service_clients/fleet_provisioning/provision-basic/main.cpp
@@ -137,9 +137,8 @@ int main(int argc, char *argv[])
     ApiHandle apiHandle;
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/samples/service_clients/fleet_provisioning/provision-csr/main.cpp
+++ b/samples/service_clients/fleet_provisioning/provision-csr/main.cpp
@@ -142,9 +142,8 @@ int main(int argc, char *argv[])
     ApiHandle apiHandle;
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/samples/service_clients/jobs/jobs-sandbox/main.cpp
+++ b/samples/service_clients/jobs/jobs-sandbox/main.cpp
@@ -462,9 +462,8 @@ int main(int argc, char *argv[])
     context.m_thingName = cmdData.thingName;
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/samples/service_clients/shadow/shadow-sandbox/main.cpp
+++ b/samples/service_clients/shadow/shadow-sandbox/main.cpp
@@ -369,9 +369,8 @@ int main(int argc, char *argv[])
     context.m_thingName = cmdData.thingName;
 
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
     // Check if the builder setup correctly.
     if (builder == nullptr)
     {

--- a/servicetests/tests/FleetProvisioning/main.cpp
+++ b/servicetests/tests/FleetProvisioning/main.cpp
@@ -96,9 +96,8 @@ struct CmdArgs
 std::shared_ptr<Aws::Crt::Mqtt5::Mqtt5Client> createMqtt5Client(const CmdArgs &cmdData, Mqtt5ClientContext &ctx)
 {
     // Create the MQTT5 builder and populate it with data from cmdData.
-    auto builder = std::unique_ptr<Aws::Iot::Mqtt5ClientBuilder>(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
-            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
+    auto builder = Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
+            cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str());
 
     // Check if the builder setup correctly.
     if (builder == nullptr)

--- a/servicetests/tests/JobsExecution/main.cpp
+++ b/servicetests/tests/JobsExecution/main.cpp
@@ -126,7 +126,7 @@ std::shared_ptr<IotJobsClient> build_mqtt5_client(
     std::promise<void> &connectionClosedPromise)
 {
     std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+        Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
             cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
 
     // Check if the builder setup correctly.

--- a/servicetests/tests/ShadowUpdate/main.cpp
+++ b/servicetests/tests/ShadowUpdate/main.cpp
@@ -154,7 +154,7 @@ std::shared_ptr<IotShadowClient> build_mqtt5_client(
     std::promise<void> &connectionClosedPromise)
 {
     std::shared_ptr<Aws::Iot::Mqtt5ClientBuilder> builder(
-        Aws::Iot::Mqtt5ClientBuilder::NewMqtt5ClientBuilderWithMtlsFromPath(
+        Aws::Iot::Mqtt5ClientBuilder::CreateMqtt5ClientBuilderWithMtlsFromPath(
             cmdData.endpoint, cmdData.cert.c_str(), cmdData.key.c_str()));
 
     // Check if the builder setup correctly.


### PR DESCRIPTION

*Description of changes:*

- Replaced deprecated `New*` raw pointer factory methods with `Create*` shared_ptr
  alternatives in mqtt5_x509, mqtt5_aws_websocket, and mqtt5_pkcs11 samples
- Updated `MIGRATION_GUIDE.md` and `MQTT5_Userguide.md` code examples to use
  Create* APIs with correct types and namespaces

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
